### PR TITLE
Non-Nullable client return types

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -46,8 +46,7 @@ object ClientGeneratorUtils {
                     } ?: Unit::class.asTypeName()
                 }
 
-        return "ApiResponse".toClassName(packages.client)
-            .parameterizedBy(returnType.copy(nullable = true))
+        return "ApiResponse".toClassName(packages.client).parameterizedBy(returnType)
     }
 
     fun simpleClientName(resourceName: String) = "$resourceName${ClientType.SIMPLE_CLIENT_SUFFIX}"

--- a/src/main/resources/templates/client-code/http-util.kt.hbs
+++ b/src/main/resources/templates/client-code/http-util.kt.hbs
@@ -34,7 +34,7 @@ fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.
 }
 
 @Throws(ApiException::class)
-fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T> =
     client.newCall(this).execute().use { response ->
         when {
             response.isSuccessful ->

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -70,7 +70,7 @@ class ExamplePath1Client(
         content: Content,
         explodeListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> {
+    ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-1"
             .toHttpUrl()
             .newBuilder()
@@ -110,7 +110,7 @@ class ExamplePath2Client(
         queryParam2: Int?,
         ifNoneMatch: String?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Content?> {
+    ): ApiResponse<Content> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-2/{path_param}"
             .pathParam("{path_param}" to pathParam)
             .toHttpUrl()
@@ -145,7 +145,7 @@ class ExamplePath2Client(
         queryParam3: Boolean?,
         ifNoneMatch: String?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> {
+    ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-2/{path_param}"
             .pathParam("{path_param}" to pathParam)
             .toHttpUrl()
@@ -180,7 +180,7 @@ class ExamplePath2Client(
         pathParam: String,
         ifMatch: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> {
+    ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-2/{path_param}"
             .pathParam("{path_param}" to pathParam)
             .toHttpUrl()
@@ -223,7 +223,7 @@ class ExamplePath3SubresourceClient(
         ifMatch: String,
         csvListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> {
+    ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-3/{path_param}/subresource"
             .pathParam("{path_param}" to pathParam)
             .toHttpUrl()

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -38,7 +38,7 @@ class ExamplePath1Client(
         explodeListQueryParam: List<String>?,
         queryParam2: Int?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<QueryResult?> {
+    ): ApiResponse<QueryResult> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-1"
             .toHttpUrl()
             .newBuilder()

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -39,7 +39,7 @@ class ExamplePath1Service(
         explodeListQueryParam: List<String>?,
         queryParam2: Int?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<QueryResult?> =
+    ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.getExamplePath1(explodeListQueryParam, queryParam2, additionalHeaders)
         }

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -49,7 +49,7 @@ class ExamplePath1Service(
         content: Content,
         explodeListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> =
+    ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.postExamplePath1(content, explodeListQueryParam, additionalHeaders)
         }
@@ -80,7 +80,7 @@ class ExamplePath2Service(
         queryParam2: Int?,
         ifNoneMatch: String?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Content?> =
+    ): ApiResponse<Content> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.getExamplePath2PathParam(pathParam, queryParam2, ifNoneMatch, additionalHeaders)
         }
@@ -91,7 +91,7 @@ class ExamplePath2Service(
         queryParam3: Boolean?,
         ifNoneMatch: String?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> =
+    ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.headOperationIdExample(pathParam, queryParam3, ifNoneMatch, additionalHeaders)
         }
@@ -102,7 +102,7 @@ class ExamplePath2Service(
         pathParam: String,
         ifMatch: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> =
+    ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.putExamplePath2PathParam(firstModel, pathParam, ifMatch, additionalHeaders)
         }
@@ -138,7 +138,7 @@ class ExamplePath3SubresourceService(
         ifMatch: String,
         csvListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> =
+    ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.putExamplePath3PathParamSubresource(firstModel, pathParam, ifMatch, csvListQueryParam, additionalHeaders)
         }

--- a/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
@@ -34,7 +34,7 @@ fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.
 }
 
 @Throws(ApiException::class)
-fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T> =
     client.newCall(this).execute().use { response ->
         when {
             response.isSuccessful ->

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
@@ -78,7 +78,7 @@ class ExamplePath2Client(
         queryParam2: Int?,
         accept: ContentType?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<QueryResult?> {
+    ): ApiResponse<QueryResult> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-2"
             .toHttpUrl()
             .newBuilder()
@@ -117,7 +117,7 @@ class MultipleResponseSchemasClient(
         accept: ContentType?,
         additionalHeaders: Map<String, String> =
             emptyMap()
-    ): ApiResponse<JsonNode?> {
+    ): ApiResponse<JsonNode> {
         val httpUrl: HttpUrl = "$baseUrl/multiple-response-schemas"
             .toHttpUrl()
             .newBuilder()

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
@@ -36,7 +36,7 @@ class ExamplePath1Client(
         queryParam2: Int?,
         acceptHeader: String = "application/vnd.custom.media+xml",
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<QueryResult?> {
+    ): ApiResponse<QueryResult> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-1"
             .toHttpUrl()
             .newBuilder()

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiService.kt
@@ -69,7 +69,7 @@ class ExamplePath2Service(
         queryParam2: Int?,
         accept: ContentType?,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<QueryResult?> =
+    ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.getExamplePath2(explodeListQueryParam, queryParam2, accept, additionalHeaders)
         }
@@ -103,7 +103,7 @@ class MultipleResponseSchemasService(
         accept: ContentType?,
         additionalHeaders: Map<String, String> =
             emptyMap()
-    ): ApiResponse<JsonNode?> =
+    ): ApiResponse<JsonNode> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.getMultipleResponseSchemas(accept, additionalHeaders)
         }

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiService.kt
@@ -38,7 +38,7 @@ class ExamplePath1Service(
         queryParam2: Int?,
         acceptHeader: String = "application/vnd.custom.media+xml",
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<QueryResult?> =
+    ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.getExamplePath1(explodeListQueryParam, queryParam2, acceptHeader, additionalHeaders)
         }

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/HttpUtil.kt
@@ -34,7 +34,7 @@ fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.
 }
 
 @Throws(ApiException::class)
-fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T> =
     client.newCall(this).execute().use { response ->
         when {
             response.isSuccessful ->

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiClient.kt
@@ -24,7 +24,7 @@ class ExampleClient(
      *
      */
     @Throws(ApiException::class)
-    fun putExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> {
+    fun putExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example"
             .toHttpUrl()
             .newBuilder()
@@ -47,7 +47,7 @@ class ExampleClient(
      *
      */
     @Throws(ApiException::class)
-    fun postExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> {
+    fun postExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example"
             .toHttpUrl()
             .newBuilder()
@@ -70,7 +70,7 @@ class ExampleClient(
      *
      */
     @Throws(ApiException::class)
-    fun patchExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> {
+    fun patchExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example"
             .toHttpUrl()
             .newBuilder()

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiService.kt
@@ -29,19 +29,19 @@ class ExampleService(
     private val apiClient: ExampleClient = ExampleClient(objectMapper, baseUrl, client)
 
     @Throws(ApiException::class)
-    fun putExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+    fun putExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.putExample(additionalHeaders)
         }
 
     @Throws(ApiException::class)
-    fun postExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+    fun postExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.postExample(additionalHeaders)
         }
 
     @Throws(ApiException::class)
-    fun patchExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+    fun patchExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.patchExample(additionalHeaders)
         }

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
@@ -34,7 +34,7 @@ fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.
 }
 
 @Throws(ApiException::class)
-fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T> =
     client.newCall(this).execute().use { response ->
         when {
             response.isSuccessful ->

--- a/src/test/resources/examples/parameterNameClash/client/ApiClient.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ApiClient.kt
@@ -33,7 +33,7 @@ class ExampleClient(
         pathB: String,
         queryB: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> {
+    ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example/{b}"
             .pathParam("{b}" to pathB)
             .toHttpUrl()
@@ -65,7 +65,7 @@ class ExampleClient(
         bodySomeObject: SomeObject,
         querySomeObject: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> {
+    ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example"
             .toHttpUrl()
             .newBuilder()

--- a/src/test/resources/examples/parameterNameClash/client/ApiService.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ApiService.kt
@@ -34,7 +34,7 @@ class ExampleService(
         pathB: String,
         queryB: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> =
+    ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.getExampleB(pathB, queryB, additionalHeaders)
         }
@@ -44,7 +44,7 @@ class ExampleService(
         bodySomeObject: SomeObject,
         querySomeObject: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> =
+    ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.postExample(bodySomeObject, querySomeObject, additionalHeaders)
         }

--- a/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
+++ b/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
@@ -34,7 +34,7 @@ fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.
 }
 
 @Throws(ApiException::class)
-fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T> =
     client.newCall(this).execute().use { response ->
         when {
             response.isSuccessful ->

--- a/src/test/resources/examples/pathLevelParameters/client/ApiClient.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiClient.kt
@@ -30,7 +30,7 @@ class ExampleClient(
         a: String,
         b: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> {
+    ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example"
             .toHttpUrl()
             .newBuilder()

--- a/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
@@ -33,7 +33,7 @@ class ExampleService(
         a: String,
         b: String,
         additionalHeaders: Map<String, String> = emptyMap()
-    ): ApiResponse<Unit?> =
+    ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.getExample(a, b, additionalHeaders)
         }

--- a/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
@@ -34,7 +34,7 @@ fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.
 }
 
 @Throws(ApiException::class)
-fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T> =
     client.newCall(this).execute().use { response ->
         when {
             response.isSuccessful ->


### PR DESCRIPTION
ISSUE-120: The http client will now return a non-nullable response type ~~on those operations that define a unique 200 successful response~~ such as follows:

```
no content -> ApiResponse<Unit>
single content schema: MyTypeOne -> ApiResponse<MyTypeOne>
multiple content schemas: -> ApiResponse<JsonNode> or ApiResponse<Any> 
```

Closes #120 