### PR TITLE
ISSUE#25 When generating inlined object definitions prefix derived Class names 

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -5,6 +5,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.getEnumValues
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isNotDefined
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.toMapValueClassName
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.toModelClassName
+import com.cjbooms.fabrikt.util.NormalisedString.toModelClassName
 import com.reprezen.kaizen.oasparser.model3.Schema
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -39,7 +40,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
         }
 
     companion object {
-        fun from(schema: Schema, oasKey: String = ""): KotlinTypeInfo =
+        fun from(schema: Schema, oasKey: String = "", enclosingName: String = ""): KotlinTypeInfo =
             when (schema.toOasType(oasKey)) {
                 OasType.Date -> Date
                 OasType.DateTime -> DateTime
@@ -55,9 +56,9 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                 OasType.Array ->
                     if (schema.itemsSchema.isNotDefined())
                         throw IllegalArgumentException("Property ${schema.name} cannot be parsed to a Schema. Check your input")
-                    else Array(from(schema.itemsSchema, oasKey))
-                OasType.Object -> Object(schema.toModelClassName())
-                OasType.Map -> Map(from(schema.additionalPropertiesSchema, "additionalProperties"))
+                    else Array(from(schema.itemsSchema, oasKey, enclosingName))
+                OasType.Object -> Object(schema.toModelClassName(enclosingName.toModelClassName()))
+                OasType.Map -> Map(from(schema.additionalPropertiesSchema, "additionalProperties", enclosingName))
                 OasType.TypedProperties -> TypedProperties(schema.toMapValueClassName())
                 OasType.UntypedProperties -> UntypedProperties
                 OasType.UntypedObject -> UntypedObject

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/ModelInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/ModelInfo.kt
@@ -33,7 +33,7 @@ data class ModelInfo(
     val maybeSuperType: ModelInfo? = schema.getSuperType(api)?.let { ModelInfo(it.name, it, api) }
     val childSchemas: Collection<String> = parentToChildren[key].orEmpty()
     val typeInfo: KotlinTypeInfo = KotlinTypeInfo.from(schema, name)
-    val properties: Collection<PropertyInfo> = schema.topLevelProperties(PropertyInfo.HTTP_SETTINGS)
+    val properties: Collection<PropertyInfo> = schema.topLevelProperties(PropertyInfo.HTTP_SETTINGS, schema)
 
     @Suppress("UNCHECKED_CAST")
     companion object {

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -47,7 +47,7 @@ object KaizenParserExtensions {
     fun Schema.isReferenceObjectDefinition() =
         isObjectType() && !isSchemaLess() && !Overlay.of(this).pathFromRoot.contains("properties")
 
-    fun Schema.toModelClassName() = safeName().toModelClassName()
+    fun Schema.toModelClassName(enclosingClassName: String = "") = enclosingClassName + safeName().toModelClassName()
 
     fun Schema.toMapValueClassName() = safeName().toMapValueClassName()
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/NormalisedString.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/NormalisedString.kt
@@ -12,9 +12,7 @@ object NormalisedString {
 
     fun String.camelCase(): String = this.pascalCase().decapitalize()
 
-    fun String.toEntityName(): String = "${this.toModelClassName()}Entity"
-
-    fun String.toModelClassName(): String = this.pascalCase()
+    fun String.toModelClassName(parentModelName: String = ""): String = parentModelName + this.pascalCase()
 
     fun String.toMapValueClassName(): String = "${this.pascalCase()}Value"
 

--- a/src/test/resources/examples/inLinedObject/api.yaml
+++ b/src/test/resources/examples/inLinedObject/api.yaml
@@ -1,7 +1,30 @@
 openapi: 3.0.0
 components:
   schemas:
-    ContainsInLinedObject:
+    FirstInlineObject:
+      type: object
+      properties:
+        generation:
+          type: object
+          properties:
+            call_home:
+              type: object
+              required:
+                - url
+              properties:
+                url:
+                  type: string
+            database_view:
+              type: object
+              required:
+                - view_name
+              properties:
+                view_name:
+                  type: string
+            direct:
+              type: string
+              
+    SecondInlineObject:
       type: object
       properties:
         generation:

--- a/src/test/resources/examples/inLinedObject/models/Models.kt
+++ b/src/test/resources/examples/inLinedObject/models/Models.kt
@@ -5,36 +5,71 @@ import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.String
 
-data class ContainsInLinedObject(
+data class FirstInlineObject(
     @param:JsonProperty("generation")
     @get:JsonProperty("generation")
     @get:Valid
-    val generation: Generation? = null
+    val generation: FirstInlineObjectGeneration? = null
 )
 
-data class CallHome(
+data class FirstInlineObjectCallHome(
     @param:JsonProperty("url")
     @get:JsonProperty("url")
     @get:NotNull
     val url: String
 )
 
-data class DatabaseView(
+data class FirstInlineObjectDatabaseView(
     @param:JsonProperty("view_name")
     @get:JsonProperty("view_name")
     @get:NotNull
     val viewName: String
 )
 
-data class Generation(
+data class FirstInlineObjectGeneration(
     @param:JsonProperty("call_home")
     @get:JsonProperty("call_home")
     @get:Valid
-    val callHome: CallHome? = null,
+    val callHome: FirstInlineObjectCallHome? = null,
     @param:JsonProperty("database_view")
     @get:JsonProperty("database_view")
     @get:Valid
-    val databaseView: DatabaseView? = null,
+    val databaseView: FirstInlineObjectDatabaseView? = null,
+    @param:JsonProperty("direct")
+    @get:JsonProperty("direct")
+    val direct: String? = null
+)
+
+data class SecondInlineObject(
+    @param:JsonProperty("generation")
+    @get:JsonProperty("generation")
+    @get:Valid
+    val generation: SecondInlineObjectGeneration? = null
+)
+
+data class SecondInlineObjectCallHome(
+    @param:JsonProperty("url")
+    @get:JsonProperty("url")
+    @get:NotNull
+    val url: String
+)
+
+data class SecondInlineObjectDatabaseView(
+    @param:JsonProperty("view_name")
+    @get:JsonProperty("view_name")
+    @get:NotNull
+    val viewName: String
+)
+
+data class SecondInlineObjectGeneration(
+    @param:JsonProperty("call_home")
+    @get:JsonProperty("call_home")
+    @get:Valid
+    val callHome: SecondInlineObjectCallHome? = null,
+    @param:JsonProperty("database_view")
+    @get:JsonProperty("database_view")
+    @get:Valid
+    val databaseView: SecondInlineObjectDatabaseView? = null,
     @param:JsonProperty("direct")
     @get:JsonProperty("direct")
     val direct: String? = null

--- a/src/test/resources/examples/mapExamples/models/Models.kt
+++ b/src/test/resources/examples/mapExamples/models/Models.kt
@@ -47,11 +47,11 @@ data class MapHolder(
     @param:JsonProperty("inlined_complex_object_with_untyped_map")
     @get:JsonProperty("inlined_complex_object_with_untyped_map")
     @get:Valid
-    val inlinedComplexObjectWithUntypedMap: InlinedComplexObjectWithUntypedMap? = null,
+    val inlinedComplexObjectWithUntypedMap: MapHolderInlinedComplexObjectWithUntypedMap? = null,
     @param:JsonProperty("inlined_complex_object_with_typed_map")
     @get:JsonProperty("inlined_complex_object_with_typed_map")
     @get:Valid
-    val inlinedComplexObjectWithTypedMap: InlinedComplexObjectWithTypedMap? = null
+    val inlinedComplexObjectWithTypedMap: MapHolderInlinedComplexObjectWithTypedMap? = null
 )
 
 data class TypedObjectMapValue(
@@ -113,7 +113,7 @@ data class ComplexObjectWithTypedMap(
     }
 }
 
-data class InlinedComplexObjectWithUntypedMap(
+data class MapHolderInlinedComplexObjectWithUntypedMap(
     @param:JsonProperty("text")
     @get:JsonProperty("text")
     val text: String? = null,
@@ -138,7 +138,7 @@ data class InlinedComplexObjectWithTypedMapValue(
     val otherNumber: Int? = null
 )
 
-data class InlinedComplexObjectWithTypedMap(
+data class MapHolderInlinedComplexObjectWithTypedMap(
     @param:JsonProperty("text")
     @get:JsonProperty("text")
     val text: String? = null,


### PR DESCRIPTION
Closes #25 

When FabriKt encounters an inlined object definition it derives a class name using the property key. This was brittle and caused collisions for common property keys such as `type` or `name` that contained inline schemas.

To help alleviate the problem FabriKt now prefixes the derived class name with the Class Name of the enclosing top level schema definition. 

This will stop collisions between separate Schema entries which is the common case. Collisions will still occur if a single schema definition contains multiple inlined schema definitions, at different depths, that share key names.