### PR TITLE
Add support for disciminated oneOf's

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -33,7 +33,9 @@ enum class ModelCodeGenOptionType(val description: String) {
     QUARKUS_REFLECTION("This option adds @RegisterForReflection to the generated models. Requires dependency \"'io.quarkus:quarkus-core:+\""),
     MICRONAUT_INTROSPECTION("This option adds @Introspected to the generated models. Requires dependency \"'io.micronaut:micronaut-core:+\""),
     MICRONAUT_REFLECTION("This option adds @ReflectiveAccess to the generated models. Requires dependency \"'io.micronaut:micronaut-core:+\""),
-    INCLUDE_COMPANION_OBJECT("This option adds a companion object to the generated models.");
+    INCLUDE_COMPANION_OBJECT("This option adds a companion object to the generated models."),
+    SEALED_INTERFACES_FOR_ONE_OF("This option enables the generation of interfaces for discriminated oneOf types"),
+    ;
 
     override fun toString() = "`${super.toString()}` - $description"
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -6,6 +6,7 @@ import com.cjbooms.fabrikt.model.OasType.Companion.toOasType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getEnumValues
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedTypedAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isNotDefined
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.toMapValueClassName
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.toModelClassName
 import com.cjbooms.fabrikt.util.NormalisedString.toModelClassName
@@ -92,7 +93,9 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                         from(schema.additionalPropertiesSchema, "", enclosingName)
                     )
                 OasType.Any -> AnyType
-                OasType.OneOfAny -> AnyType
+                OasType.OneOfAny ->
+                    if (schema.isOneOfSuperInterface()) Object(schema.toModelClassName(enclosingName.toModelClassName()))
+                    else AnyType
             }
 
         private fun getOverridableDateTimeType(): KotlinTypeInfo {

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -102,7 +102,7 @@ object KaizenParserExtensions {
         "additionalProperties" && properties?.isEmpty() != true && !isSimpleType()
 
     fun Schema.isSimpleType(): Boolean =
-        (simpleTypes.contains(type) && !isEnumDefinition()) || isSimpleMapDefinition() || isSimpleOneOfAnyDefinition()
+        !isOneOfSuperInterface() && ((simpleTypes.contains(type) && !isEnumDefinition()) || isSimpleMapDefinition() || isSimpleOneOfAnyDefinition())
 
     private fun Schema.isObjectType() = OasType.Object.type == type
 
@@ -209,6 +209,9 @@ object KaizenParserExtensions {
 
     fun Schema.isOneOfPolymorphicTypes() =
         this.oneOfSchemas?.firstOrNull()?.allOfSchemas?.firstOrNull() != null
+
+    fun Schema.isOneOfSuperInterface() =
+        discriminator != null && discriminator.propertyName != null && oneOfSchemas.isNotEmpty()
 
     fun OpenApi3.basePath(): String =
         servers

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -51,6 +51,8 @@ class ModelGeneratorTest {
         "responsesSchema",
         "webhook",
         "instantDateTime",
+        "singleAllOf",
+        "discriminatedOneOf",
     )
 
     @BeforeEach
@@ -79,6 +81,7 @@ class ModelGeneratorTest {
         val models = JacksonModelGenerator(
             Packages(basePackage),
             sourceApi,
+            setOf(ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_OF),
         ).generate().toSingleFile()
 
         assertThat(models).isEqualTo(expectedModels)

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+paths:
+components:
+  schemas:
+    SomeObj:
+      type: object
+      required:
+        - state
+      properties:
+        state:
+          $ref: '#/components/schemas/State'
+    State:
+      oneOf:
+        - $ref: '#/components/schemas/StateA'
+        - $ref: '#/components/schemas/StateB'
+      discriminator:
+        propertyName: status
+        mapping:
+          a: '#/components/schemas/StateA'
+          b: '#/components/schemas/StateB'
+    Status:
+      type: string
+      enum:
+        - a
+        - b
+    StateA:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/Status'
+    StateB:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/Status'

--- a/src/test/resources/examples/discriminatedOneOf/models/Models.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/Models.kt
@@ -1,0 +1,53 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import kotlin.String
+import kotlin.collections.Map
+
+data class SomeObj(
+    @param:JsonProperty("state")
+    @get:JsonProperty("state")
+    @get:NotNull
+    @get:Valid
+    val state: State
+)
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "status",
+    visible = true
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = StateA::class, name = "a"),
+    JsonSubTypes.Type(
+        value =
+        StateB::class,
+        name = "b"
+    )
+)
+sealed interface State
+
+object StateA : State
+
+object StateB : State
+
+enum class Status(
+    @JsonValue
+    val value: String
+) {
+    A("a"),
+
+    B("b");
+
+    companion object {
+        private val mapping: Map<String, Status> = values().associateBy(Status::value)
+
+        fun fromValue(value: String): Status? = mapping[value]
+    }
+}


### PR DESCRIPTION
This is something very few code generators even try to implement, but it was fairly easy to add to fabrikt. Currently we use inheritance because that's what openapi-generator supports, but apparently the OpenAPI spec people have the opinion that oneOf should be used for modelling sum types[^1]. This is also the only way to model these that is properly supported by swagger-ui.

The implementation is a bit of a rough sketch, but works for my use-case, which I added as a test case in reduced form. I'm very open for feedback, especially around the differentiation of "normal" oneOf's that are generated as Any type and discriminated ones (oneOfSuperInterface called in the implementation).

Some notes:

* it uses sealed *interfaces* in order to not conflict with any existing inheritance, which are a kotlin 1.5+ feature, so maybe this should be behind a feature flag?
* it assumes that any given type will only be part of a single oneOf type. OAI doesn't have this limitation and since the generated interfaces don't have any properties or methods it could work just fine, but I haven't tried.
* there is some duplication that I could get rid of, but I defer that until I know this is something that has a chance of getting merged
* consistency between oneOf members and the mappings is checked. I'm not sure this is necessary, but seems like the right thing to do.
* the current implementation checks for the propertyName within the member fields, but I don't think that's necessary. At least I can imagine that in many cases the explicit field in the members isn't actually necessary or useful. wdyt?

[^1]: The [OAI page](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/) explicitly states this: "The discriminator is used with anyOf or oneOf keywords *only*."