### PR TITLE
Issue #24 Fix client options

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
@@ -39,6 +39,8 @@ object CodeGen {
         modelOptions: Set<ModelCodeGenOptionType>,
         clientOptions: Set<ClientCodeGenOptionType>
     ) {
+        MutableSettings.updateSettings(codeGenTypes, modelOptions, clientOptions)
+
         val suppliedApi = pathToApi.toFile().readText()
         val baseDir = pathToApi.parent
 
@@ -46,8 +48,7 @@ object CodeGen {
 
         val packages = Packages(basePackage)
         val sourceApi = SourceApi.create(suppliedApi, apiFragments, baseDir)
-        val generator = CodeGenerator(packages, sourceApi, codeGenTypes, modelOptions, clientOptions)
-        MutableSettings.updateSettings(codeGenTypes, modelOptions, clientOptions)
+        val generator = CodeGenerator(packages, sourceApi)
         generator.generate().forEach { it.writeFileTo(outputDir.toFile()) }
     }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
@@ -5,9 +5,10 @@ import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 
 object MutableSettings {
-    var generationTypes: MutableSet<CodeGenerationType> = mutableSetOf()
-    var modelOptions: MutableSet<ModelCodeGenOptionType> = mutableSetOf()
-    var clientOptions: MutableSet<ClientCodeGenOptionType> = mutableSetOf()
+    private lateinit var generationTypes: MutableSet<CodeGenerationType>
+    private lateinit var modelOptions: MutableSet<ModelCodeGenOptionType>
+    private lateinit var clientOptions: MutableSet<ClientCodeGenOptionType>
+
     fun updateSettings(
         genTypes: Set<CodeGenerationType>,
         modelOptions: Set<ModelCodeGenOptionType>,
@@ -17,4 +18,10 @@ object MutableSettings {
         this.modelOptions = modelOptions.toMutableSet()
         this.clientOptions = clientOptions.toMutableSet()
     }
+
+    fun addOption(option: ModelCodeGenOptionType) = modelOptions.add(option)
+
+    fun modelOptions() = this.modelOptions.toSet()
+    fun generationTypes() = this.generationTypes.toSet()
+    fun clientOptions() = this.clientOptions.toSet()
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/QuarkusReflectionModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/QuarkusReflectionModelGenerator.kt
@@ -1,6 +1,6 @@
 package com.cjbooms.fabrikt.generators.model
 
-import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
+import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.model.Models
 import com.cjbooms.fabrikt.model.QuarkusReflectionModel
 import com.cjbooms.fabrikt.model.ResourceFile
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 class QuarkusReflectionModelGenerator(
     private val models: Models,
-    private val options: Set<ModelCodeGenOptionType> = emptySet()
+    private val generationTypes: Set<CodeGenerationType> = emptySet()
 ) {
     companion object {
         const val RESOURCE_FILE_NAME = "reflection-config.json"
@@ -18,7 +18,7 @@ class QuarkusReflectionModelGenerator(
     private val objectMapper: ObjectMapper = ObjectMapper().registerKotlinModule().enable(SerializationFeature.INDENT_OUTPUT)
 
     fun generate(): ResourceFile? {
-        return if (options.any { it == ModelCodeGenOptionType.QUARKUS_REFLECTION }) {
+        return if (generationTypes.any { it == CodeGenerationType.QUARKUS_REFLECTION_CONFIG }) {
             val reflectionConfigs = models.models.map {
                 QuarkusReflectionModel(it.className.canonicalName)
             }

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -57,13 +57,13 @@ object KaizenParserExtensions {
 
     fun Schema.isEnumDefinition(): Boolean =
         this.type == OasType.Text.type && (this.hasEnums() ||
-            (MutableSettings.modelOptions.contains(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS) &&
+            (MutableSettings.modelOptions().contains(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS) &&
                 extensions.containsKey(EXTENSIBLE_ENUM_KEY)))
 
     @Suppress("UNCHECKED_CAST")
     fun Schema.getEnumValues(): List<String> = when {
         this.hasEnums() -> this.enums.map { it.toString() }
-        !MutableSettings.modelOptions.contains(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS) -> emptyList()
+        !MutableSettings.modelOptions().contains(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS) -> emptyList()
         else -> extensions[EXTENSIBLE_ENUM_KEY]?.let { it as List<String> } ?: emptyList()
     }
 

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
+import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
@@ -10,6 +11,7 @@ import com.squareup.kotlinpoet.FileSpec
 import java.nio.file.Paths
 import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
@@ -39,11 +41,16 @@ class ModelGeneratorTest {
         "wildCardTypes"
     )
 
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(setOf(CodeGenerationType.HTTP_MODELS), emptySet(), emptySet())
+    }
+
     @ParameterizedTest
     @MethodSource("testCases")
     fun `correct models are generated for different OpenApi Specifications`(testCaseName: String) {
         print("Testcase: $testCaseName")
-        MutableSettings.modelOptions.add(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS)
+        MutableSettings.addOption(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS)
         val basePackage = "examples.$testCaseName"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.generators
 
 import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
+import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.client.OkHttpEnhancedClientGenerator
 import com.cjbooms.fabrikt.generators.client.OkHttpSimpleClientGenerator
@@ -13,6 +14,7 @@ import com.cjbooms.fabrikt.validation.Linter
 import com.squareup.kotlinpoet.FileSpec
 import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -23,6 +25,11 @@ class OkHttpClientGeneratorTest {
     private fun fullApiTestCases(): Stream<String> = Stream.of(
         "okHttpClient"
     )
+
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(setOf(CodeGenerationType.CLIENT), emptySet(), emptySet())
+    }
 
     @ParameterizedTest
     @MethodSource("fullApiTestCases")

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
@@ -1,6 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
-import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
+import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
 import com.cjbooms.fabrikt.generators.model.QuarkusReflectionModelGenerator
@@ -28,11 +28,11 @@ class ResourceGeneratorTest {
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
         val expectedResource = javaClass.getResource("/examples/$testCaseName/resources/reflection-config.json").readText()
-        val options = setOf(ModelCodeGenOptionType.QUARKUS_REFLECTION)
+        val generationTypes = setOf(CodeGenerationType.QUARKUS_REFLECTION_CONFIG)
 
-        val models = JacksonModelGenerator(Packages(basePackage), sourceApi, options).generate()
+        val models = JacksonModelGenerator(Packages(basePackage), sourceApi, emptySet()).generate()
 
-        val resources = QuarkusReflectionModelGenerator(models, options).generate()?.toSingleFile()
+        val resources = QuarkusReflectionModelGenerator(models, generationTypes).generate()?.toSingleFile()
 
         assertThat(resources).isEqualTo(expectedResource)
     }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
+import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.controller.SpringControllerGenerator
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports
@@ -14,6 +15,7 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
@@ -33,6 +35,11 @@ class SpringControllerGeneratorTest {
         val models = JacksonModelGenerator(Packages(basePackage), api).generate().models
         val services = SpringServiceInterfaceGenerator(Packages(basePackage), api, models).generate().services
         generated = SpringControllerGenerator(Packages(basePackage), api, services, models).generate().files
+    }
+
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(setOf(CodeGenerationType.CONTROLLERS), emptySet(), emptySet())
     }
 
     @Test

--- a/src/test/kotlin/com/cjbooms/fabrikt/model/SourceApiTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/model/SourceApiTest.kt
@@ -1,11 +1,19 @@
 package com.cjbooms.fabrikt.model
 
 import com.beust.jcommander.ParameterException
+import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.generators.MutableSettings
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class SourceApiTest {
+
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(setOf(CodeGenerationType.HTTP_MODELS), emptySet(), emptySet())
+    }
 
     @Test
     fun testParentToChildren() {


### PR DESCRIPTION
`quarkus_reflection_config` target and `x_extensible_enums` model option aren't picked up by the client code gen