### PR TITLE
Only make it a data class if there are constructor parameters. 

### DIFF
--- a/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
@@ -13,6 +13,7 @@ components:
           obj_one_only: '#/components/schemas/ConcreteImplOne'
           obj_two_first: '#/components/schemas/ConcreteImplTwo'
           obj_two_second: '#/components/schemas/ConcreteImplTwo'
+          obj_three: '#/components/schemas/ConcreteImplThree'
       properties:
         some_enum:
           $ref: '#/components/schemas/EnumDiscriminator'
@@ -32,6 +33,10 @@ components:
           properties:
             some_prop:
               type: string
+              
+    ConcreteImplThree:
+      allOf:
+        - $ref: '#/components/schemas/PolymorphicEnumDiscriminator'
 
     EnumDiscriminator:
       type: string
@@ -39,6 +44,7 @@ components:
         - obj_one_only
         - obj_two_first
         - obj_two_second
+        - obj_three
 
 
 

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
@@ -25,7 +25,12 @@ import kotlin.collections.Map
         name =
         "obj_two_first"
     ),
-    JsonSubTypes.Type(value = ConcreteImplTwo::class, name = "obj_two_second")
+    JsonSubTypes.Type(
+        value = ConcreteImplTwo::class,
+        name =
+        "obj_two_second"
+    ),
+    JsonSubTypes.Type(value = ConcreteImplThree::class, name = "obj_three")
 )
 sealed class PolymorphicEnumDiscriminator() {
     abstract val someEnum: EnumDiscriminator
@@ -39,7 +44,9 @@ enum class EnumDiscriminator(
 
     OBJ_TWO_FIRST("obj_two_first"),
 
-    OBJ_TWO_SECOND("obj_two_second");
+    OBJ_TWO_SECOND("obj_two_second"),
+
+    OBJ_THREE("obj_three");
 
     companion object {
         private val mapping: Map<String, EnumDiscriminator> =
@@ -68,3 +75,9 @@ data class ConcreteImplTwo(
     @get:JsonProperty("some_prop")
     val someProp: String? = null
 ) : PolymorphicEnumDiscriminator()
+
+class ConcreteImplThree() : PolymorphicEnumDiscriminator() {
+    @get:JsonProperty("some_enum")
+    @get:NotNull
+    override val someEnum: EnumDiscriminator = EnumDiscriminator.OBJ_THREE
+}


### PR DESCRIPTION
There are cases as in the added example where it's desirable to have a polymorphic subtype that is just a marker class containing a hard-coded discriminator value