### PR TITLE
Fixing bug when generating HTTP parameters on an non-exploded format.

### DIFF
--- a/src/main/resources/templates/client-code/http-util.kt.hbs
+++ b/src/main/resources/templates/client-code/http-util.kt.hbs
@@ -24,7 +24,7 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it) }
-        else addQueryParameter(key, values.joinToString())
+        else addQueryParameter(key, values.joinToString(","))
     }
 }
 

--- a/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
@@ -24,7 +24,7 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it) }
-        else addQueryParameter(key, values.joinToString())
+        else addQueryParameter(key, values.joinToString(","))
     }
 }
 


### PR DESCRIPTION
The parameters are concatenated by default with ", ", leaving a space between the comma and the next parameter