### PR TITLE
ISSUE#44 Fixing client generation code for generic typed responses 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     // Below dependencies are solely present so code examples in the test resources dir compile
     testImplementation("javax.validation:validation-api:2.0.1.Final")
     testImplementation("org.springframework:spring-webmvc:5.1.9.RELEASE")
+    testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
 }
 
 tasks {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -1,7 +1,7 @@
 package com.cjbooms.fabrikt.generators
 
 import com.cjbooms.fabrikt.generators.ValidationAnnotations.fieldValid
-import com.cjbooms.fabrikt.generators.model.JacksonAnnotations
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.PropertyInfo
 import com.squareup.kotlinpoet.ClassName
@@ -65,7 +65,7 @@ object PropertyUtils {
                     .addParameter("name", String::class)
                     .addParameter("value", parameterizedType)
                     .addStatement("$name[name] = value")
-                    .addAnnotation(JacksonAnnotations.anySetter)
+                    .addAnnotation(JacksonMetadata.anySetter)
                     .build()
             )
         } else {
@@ -88,14 +88,14 @@ object PropertyUtils {
                             property.addModifiers(KModifier.OVERRIDE)
                             classBuilder.addSuperclassConstructorParameter(name)
                         }
-                        property.addAnnotation(JacksonAnnotations.jacksonParameterAnnotation(oasKey))
+                        property.addAnnotation(JacksonMetadata.jacksonParameterAnnotation(oasKey))
                     }
-                    property.addAnnotation(JacksonAnnotations.jacksonPropertyAnnotation(oasKey))
+                    property.addAnnotation(JacksonMetadata.jacksonPropertyAnnotation(oasKey))
                     property.addValidationAnnotations(this)
                 }
                 ClassType.VANILLA_MODEL -> {
-                    property.addAnnotation(JacksonAnnotations.jacksonParameterAnnotation(oasKey))
-                    property.addAnnotation(JacksonAnnotations.jacksonPropertyAnnotation(oasKey))
+                    property.addAnnotation(JacksonMetadata.jacksonParameterAnnotation(oasKey))
+                    property.addAnnotation(JacksonMetadata.jacksonPropertyAnnotation(oasKey))
                     property.addValidationAnnotations(this)
                 }
             }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
@@ -5,7 +5,8 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.TypeName
 
