### PR TITLE
Support for additional properties being maps of maps

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/TypeFactory.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/TypeFactory.kt
@@ -17,6 +17,15 @@ object TypeFactory {
             )
         )
 
+    fun createMutableMapOfMapsStringToStringType(type: TypeName) =
+        ClassName("kotlin.collections", "MutableMap").parameterizedBy(
+            String::class.asTypeName(),
+            Map::class.asTypeName().parameterizedBy(
+                String::class.asTypeName(),
+                type
+            )
+        )
+
     fun createMutableMapOfStringToType(type: TypeName) =
         ClassName("kotlin.collections", "MutableMap").parameterizedBy(
             String::class.asTypeName(),

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -9,6 +9,7 @@ import com.cjbooms.fabrikt.generators.PropertyUtils.isNullable
 import com.cjbooms.fabrikt.generators.TypeFactory.createList
 import com.cjbooms.fabrikt.generators.TypeFactory.createMapOfMapsStringToStringAny
 import com.cjbooms.fabrikt.generators.TypeFactory.createMapOfStringToType
+import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfMapsStringToStringType
 import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfStringToType
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.JSON_VALUE
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.basePolymorphicType
@@ -77,15 +78,15 @@ class JacksonModelGenerator(
                 )
                 is KotlinTypeInfo.Map ->
                     when (val paramType = typeInfo.parameterizedType) {
-                        is KotlinTypeInfo.UntypedProperties -> createMapOfMapsStringToStringAny()
-                        is KotlinTypeInfo.UnknownProperties ->
+                        is KotlinTypeInfo.UntypedObjectAdditionalProperties -> createMapOfMapsStringToStringAny()
+                        is KotlinTypeInfo.UnknownAdditionalProperties ->
                             createMapOfStringToType(
                                 toClassName(
                                     basePackage,
                                     paramType
                                 )
                             )
-                        is KotlinTypeInfo.TypedProperties ->
+                        is KotlinTypeInfo.GeneratedTypedAdditionalProperties ->
                             createMapOfStringToType(
                                 toClassName(
                                     basePackage,
@@ -100,9 +101,15 @@ class JacksonModelGenerator(
                         )
                     }
                 is KotlinTypeInfo.UntypedObject -> createMapOfStringToType(className)
-                is KotlinTypeInfo.UnknownProperties -> createMutableMapOfStringToType(className)
-                is KotlinTypeInfo.UntypedProperties -> createMutableMapOfStringToType(className)
-                is KotlinTypeInfo.TypedProperties -> createMutableMapOfStringToType(className)
+                is KotlinTypeInfo.UnknownAdditionalProperties -> createMutableMapOfStringToType(className)
+                is KotlinTypeInfo.UntypedObjectAdditionalProperties -> createMutableMapOfStringToType(className)
+                is KotlinTypeInfo.GeneratedTypedAdditionalProperties -> createMutableMapOfStringToType(className)
+                is KotlinTypeInfo.MapTypeAdditionalProperties -> createMutableMapOfMapsStringToStringType(
+                    toModelType(
+                        basePackage,
+                        typeInfo.parameterizedType
+                    )
+                )
                 else -> className
             }
             return if (isNullable) typeName.copy(nullable = true) else typeName
@@ -113,6 +120,11 @@ class JacksonModelGenerator(
                 generatedType(
                     basePackage,
                     typeInfo.generatedModelClassName!!
+                )
+            else if (typeInfo is KotlinTypeInfo.MapTypeAdditionalProperties)
+                generatedType(
+                    basePackage,
+                    typeInfo.parameterizedType.generatedModelClassName!!
                 )
             else typeInfo.modelKClass.asTypeName()
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/OasType.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/OasType.kt
@@ -2,6 +2,7 @@ package com.cjbooms.fabrikt.model
 
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlineableMapDefinition
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isMapTypeAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isTypedAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isUnknownAdditionalProperties
@@ -33,9 +34,10 @@ sealed class OasType(
     object Enum : OasType("string", specialization = Specialization.ENUM)
     object Uuid : OasType("string", specialization = Specialization.UUID)
     object Map : OasType("object", specialization = Specialization.MAP)
-    object UnknownProperties : OasType("object", specialization = Specialization.UNKNOWN_ADDITIONAL_PROPERTIES)
-    object UntypedProperties : OasType("object", specialization = Specialization.UNTYPED_OBJECT_ADDITIONAL_PROPERTIES)
-    object TypedProperties : OasType("object", specialization = Specialization.TYPED_OBJECT_ADDITIONAL_PROPERTIES)
+    object UnknownAdditionalProperties : OasType("object", specialization = Specialization.UNKNOWN_ADDITIONAL_PROPERTIES)
+    object UntypedObjectAdditionalProperties : OasType("object", specialization = Specialization.UNTYPED_OBJECT_ADDITIONAL_PROPERTIES)
+    object TypedObjectAdditionalProperties : OasType("object", specialization = Specialization.TYPED_OBJECT_ADDITIONAL_PROPERTIES)
+    object TypedMapAdditionalProperties : OasType("object", specialization = Specialization.TYPED_MAP_ADDITIONAL_PROPERTIES)
     companion object {
         fun Schema.toOasType(oasKey: String): OasType =
             values(OasType::class)
@@ -55,6 +57,7 @@ sealed class OasType(
             when {
                 isUuidDefinition() -> Specialization.UUID
                 isEnumDefinition() -> Specialization.ENUM
+                isMapTypeAdditionalProperties(oasKey) -> Specialization.TYPED_MAP_ADDITIONAL_PROPERTIES
                 isInlineableMapDefinition() -> Specialization.MAP
                 isTypedAdditionalProperties(oasKey) -> Specialization.TYPED_OBJECT_ADDITIONAL_PROPERTIES
                 isUntypedAdditionalProperties(oasKey) -> Specialization.UNTYPED_OBJECT_ADDITIONAL_PROPERTIES
@@ -69,6 +72,7 @@ sealed class OasType(
         MAP,
         UNKNOWN_ADDITIONAL_PROPERTIES,
         TYPED_OBJECT_ADDITIONAL_PROPERTIES,
+        TYPED_MAP_ADDITIONAL_PROPERTIES,
         UNTYPED_OBJECT_ADDITIONAL_PROPERTIES,
         UNTYPED_OBJECT,
         UUID,

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -4,6 +4,7 @@ import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.model.OasType
 import com.cjbooms.fabrikt.model.PropertyInfo
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.getSchemaNameInParent
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeys
 import com.cjbooms.fabrikt.util.NormalisedString.toMapValueClassName
 import com.cjbooms.fabrikt.util.NormalisedString.toModelClassName
@@ -89,6 +90,10 @@ object KaizenParserExtensions {
 
     fun Schema.isTypedAdditionalProperties(oasKey: String) = type == OasType.Object.type &&
         (getSchemaNameInParent() == "additionalProperties" || oasKey == "additionalProperties") && properties?.isEmpty() != true
+
+    fun Schema.isMapTypeAdditionalProperties(oasKey: String) = type == OasType.Object.type &&
+        (oasKey == "additionalProperties") && properties?.isEmpty() == true &&
+        hasAdditionalProperties()
 
     fun Schema.isComplexTypedAdditionalProperties(oasKey: String) =
         getSchemaNameInParent() ?: oasKey == "additionalProperties" && properties?.isEmpty() != true && !isSimpleType()

--- a/src/test/resources/examples/externalReferences/external-models.yaml
+++ b/src/test/resources/examples/externalReferences/external-models.yaml
@@ -22,6 +22,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExternalObjectThree'
+      additionalProperties:
+        type: object
+        minProperties: 1
+        additionalProperties:
+          $ref: '#/components/schemas/ExternalObjectFour'
    
     ExternalObjectThree:
       type: object
@@ -36,6 +41,18 @@ components:
             - two
             - three
         description:
+          type: string   
+          
+    ExternalObjectFour:
+      type: object
+      properties:
+        blah:
+          type: string     
+          
+    IgnoredExternalObjectFive:
+      type: object
+      properties:
+        blah:
           type: string
     
     ExternalOneOf:

--- a/src/test/resources/examples/externalReferences/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/models/Models.kt
@@ -1,5 +1,6 @@
 package examples.externalReferences.models
 
+import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
@@ -8,6 +9,8 @@ import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
 
 data class ContainingExternalReference(
     @param:JsonProperty("some-external-reference")
@@ -43,7 +46,14 @@ data class ExternalObjectTwo(
     @get:JsonProperty("list-others")
     @get:Valid
     val listOthers: List<ExternalObjectThree>? = null
-)
+) {
+    val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf()
+
+    @JsonAnySetter
+    fun set(name: String, value: Map<String, ExternalObjectFour>) {
+        properties[name] = value
+    }
+}
 
 data class ExternalObject(
     @param:JsonProperty("another")
@@ -54,6 +64,12 @@ data class ExternalObject(
     @get:JsonProperty("one_of")
     @get:Valid
     val oneOf: ParentOneOf? = null
+)
+
+data class ExternalObjectFour(
+    @param:JsonProperty("blah")
+    @get:JsonProperty("blah")
+    val blah: String? = null
 )
 
 @JsonTypeInfo(

--- a/src/test/resources/examples/mapExamples/api.yaml
+++ b/src/test/resources/examples/mapExamples/api.yaml
@@ -62,6 +62,17 @@ components:
                 type: string
               other_number:
                 type: integer
+      additionalProperties:
+        type: object
+        minProperties: 1
+        additionalProperties:
+          $ref: '#/components/schemas/ExternalObjectFour'
+
+    ExternalObjectFour:
+      type: object
+      properties:
+        blah:
+          type: string
 
     ComplexObjectWithUntypedMap:
       type: object

--- a/src/test/resources/examples/mapExamples/models/Models.kt
+++ b/src/test/resources/examples/mapExamples/models/Models.kt
@@ -53,7 +53,14 @@ data class MapHolder(
     @get:JsonProperty("inlined_complex_object_with_typed_map")
     @get:Valid
     val inlinedComplexObjectWithTypedMap: MapHolderInlinedComplexObjectWithTypedMap? = null
-)
+) {
+    val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf()
+
+    @JsonAnySetter
+    fun set(name: String, value: Map<String, ExternalObjectFour>) {
+        properties[name] = value
+    }
+}
 
 data class TypedObjectMapValue(
     @param:JsonProperty("code")
@@ -154,6 +161,12 @@ data class MapHolderInlinedComplexObjectWithTypedMap(
         properties[name] = value
     }
 }
+
+data class ExternalObjectFour(
+    @param:JsonProperty("blah")
+    @get:JsonProperty("blah")
+    val blah: String? = null
+)
 
 data class ComplexObjectWithRefTypedMap(
     @param:JsonProperty("text")


### PR DESCRIPTION
It is now possible to specify maps of maps in additional properties section via:
```
      additionalProperties:
        type: object
        additionalProperties:
          $ref: '#/components/schemas/ExternalObjectFour'
```