### PR TITLE
Improvements to inlined enum class generation.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -45,7 +45,8 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                 OasType.Date -> Date
                 OasType.DateTime -> DateTime
                 OasType.Text -> Text
-                OasType.Enum -> Enum(schema.getEnumValues(), schema.toModelClassName())
+                OasType.Enum ->
+                    Enum(schema.getEnumValues(), schema.toModelClassName(enclosingName.toModelClassName()))
                 OasType.Double -> Double
                 OasType.Float -> Float
                 OasType.Number -> Numeric

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -70,7 +70,9 @@ sealed class PropertyInfo {
                             property.value,
                             settings.markAsInherited,
                             this,
-                            if (property.value.isInlinedArrayDefinition() || property.value.itemsSchema.isEnumDefinition()) enclosingSchema else null
+                            if (property.value.isInlinedArrayDefinition() || property.value.itemsSchema.isEnumDefinition())
+                                enclosingSchema
+                            else null
                         )
                     OasType.Object.type ->
                         if (property.value.isInlineableMapDefinition() || property.value.isSchemaLess())
@@ -88,9 +90,7 @@ sealed class PropertyInfo {
                         else if (property.value.isInlinedObjectDefinition())
                             ObjectInlinedField(
                                 isRequired = isRequired(
-                                    property,
-                                    settings.markReadWriteOnlyOptional,
-                                    settings.markAllOptional
+                                    property, settings.markReadWriteOnlyOptional, settings.markAllOptional
                                 ),
                                 oasKey = property.key,
                                 schema = property.value,
@@ -150,7 +150,8 @@ sealed class PropertyInfo {
         val maybeDiscriminator: DiscriminatorKey?,
         val enclosingSchema: Schema? = null
     ) : PropertyInfo() {
-        override val typeInfo: KotlinTypeInfo = KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toModelClassName() ?: "")
+        override val typeInfo: KotlinTypeInfo =
+            KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toModelClassName() ?: "")
         val pattern: String? = schema.safeField(Schema::getPattern)
         val maxLength: Int? = schema.safeField(Schema::getMaxLength)
         val minLength: Int? = schema.safeField(Schema::getMinLength)
@@ -162,12 +163,12 @@ sealed class PropertyInfo {
         private fun <T> Schema.safeField(getField: Schema.() -> T?): T? =
             when {
                 this.getField() != null -> this.getField()
-                allOfSchemas?.firstOrNull { it.getField() != null } != null -> allOfSchemas.first { it.getField() != null }
-                    .getField()
-                oneOfSchemas?.firstOrNull { it.getField() != null } != null -> oneOfSchemas.first { it.getField() != null }
-                    .getField()
-                anyOfSchemas?.firstOrNull { it.getField() != null } != null -> anyOfSchemas.first { it.getField() != null }
-                    .getField()
+                allOfSchemas?.firstOrNull { it.getField() != null } != null ->
+                    allOfSchemas.first { it.getField() != null }.getField()
+                oneOfSchemas?.firstOrNull { it.getField() != null } != null ->
+                    oneOfSchemas.first { it.getField() != null }.getField()
+                anyOfSchemas?.firstOrNull { it.getField() != null } != null ->
+                    anyOfSchemas.first { it.getField() != null }.getField()
                 else -> null
             }
     }

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -42,6 +42,9 @@ object KaizenParserExtensions {
     fun Schema.isInlinedObjectDefinition() =
         isObjectType() && !isSchemaLess() && Overlay.of(this).pathFromRoot.contains("properties")
 
+    fun Schema.isInlinedEnumDefinition() =
+        isEnumDefinition() && !isSchemaLess() && Overlay.of(this).pathFromRoot.contains("properties")
+
     fun Schema.isInlinedArrayDefinition() =
         isArrayType() && !isSchemaLess() && this.itemsSchema.isInlinedObjectDefinition()
 

--- a/src/test/resources/examples/defaultValues/models/Models.kt
+++ b/src/test/resources/examples/defaultValues/models/Models.kt
@@ -19,7 +19,7 @@ data class PersonWithDefaults(
     @param:JsonProperty("enum_default")
     @get:JsonProperty("enum_default")
     @get:NotNull
-    val enumDefault: EnumDefault = EnumDefault.TALL,
+    val enumDefault: PersonWithDefaultsEnumDefault = PersonWithDefaultsEnumDefault.TALL,
     @param:JsonProperty("boolean_default")
     @get:JsonProperty("boolean_default")
     @get:NotNull
@@ -30,7 +30,7 @@ data class PersonWithDefaults(
     val stringPhrase: String = "Cowabunga Dude"
 )
 
-enum class EnumDefault(
+enum class PersonWithDefaultsEnumDefault(
     @JsonValue
     val value: String
 ) {

--- a/src/test/resources/examples/enumExamples/models/Models.kt
+++ b/src/test/resources/examples/enumExamples/models/Models.kt
@@ -8,13 +8,13 @@ import kotlin.collections.List
 data class EnumHolder(
     @param:JsonProperty("array_of_enums")
     @get:JsonProperty("array_of_enums")
-    val arrayOfEnums: List<ArrayOfEnums>? = null,
+    val arrayOfEnums: List<EnumHolderArrayOfEnums>? = null,
     @param:JsonProperty("inlined_enum")
     @get:JsonProperty("inlined_enum")
-    val inlinedEnum: InlinedEnum? = null,
+    val inlinedEnum: EnumHolderInlinedEnum? = null,
     @param:JsonProperty("inlined_extensible_enum")
     @get:JsonProperty("inlined_extensible_enum")
-    val inlinedExtensibleEnum: InlinedExtensibleEnum? = null,
+    val inlinedExtensibleEnum: EnumHolderInlinedExtensibleEnum? = null,
     @param:JsonProperty("enum_ref")
     @get:JsonProperty("enum_ref")
     val enumRef: EnumObject? = null,
@@ -23,7 +23,7 @@ data class EnumHolder(
     val extensibleEnumRef: ExtensibleEnumObject? = null
 )
 
-enum class ArrayOfEnums(
+enum class EnumHolderArrayOfEnums(
     @JsonValue
     val value: String
 ) {
@@ -32,7 +32,7 @@ enum class ArrayOfEnums(
     ARRAY_ENUM_TWO("array_enum_two");
 }
 
-enum class InlinedEnum(
+enum class EnumHolderInlinedEnum(
     @JsonValue
     val value: String
 ) {
@@ -43,7 +43,7 @@ enum class InlinedEnum(
     INLINED_THREE("inlined_three");
 }
 
-enum class InlinedExtensibleEnum(
+enum class EnumHolderInlinedExtensibleEnum(
     @JsonValue
     val value: String
 ) {

--- a/src/test/resources/examples/externalReferences/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/models/Models.kt
@@ -14,7 +14,7 @@ data class ContainingExternalReference(
     val someExternalReference: ExternalObject? = null
 )
 
-enum class Enum(
+enum class ExternalObjectThreeEnum(
     @JsonValue
     val value: String
 ) {
@@ -29,7 +29,7 @@ data class ExternalObjectThree(
     @param:JsonProperty("enum")
     @get:JsonProperty("enum")
     @get:NotNull
-    val enum: Enum,
+    val enum: ExternalObjectThreeEnum,
     @param:JsonProperty("description")
     @get:JsonProperty("description")
     @get:NotNull

--- a/src/test/resources/examples/githubApi/models/Models.kt
+++ b/src/test/resources/examples/githubApi/models/Models.kt
@@ -91,7 +91,7 @@ data class ContributorQueryResult(
     val items: List<Contributor>
 )
 
-enum class Status(
+enum class ContributorStatus(
     @JsonValue
     val value: String
 ) {
@@ -128,7 +128,7 @@ data class Contributor(
     @param:JsonProperty("status")
     @get:JsonProperty("status")
     @get:NotNull
-    val status: Status,
+    val status: ContributorStatus,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     val etag: String? = null,
@@ -155,6 +155,15 @@ data class OrganisationQueryResult(
     @get:Valid
     val items: List<Organisation>
 )
+
+enum class OrganisationStatus(
+    @JsonValue
+    val value: String
+) {
+    ACTIVE("active"),
+
+    INACTIVE("inactive");
+}
 
 data class Webhook(
     @param:JsonProperty("url")
@@ -194,7 +203,7 @@ data class Organisation(
     @param:JsonProperty("status")
     @get:JsonProperty("status")
     @get:NotNull
-    val status: Status,
+    val status: OrganisationStatus,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     val etag: String? = null,
@@ -226,7 +235,16 @@ data class RepositoryQueryResult(
     val items: List<Repository>
 )
 
-enum class Visibility(
+enum class RepositoryStatus(
+    @JsonValue
+    val value: String
+) {
+    ACTIVE("active"),
+
+    INACTIVE("inactive");
+}
+
+enum class RepositoryVisibility(
     @JsonValue
     val value: String
 ) {
@@ -263,7 +281,7 @@ data class Repository(
     @param:JsonProperty("status")
     @get:JsonProperty("status")
     @get:NotNull
-    val status: Status,
+    val status: RepositoryStatus,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     val etag: String? = null,
@@ -277,7 +295,7 @@ data class Repository(
     val name: String,
     @param:JsonProperty("visibility")
     @get:JsonProperty("visibility")
-    val visibility: Visibility? = null,
+    val visibility: RepositoryVisibility? = null,
     @param:JsonProperty("tags")
     @get:JsonProperty("tags")
     val tags: List<String>? = null
@@ -297,6 +315,15 @@ data class PullRequestQueryResult(
     @get:Valid
     val items: List<PullRequest>
 )
+
+enum class PullRequestStatus(
+    @JsonValue
+    val value: String
+) {
+    ACTIVE("active"),
+
+    INACTIVE("inactive");
+}
 
 data class Author(
     @param:JsonProperty("name")
@@ -335,7 +362,7 @@ data class PullRequest(
     @param:JsonProperty("status")
     @get:JsonProperty("status")
     @get:NotNull
-    val status: Status,
+    val status: PullRequestStatus,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     val etag: String? = null,

--- a/src/test/resources/examples/githubApi/resources/reflection-config.json
+++ b/src/test/resources/examples/githubApi/resources/reflection-config.json
@@ -39,7 +39,7 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.Status",
+  "name" : "examples.githubApi.models.ContributorStatus",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -56,6 +56,14 @@
   "allPublicFields" : true
 }, {
   "name" : "examples.githubApi.models.OrganisationQueryResult",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.OrganisationStatus",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -87,7 +95,15 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.Visibility",
+  "name" : "examples.githubApi.models.RepositoryStatus",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.RepositoryVisibility",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -104,6 +120,14 @@
   "allPublicFields" : true
 }, {
   "name" : "examples.githubApi.models.PullRequestQueryResult",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.PullRequestStatus",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,

--- a/src/test/resources/examples/javaSerializableModels/models/Models.kt
+++ b/src/test/resources/examples/javaSerializableModels/models/Models.kt
@@ -46,13 +46,13 @@ sealed class Content(
     open val id: String? = null,
     open val firstAttr: OffsetDateTime? = null,
     open val secondAttr: String? = null,
-    open val thirdAttr: ThirdAttr? = null,
+    open val thirdAttr: ContentThirdAttr? = null,
     open val etag: String? = null
 ) {
-    abstract val modelType: ModelType
+    abstract val modelType: ContentModelType
 }
 
-enum class ThirdAttr(
+enum class ContentThirdAttr(
     @JsonValue
     val value: String
 ) {
@@ -61,7 +61,7 @@ enum class ThirdAttr(
     ENUM_TYPE_2("enum_type_2");
 }
 
-enum class ModelType(
+enum class ContentModelType(
     @JsonValue
     val value: String
 ) {
@@ -84,7 +84,7 @@ data class FirstModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -94,7 +94,7 @@ data class FirstModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag), Serializable {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.FIRST_MODEL
+    override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
 
 data class SecondModel(
@@ -109,7 +109,7 @@ data class SecondModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -122,7 +122,7 @@ data class SecondModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag), Serializable {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.SECOND_MODEL
+    override val modelType: ContentModelType = ContentModelType.SECOND_MODEL
 }
 
 data class ThirdModel(
@@ -137,7 +137,7 @@ data class ThirdModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -150,5 +150,5 @@ data class ThirdModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag), Serializable {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.THIRD_MODEL
+    override val modelType: ContentModelType = ContentModelType.THIRD_MODEL
 }

--- a/src/test/resources/examples/okHttpClient/models/Models.kt
+++ b/src/test/resources/examples/okHttpClient/models/Models.kt
@@ -45,13 +45,13 @@ sealed class Content(
     open val id: String? = null,
     open val firstAttr: OffsetDateTime? = null,
     open val secondAttr: String? = null,
-    open val thirdAttr: ThirdAttr? = null,
+    open val thirdAttr: ContentThirdAttr? = null,
     open val etag: String? = null
 ) {
-    abstract val modelType: ModelType
+    abstract val modelType: ContentModelType
 }
 
-enum class ThirdAttr(
+enum class ContentThirdAttr(
     @JsonValue
     val value: String
 ) {
@@ -60,7 +60,7 @@ enum class ThirdAttr(
     ENUM_TYPE_2("enum_type_2");
 }
 
-enum class ModelType(
+enum class ContentModelType(
     @JsonValue
     val value: String
 ) {
@@ -83,7 +83,7 @@ data class FirstModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -93,7 +93,7 @@ data class FirstModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag) {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.FIRST_MODEL
+    override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
 
 data class SecondModel(
@@ -108,7 +108,7 @@ data class SecondModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -121,7 +121,7 @@ data class SecondModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag) {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.SECOND_MODEL
+    override val modelType: ContentModelType = ContentModelType.SECOND_MODEL
 }
 
 data class ThirdModel(
@@ -136,7 +136,7 @@ data class ThirdModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -149,5 +149,5 @@ data class ThirdModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag) {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.THIRD_MODEL
+    override val modelType: ContentModelType = ContentModelType.THIRD_MODEL
 }

--- a/src/test/resources/examples/quarkusReflectionModels/models/Models.kt
+++ b/src/test/resources/examples/quarkusReflectionModels/models/Models.kt
@@ -48,14 +48,14 @@ sealed class Content(
     open val id: String? = null,
     open val firstAttr: OffsetDateTime? = null,
     open val secondAttr: String? = null,
-    open val thirdAttr: ThirdAttr? = null,
+    open val thirdAttr: ContentThirdAttr? = null,
     open val etag: String? = null
 ) {
-    abstract val modelType: ModelType
+    abstract val modelType: ContentModelType
 }
 
 @RegisterForReflection
-enum class ThirdAttr(
+enum class ContentThirdAttr(
     @JsonValue
     val value: String
 ) {
@@ -65,7 +65,7 @@ enum class ThirdAttr(
 }
 
 @RegisterForReflection
-enum class ModelType(
+enum class ContentModelType(
     @JsonValue
     val value: String
 ) {
@@ -89,7 +89,7 @@ data class FirstModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -99,7 +99,7 @@ data class FirstModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag) {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.FIRST_MODEL
+    override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
 
 @RegisterForReflection
@@ -115,7 +115,7 @@ data class SecondModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -128,7 +128,7 @@ data class SecondModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag) {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.SECOND_MODEL
+    override val modelType: ContentModelType = ContentModelType.SECOND_MODEL
 }
 
 @RegisterForReflection
@@ -144,7 +144,7 @@ data class ThirdModel(
     override val secondAttr: String? = null,
     @param:JsonProperty("third_attr")
     @get:JsonProperty("third_attr")
-    override val thirdAttr: ThirdAttr? = null,
+    override val thirdAttr: ContentThirdAttr? = null,
     @param:JsonProperty("etag")
     @get:JsonProperty("etag")
     override val etag: String? = null,
@@ -157,5 +157,5 @@ data class ThirdModel(
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag) {
     @get:JsonProperty("model_type")
     @get:NotNull
-    override val modelType: ModelType = ModelType.THIRD_MODEL
+    override val modelType: ContentModelType = ContentModelType.THIRD_MODEL
 }


### PR DESCRIPTION
Inlined enums now get a class name prefixed with the class name that declares them. This should help avoid conflicts between enums with the same name inlined in different schemas