-object JacksonAnnotations {
+object JacksonMetadata {
+    val TYPE_REFERENCE_IMPORT = Pair("com.fasterxml.jackson.module.kotlin", "jacksonTypeRef")
     private val JSON_PROPERTY_CLASS = ClassName("com.fasterxml.jackson.annotation", "JsonProperty")
     private val JSON_VALUE_CLASS = ClassName("com.fasterxml.jackson.annotation", "JsonValue")
     private val JSON_TYPE_INFO_CLASS = ClassName("com.fasterxml.jackson.annotation", "JsonTypeInfo")

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -10,9 +10,9 @@ import com.cjbooms.fabrikt.generators.TypeFactory.createList
 import com.cjbooms.fabrikt.generators.TypeFactory.createMapOfMapsStringToStringAny
 import com.cjbooms.fabrikt.generators.TypeFactory.createMapOfStringToType
 import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfStringToType
-import com.cjbooms.fabrikt.generators.model.JacksonAnnotations.JSON_VALUE
-import com.cjbooms.fabrikt.generators.model.JacksonAnnotations.basePolymorphicType
-import com.cjbooms.fabrikt.generators.model.JacksonAnnotations.polymorphicSubTypes
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.JSON_VALUE
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.basePolymorphicType
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.polymorphicSubTypes
 import com.cjbooms.fabrikt.model.Destinations.modelsPackage
 import com.cjbooms.fabrikt.model.GeneratedType
 import com.cjbooms.fabrikt.model.KotlinTypeInfo

--- a/src/main/resources/templates/client-code/http-util.kt.hbs
+++ b/src/main/resources/templates/client-code/http-util.kt.hbs
@@ -1,5 +1,6 @@
 package {{ client }}
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.FormBody
 import okhttp3.Headers
@@ -34,11 +35,11 @@ fun Headers.Builder.header(key: String, value: String?): Headers.Builder {
 }
 
 @Throws(ApiException::class)
-fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, classOfT: Class<T>): ApiResponse<T?> =
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
     client.newCall(this).execute().use { response ->
         when {
             response.isSuccessful ->
-                ApiResponse(response.code, response.headers, response.body?.deserialize(objectMapper, classOfT))
+                ApiResponse(response.code, response.headers, response.body?.deserialize(objectMapper, typeRef))
             response.isBadRequest() ->
                 throw ApiClientException(response.code, response.headers, response.errorMessage())
             response.isServerError() ->
@@ -53,8 +54,8 @@ fun String.pathParam(vararg params: Pair<String, Any>): String = params.asSequen
         this.replace(param.first, param.second.toString())
     }
 
-fun <T> ResponseBody.deserialize(objectMapper: ObjectMapper, classOfT: Class<T>) =
-    this.string().isNotBlankOrNull()?.let { objectMapper.readValue(it, classOfT) }
+fun <T> ResponseBody.deserialize(objectMapper: ObjectMapper, typeRef: TypeReference<T>): T? =
+    this.string().isNotBlankOrNull()?.let { objectMapper.readValue(it, typeRef) }
 
 fun String?.isNotBlankOrNull() = if (this.isNullOrBlank()) null else this
 

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -5,6 +5,7 @@ import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.client.OkHttpEnhancedClientGenerator
 import com.cjbooms.fabrikt.generators.client.OkHttpSimpleClientGenerator
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Models
@@ -130,6 +131,7 @@ class OkHttpClientGeneratorTest {
         this.forEach {
             val builder = singleFileBuilder
                 .addType(it.spec)
+                .addImport(JacksonMetadata.TYPE_REFERENCE_IMPORT.first, JacksonMetadata.TYPE_REFERENCE_IMPORT.second)
             builder.build()
         }
         return Linter.lintString(singleFileBuilder.build().toString())

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -1,6 +1,7 @@
 package examples.okHttpClient.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import examples.okHttpClient.models.Content
 import examples.okHttpClient.models.FirstModel
 import examples.okHttpClient.models.QueryResult
@@ -50,7 +51,7 @@ class ExamplePathClient(
             .get()
             .build()
 
-        return request.execute(client, objectMapper, QueryResult::class.java)
+        return request.execute(client, objectMapper, jacksonTypeRef())
     }
 
     /**
@@ -75,7 +76,7 @@ class ExamplePathClient(
             .post(objectMapper.writeValueAsString(generatedType).toRequestBody("application/json".toMediaType()))
             .build()
 
-        return request.execute(client, objectMapper, Unit::class.java)
+        return request.execute(client, objectMapper, jacksonTypeRef())
     }
 
     /**
@@ -109,7 +110,7 @@ class ExamplePathClient(
             .get()
             .build()
 
-        return request.execute(client, objectMapper, Content::class.java)
+        return request.execute(client, objectMapper, jacksonTypeRef())
     }
 
     /**
@@ -142,7 +143,7 @@ class ExamplePathClient(
             .head()
             .build()
 
-        return request.execute(client, objectMapper, Unit::class.java)
+        return request.execute(client, objectMapper, jacksonTypeRef())
     }
 
     /**
@@ -173,7 +174,7 @@ class ExamplePathClient(
             .put(objectMapper.writeValueAsString(firstModel).toRequestBody("application/json".toMediaType()))
             .build()
 
-        return request.execute(client, objectMapper, Unit::class.java)
+        return request.execute(client, objectMapper, jacksonTypeRef())
     }
 }
 
@@ -214,6 +215,6 @@ class ExamplePathSubresourceClient(
             .put(objectMapper.writeValueAsString(firstModel).toRequestBody("application/json".toMediaType()))
             .build()
 
-        return request.execute(client, objectMapper, Unit::class.java)
+        return request.execute(client, objectMapper, jacksonTypeRef())
     }
 }


### PR DESCRIPTION
Return types such as `Map<String, Any>?` are now supported using TypeReference