### PR TITLE
Disable inline generation of full schema objects from array generation

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -222,11 +222,6 @@ class JacksonModelGenerator(
                                         it.name.toModelClassName(enclosingModelName), props
                                     )
                                 }
-                            items.isReferenceObjectDefinition() ->
-                                items.topLevelProperties(HTTP_SETTINGS, enclosingSchema).let { props ->
-                                    buildInLinedModels(props, enclosingSchema, apiDocUrl) +
-                                        standardDataClass(items.safeName().toModelClassName(), props)
-                                }
                             items.isEnumDefinition() ->
                                 setOf(
                                     buildEnumClass(

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -33,7 +33,11 @@ class OkHttpClientGeneratorTest {
 
     @BeforeEach
     fun init() {
-        MutableSettings.updateSettings(setOf(CodeGenerationType.CLIENT), setOf(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS), emptySet())
+        MutableSettings.updateSettings(
+            setOf(CodeGenerationType.CLIENT),
+            setOf(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS),
+            emptySet()
+        )
     }
 
     @ParameterizedTest
@@ -144,11 +148,13 @@ class OkHttpClientGeneratorTest {
     private fun Models.toSingleFile(): String {
         val destPackage = if (models.isNotEmpty()) models.first().destinationPackage else ""
         val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
-        models.forEach {
-            val builder = singleFileBuilder
-                .addType(it.spec)
-            builder.build()
-        }
+        models
+            .sortedBy { it.spec.name }
+            .forEach {
+                val builder = singleFileBuilder
+                    .addType(it.spec)
+                builder.build()
+            }
         return Linter.lintString(singleFileBuilder.build().toString())
     }
 }

--- a/src/test/resources/examples/githubApi/resources/reflection-config.json
+++ b/src/test/resources/examples/githubApi/resources/reflection-config.json
@@ -39,7 +39,23 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.ContributorStatus",
+  "name" : "examples.githubApi.models.OrganisationQueryResult",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.RepositoryQueryResult",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.PullRequestQueryResult",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -55,23 +71,7 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.OrganisationQueryResult",
-  "allDeclaredConstructors" : true,
-  "allPublicConstructors" : true,
-  "allDeclaredMethods" : true,
-  "allPublicMethods" : true,
-  "allDeclaredFields" : true,
-  "allPublicFields" : true
-}, {
-  "name" : "examples.githubApi.models.OrganisationStatus",
-  "allDeclaredConstructors" : true,
-  "allPublicConstructors" : true,
-  "allDeclaredMethods" : true,
-  "allPublicMethods" : true,
-  "allDeclaredFields" : true,
-  "allPublicFields" : true
-}, {
-  "name" : "examples.githubApi.models.Webhook",
+  "name" : "examples.githubApi.models.ContributorStatus",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -87,7 +87,15 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.RepositoryQueryResult",
+  "name" : "examples.githubApi.models.OrganisationStatus",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.Repository",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -111,15 +119,7 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.Repository",
-  "allDeclaredConstructors" : true,
-  "allPublicConstructors" : true,
-  "allDeclaredMethods" : true,
-  "allPublicMethods" : true,
-  "allDeclaredFields" : true,
-  "allPublicFields" : true
-}, {
-  "name" : "examples.githubApi.models.PullRequestQueryResult",
+  "name" : "examples.githubApi.models.PullRequest",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,
@@ -135,7 +135,7 @@
   "allDeclaredFields" : true,
   "allPublicFields" : true
 }, {
-  "name" : "examples.githubApi.models.PullRequest",
+  "name" : "examples.githubApi.models.Webhook",
   "allDeclaredConstructors" : true,
   "allPublicConstructors" : true,
   "allDeclaredMethods" : true,

--- a/src/test/resources/examples/okHttpClient/models/Models.kt
+++ b/src/test/resources/examples/okHttpClient/models/Models.kt
@@ -14,15 +14,6 @@ import kotlin.String
 import kotlin.collections.List
 import kotlin.collections.Map
 
-data class QueryResult(
-    @param:JsonProperty("items")
-    @get:JsonProperty("items")
-    @get:NotNull
-    @get:Size(min = 0)
-    @get:Valid
-    val items: List<Content>
-)
-
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
@@ -52,22 +43,6 @@ sealed class Content(
     abstract val modelType: ContentModelType
 }
 
-enum class ContentThirdAttr(
-    @JsonValue
-    val value: String
-) {
-    ENUM_TYPE_1("enum_type_1"),
-
-    ENUM_TYPE_2("enum_type_2");
-
-    companion object {
-        private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
-
-        fun fromValue(value: String): ContentThirdAttr? = mapping[value]
-    }
-}
-
 enum class ContentModelType(
     @JsonValue
     val value: String
@@ -83,6 +58,22 @@ enum class ContentModelType(
             values().associateBy(ContentModelType::value)
 
         fun fromValue(value: String): ContentModelType? = mapping[value]
+    }
+}
+
+enum class ContentThirdAttr(
+    @JsonValue
+    val value: String
+) {
+    ENUM_TYPE_1("enum_type_1"),
+
+    ENUM_TYPE_2("enum_type_2");
+
+    companion object {
+        private val mapping: Map<String, ContentThirdAttr> =
+            values().associateBy(ContentThirdAttr::value)
+
+        fun fromValue(value: String): ContentThirdAttr? = mapping[value]
     }
 }
 
@@ -110,6 +101,15 @@ data class FirstModel(
     @get:NotNull
     override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
+
+data class QueryResult(
+    @param:JsonProperty("items")
+    @get:JsonProperty("items")
+    @get:NotNull
+    @get:Size(min = 0)
+    @get:Valid
+    val items: List<Content>
+)
 
 data class SecondModel(
     @param:JsonProperty("id")

--- a/src/test/resources/examples/okHttpClientMultiMediaType/models/Models.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/models/Models.kt
@@ -14,39 +14,6 @@ import kotlin.String
 import kotlin.collections.List
 import kotlin.collections.Map
 
-enum class ContentType(
-    @JsonValue
-    val value: String
-) {
-    APPLICATION_JSON("application/json"),
-
-    APPLICATION_VND_CUSTOM_MEDIA_JSON("application/vnd.custom.media+json");
-
-    companion object {
-        private val mapping: Map<String, ContentType> = values().associateBy(ContentType::value)
-
-        fun fromValue(value: String): ContentType? = mapping[value]
-    }
-}
-
-data class QueryResult(
-    @param:JsonProperty("items")
-    @get:JsonProperty("items")
-    @get:NotNull
-    @get:Size(min = 0)
-    @get:Valid
-    val items: List<Content>
-)
-
-data class OtherQueryResult(
-    @param:JsonProperty("items")
-    @get:JsonProperty("items")
-    @get:NotNull
-    @get:Size(min = 0)
-    @get:Valid
-    val items: List<AlternateResponseModel>
-)
-
 data class AlternateResponseModel(
     @param:JsonProperty("extra_first_attr")
     @get:JsonProperty("extra_first_attr")
@@ -85,6 +52,24 @@ sealed class Content(
     abstract val modelType: ContentModelType
 }
 
+enum class ContentModelType(
+    @JsonValue
+    val value: String
+) {
+    FIRST_MODEL("first_model"),
+
+    SECOND_MODEL("second_model"),
+
+    THIRD_MODEL("third_model");
+
+    companion object {
+        private val mapping: Map<String, ContentModelType> =
+            values().associateBy(ContentModelType::value)
+
+        fun fromValue(value: String): ContentModelType? = mapping[value]
+    }
+}
+
 enum class ContentThirdAttr(
     @JsonValue
     val value: String
@@ -101,21 +86,18 @@ enum class ContentThirdAttr(
     }
 }
 
-enum class ContentModelType(
+enum class ContentType(
     @JsonValue
     val value: String
 ) {
-    FIRST_MODEL("first_model"),
+    APPLICATION_JSON("application/json"),
 
-    SECOND_MODEL("second_model"),
-
-    THIRD_MODEL("third_model");
+    APPLICATION_VND_CUSTOM_MEDIA_JSON("application/vnd.custom.media+json");
 
     companion object {
-        private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+        private val mapping: Map<String, ContentType> = values().associateBy(ContentType::value)
 
-        fun fromValue(value: String): ContentModelType? = mapping[value]
+        fun fromValue(value: String): ContentType? = mapping[value]
     }
 }
 
@@ -143,6 +125,24 @@ data class FirstModel(
     @get:NotNull
     override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
+
+data class OtherQueryResult(
+    @param:JsonProperty("items")
+    @get:JsonProperty("items")
+    @get:NotNull
+    @get:Size(min = 0)
+    @get:Valid
+    val items: List<AlternateResponseModel>
+)
+
+data class QueryResult(
+    @param:JsonProperty("items")
+    @get:JsonProperty("items")
+    @get:NotNull
+    @get:Size(min = 0)
+    @get:Valid
+    val items: List<Content>
+)
 
 data class SecondModel(
     @param:JsonProperty("id")


### PR DESCRIPTION
Arrays were still triggering inline generation logic for full schemas. This disables that logic

closes #103 