### PR TITLE
ISSUE-60 Adding logic to detect when an schema is referenced in an external API document

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -137,7 +137,7 @@ object KaizenParserExtensions {
         val keys = mappings?.entries?.filter {
             it.value.toString().contains(enclosingSchema.name)
         }?.map { it.key }
-        return if (keys.isNullOrEmpty()) listOf(enclosingSchema.name.toModelClassName()) else keys
+        return if (keys.isNullOrEmpty()) listOf(enclosingSchema.safeName().toModelClassName()) else keys
     }
 
     fun Schema.isInLinedObjectUnderAllOf(): Boolean =

--- a/src/test/resources/examples/externalReferences/external-models.yaml
+++ b/src/test/resources/examples/externalReferences/external-models.yaml
@@ -1,10 +1,17 @@
+openapi: 3.0.0
+paths: {}
+info:
+  title: ""
+  version: ""
 components:
   schemas:
     ExternalObject:
       type: object
       properties:
         another:
-          $ref: "#/components/schemas/ExternalObjectTwo"
+          $ref: "#/components/schemas/ExternalObjectTwo"        
+        one_of:
+          $ref: "#/components/schemas/ExternalOneOf"
           
     ExternalObjectTwo:
       type: object
@@ -30,3 +37,32 @@ components:
             - three
         description:
           type: string
+    
+    ExternalOneOf:
+      oneOf:
+        - $ref: '#/components/schemas/OneOfOne'
+        - $ref: '#/components/schemas/OneOfTwo'
+
+    ParentOneOf:
+      type: object
+      discriminator:
+        propertyName: discriminator
+      properties:
+        discriminator:
+          type: string
+          
+    OneOfOne:
+      allOf:
+        - $ref: '#/components/schemas/ParentOneOf'
+        - type: object
+          properties:
+            oneOfOne:
+              type: string
+
+    OneOfTwo:
+      allOf:
+        - $ref: '#/components/schemas/ParentOneOf'
+        - type: object
+          properties:
+            oneOfTwo:
+              type: string

--- a/src/test/resources/examples/externalReferences/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/models/Models.kt
@@ -1,6 +1,8 @@
 package examples.externalReferences.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonValue
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
@@ -47,5 +49,40 @@ data class ExternalObject(
     @param:JsonProperty("another")
     @get:JsonProperty("another")
     @get:Valid
-    val another: ExternalObjectTwo? = null
+    val another: ExternalObjectTwo? = null,
+    @param:JsonProperty("one_of")
+    @get:JsonProperty("one_of")
+    @get:Valid
+    val oneOf: ParentOneOf? = null
 )
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "discriminator",
+    visible = true
+)
+@JsonSubTypes()
+sealed class ParentOneOf() {
+    abstract val discriminator: String
+}
+
+data class OneOfOne(
+    @param:JsonProperty("oneOfOne")
+    @get:JsonProperty("oneOfOne")
+    val oneOfOne: String? = null
+) : ParentOneOf() {
+    @get:JsonProperty("discriminator")
+    @get:NotNull
+    override val discriminator: String = "OneOfOne"
+}
+
+data class OneOfTwo(
+    @param:JsonProperty("oneOfTwo")
+    @get:JsonProperty("oneOfTwo")
+    val oneOfTwo: String? = null
+) : ParentOneOf() {
+    @get:JsonProperty("discriminator")
+    @get:NotNull
+    override val discriminator: String = "OneOfTwo"
+}


### PR DESCRIPTION
When this occurs, simply parse the entire external API spec, and generate models for every schema within it. We could be more targeted with this but attempts I made to do so were resulting in quite complicated code.