### PR TITLE
Fix inline generation bug #103

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -199,15 +199,7 @@ class JacksonModelGenerator(
                     val inlinedModels = buildInLinedModels(props, enclosingSchema, apiDocUrl)
                     inlinedModels + currentModel
                 }
-                is PropertyInfo.ObjectRefField ->
-                    when {
-                        it.schema.isReferenceObjectDefinition() ->
-                            it.schema.topLevelProperties(HTTP_SETTINGS, enclosingSchema).let { props ->
-                                buildInLinedModels(props, enclosingSchema, apiDocUrl) +
-                                    standardDataClass(it.schema.safeName().toModelClassName(), props)
-                            }
-                        else -> emptySet()
-                    }
+                is PropertyInfo.ObjectRefField -> emptySet() // Not an inlined definition, so do nothing
                 is PropertyInfo.MapField ->
                     buildMapModel(it)?.let { mapModel -> setOf(mapModel) } ?: emptySet()
                 is PropertyInfo.AdditionalProperties ->

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
@@ -5,6 +5,11 @@ info:
   version: ""
 components:
   schemas:
+    Wrapper:
+      type: object
+      properties:
+        polymorph:
+          $ref: '#/components/schemas/PolymorphicEnumDiscriminator'
     PolymorphicEnumDiscriminator:
       type: object
       discriminator:

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonValue
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.String
 import kotlin.collections.Map
@@ -81,3 +82,10 @@ enum class EnumDiscriminator(
 sealed class PolymorphicEnumDiscriminator() {
     abstract val someEnum: EnumDiscriminator
 }
+
+data class Wrapper(
+    @param:JsonProperty("polymorph")
+    @get:JsonProperty("polymorph")
+    @get:Valid
+    val polymorph: PolymorphicEnumDiscriminator? = null
+)

--- a/src/test/resources/examples/githubApi/resources/reflection-config.json
+++ b/src/test/resources/examples/githubApi/resources/reflection-config.json
@@ -135,7 +135,7 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.Author",
+  "name" : "examples.githubApi.models.PullRequest",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -143,7 +143,7 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.PullRequest",
+  "name" : "examples.githubApi.models.Author",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,


### PR DESCRIPTION
A bug was introduced that was causing top-level schema definitions to be generated as part of the inlined generation logic. This resulted in complex polymorphic classes getting over-written with simpler inline-derived versions.

This PR removes the logic that generates referenced schemas during inline generation. It relies on the fact that these schemas will undergo regular/full generation.

Closes #103 