### PR TITLE
Use x-extensible-enum value for json subtype annotation

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
@@ -1,5 +1,7 @@
 package com.cjbooms.fabrikt.generators.model
 
+import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.util.NormalisedString.pascalCase
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -47,13 +49,17 @@ object JacksonMetadata {
         .addMember("visible = true")
         .build()
 
-    fun polymorphicSubTypes(typePairs: Map<String, TypeName>): AnnotationSpec {
+    fun polymorphicSubTypes(typePairs: Map<String, TypeName>, enumDiscriminator: KotlinTypeInfo.Enum?): AnnotationSpec {
         val codeBuilder = CodeBlock.builder()
         typePairs.forEach { (name, type) ->
             if (codeBuilder.isNotEmpty()) codeBuilder.add(",")
+            val maybeSchemaEnumValue = enumDiscriminator?.entries?.firstOrNull {
+                // lowercase to cover UPPER_SNAKE_CASE
+                it.pascalCase() == name || it.toLowerCase().pascalCase() == name
+            }
             codeBuilder.add(
                 "%T.Type(value = %T::class, name = %S)",
-                JSON_SUB_TYPES_CLASS, type, name
+                JSON_SUB_TYPES_CLASS, type, maybeSchemaEnumValue ?: name
             )
         }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -373,7 +373,10 @@ class JacksonModelGenerator(
                 it to toModelType(packages.base, KotlinTypeInfo.from(schemaInfo.schema, schemaInfo.name))
             }
         }.toMap()
-        classBuilder.addAnnotation(polymorphicSubTypes(mappings))
+        val maybeEnumDiscriminator = properties
+            .firstOrNull { it.name == discriminator.propertyName }?.typeInfo as? KotlinTypeInfo.Enum
+
+        classBuilder.addAnnotation(polymorphicSubTypes(mappings, maybeEnumDiscriminator))
             .addQuarkusReflectionAnnotation()
             .addMicronautIntrospectedAnnotation()
 

--- a/src/test/resources/examples/oneOfPolymorphicModels/models/Models.kt
+++ b/src/test/resources/examples/oneOfPolymorphicModels/models/Models.kt
@@ -116,9 +116,9 @@ data class PolymorphicTypeTwoB(
     JsonSubTypes.Type(
         value = ChildTypeA::class,
         name =
-        "ChildTypeA"
+        "CHILD_TYPE_A"
     ),
-    JsonSubTypes.Type(value = ChildTypeB::class, name = "ChildTypeB")
+    JsonSubTypes.Type(value = ChildTypeB::class, name = "CHILD_TYPE_B")
 )
 sealed class ParentSpec() {
     abstract val type: ParentType


### PR DESCRIPTION
When the discriminator is an x-extensible-enum, the enum value should be used to select the subtype, not the class name as a string.