### PR TITLE
Adding test and validating that it fails with the older version of Kaizen parser

### DIFF
--- a/src/test/kotlin/com/cjbooms/fabrikt/util/YamlUtilsTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/util/YamlUtilsTest.kt
@@ -34,4 +34,38 @@ class YamlUtilsTest {
         assertTrue(enum.isArray)
         assertThat(enum.first().toString()).isEqualTo("\"NO\"")
     }
+
+    @Test
+    fun `encoding object is correctly parsed by Kaizen parser`() {
+        val encodingInput =
+            """
+        | openapi: 3.0.1
+        | info:
+        |   title: Sample API
+        |   version: "1.0"
+        | paths:
+        |   /endpoint:
+        |     post:
+        |       requestBody:
+        |         required: true
+        |         content:
+        |           application/json:
+        |             schema:
+        |               type: object
+        |               properties:
+        |                 image:
+        |                   type: string
+        |                   format: binary
+        |             encoding:
+        |               image:
+        |                 contentType: image/png, image/jpeg, image/webp
+        |       responses:
+        |         200:
+        |           description: Everything OK
+        """.trimMargin()
+
+        val api = YamlUtils.parseOpenApi(encodingInput)
+
+        assertThat(api.isValid).isEqualTo(true)
+    }
 }


### PR DESCRIPTION
Adds a test to validate #92 is fixed