### PR TITLE
Fix enum reference

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -15,6 +15,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.toModelClassName
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
+import com.cjbooms.fabrikt.util.NormalisedString.toEnumName
 import com.reprezen.kaizen.oasparser.model3.Schema
 
 sealed class PropertyInfo {
@@ -138,7 +139,7 @@ sealed class PropertyInfo {
     sealed class DiscriminatorKey(val stringValue: String) {
         class StringKey(value: String) : DiscriminatorKey(value)
         class EnumKey(value: String) : DiscriminatorKey(value) {
-            val enumKey = value.toUpperCase()
+            val enumKey = value.toEnumName()
         }
     }
 

--- a/src/test/resources/examples/oneOfPolymorphicModels/api.yaml
+++ b/src/test/resources/examples/oneOfPolymorphicModels/api.yaml
@@ -69,3 +69,40 @@ components:
             whateverD:
               type: integer
               format: int32
+
+    ParentSpec:
+      type: object
+      discriminator:
+        propertyName: type
+      required:
+        - type
+      properties:
+        type:
+          $ref: '#/components/schemas/ParentType'
+
+    ParentType:
+      type: string
+      description: Shows which child type is being returned
+      x-extensible-enum:
+        - "CHILD_TYPE_A"
+        - "CHILD_TYPE_B"
+
+    ChildTypeA:
+      allOf:
+        - $ref: '#/components/schemas/ParentSpec'
+        - type: object
+          required:
+            - some_string
+          properties:
+            some_string:
+              type: string
+
+    ChildTypeB:
+      allOf:
+        - $ref: '#/components/schemas/ParentSpec'
+        - type: object
+          required:
+            - some_int
+          properties:
+            some_int:
+              type: integer

--- a/src/test/resources/examples/oneOfPolymorphicModels/models/Models.kt
+++ b/src/test/resources/examples/oneOfPolymorphicModels/models/Models.kt
@@ -3,11 +3,13 @@ package examples.oneOfPolymorphicModels.models
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.Map
 
 data class ContainsOneOfPolymorphicTypes(
     @param:JsonProperty("one_one_of")
@@ -102,4 +104,59 @@ data class PolymorphicTypeTwoB(
     @get:JsonProperty("shared")
     @get:NotNull
     override val shared: String = "PolymorphicTypeTwoB"
+}
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+    visible = true
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(
+        value = ChildTypeA::class,
+        name =
+        "ChildTypeA"
+    ),
+    JsonSubTypes.Type(value = ChildTypeB::class, name = "ChildTypeB")
+)
+sealed class ParentSpec() {
+    abstract val type: ParentType
+}
+
+enum class ParentType(
+    @JsonValue
+    val value: String
+) {
+    CHILD_TYPE_A("CHILD_TYPE_A"),
+
+    CHILD_TYPE_B("CHILD_TYPE_B");
+
+    companion object {
+        private val mapping: Map<String, ParentType> = values().associateBy(ParentType::value)
+
+        fun fromValue(value: String): ParentType? = mapping[value]
+    }
+}
+
+data class ChildTypeA(
+    @param:JsonProperty("some_string")
+    @get:JsonProperty("some_string")
+    @get:NotNull
+    val someString: String
+) : ParentSpec() {
+    @get:JsonProperty("type")
+    @get:NotNull
+    override val type: ParentType = ParentType.CHILD_TYPE_A
+}
+
+data class ChildTypeB(
+    @param:JsonProperty("some_int")
+    @get:JsonProperty("some_int")
+    @get:NotNull
+    val someInt: Int
+) : ParentSpec() {
+    @get:JsonProperty("type")
+    @get:NotNull
+    override val type: ParentType = ParentType.CHILD_TYPE_B
 }


### PR DESCRIPTION
The reference to the enum value `ParentType.CHILD_TYPE_A`  in `ChildTypeA` in the example, was previously referencing `ParentType.CHILDTYPEA`