### PR TITLE
fix broken codegen for put/post/patch requests without request body

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -234,7 +234,7 @@ data class SimpleClientOperationStatement(
     }
 
     private fun CodeBlock.Builder.addRequestExecutionStatement() =
-        this.add("\nreturn request.execute(client, objectMapper, jacksonTypeRef())")
+        this.add("\nreturn request.execute(client, objectMapper, jacksonTypeRef())\n")
 
     private fun CodeBlock.Builder.addRequestSerializerStatement(verb: String) {
         val requestBody = operation.requestBody

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -247,6 +247,6 @@ data class SimpleClientOperationStatement(
                 requestBody.getPrimaryContentMediaType()?.key,
                 "toMediaType".toClassName("okhttp3.MediaType.Companion")
             )
-        } ?: this.add("\n%N()", verb)
+        } ?: this.add("\n.%N()", verb)
     }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -238,15 +238,16 @@ data class SimpleClientOperationStatement(
 
     private fun CodeBlock.Builder.addRequestSerializerStatement(verb: String) {
         val requestBody = operation.requestBody
+        val toRequestBody = "toRequestBody".toClassName("okhttp3.RequestBody.Companion")
         requestBody.toBodyRequestSchema().firstOrNull()?.let {
             this.add(
                 "\n.%N(objectMapper.writeValueAsString(%N).%T(%S.%T()))",
                 verb,
                 it.toVarName(),
-                "toRequestBody".toClassName("okhttp3.RequestBody.Companion"),
+                toRequestBody,
                 requestBody.getPrimaryContentMediaType()?.key,
                 "toMediaType".toClassName("okhttp3.MediaType.Companion")
             )
-        } ?: this.add("\n.%N()", verb)
+        } ?: this.add("\n.%N(ByteArray(0).%T())", verb, toRequestBody)
     }
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -28,7 +28,8 @@ class OkHttpClientGeneratorTest {
     @Suppress("unused")
     private fun fullApiTestCases(): Stream<String> = Stream.of(
         "okHttpClient",
-        "okHttpClientMultiMediaType"
+        "okHttpClientMultiMediaType",
+        "okHttpClientPostWithoutRequestBody",
     )
 
     @BeforeEach

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/api.yaml
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/api.yaml
@@ -1,0 +1,10 @@
+openapi: "3.0.0"
+info:
+  title: "API Example"
+  version: "1.0"
+paths:
+  /example:
+    post:
+      responses:
+        '204':
+          description: example

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/api.yaml
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/api.yaml
@@ -4,7 +4,15 @@ info:
   version: "1.0"
 paths:
   /example:
+    put:
+      responses:
+        '204':
+          description: example
     post:
+      responses:
+        '204':
+          description: example
+    patch:
       responses:
         '204':
           description: example

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiClient.kt
@@ -1,0 +1,44 @@
+package examples.okHttpClientPostWithoutRequestBody.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+@Suppress("unused")
+class ExampleClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val client: OkHttpClient
+) {
+    /**
+     *
+     */
+    @Throws(ApiException::class)
+    fun postExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> {
+        val httpUrl: HttpUrl = "$baseUrl/example"
+            .toHttpUrl()
+            .newBuilder()
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .post()
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiClient.kt
@@ -7,6 +7,7 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -19,6 +20,29 @@ class ExampleClient(
     private val baseUrl: String,
     private val client: OkHttpClient
 ) {
+    /**
+     *
+     */
+    @Throws(ApiException::class)
+    fun putExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> {
+        val httpUrl: HttpUrl = "$baseUrl/example"
+            .toHttpUrl()
+            .newBuilder()
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .put(ByteArray(0).toRequestBody())
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+
     /**
      *
      */
@@ -36,7 +60,30 @@ class ExampleClient(
         val request: Request = Request.Builder()
             .url(httpUrl)
             .headers(httpHeaders)
-            .post()
+            .post(ByteArray(0).toRequestBody())
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     *
+     */
+    @Throws(ApiException::class)
+    fun patchExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> {
+        val httpUrl: HttpUrl = "$baseUrl/example"
+            .toHttpUrl()
+            .newBuilder()
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .patch(ByteArray(0).toRequestBody())
             .build()
 
         return request.execute(client, objectMapper, jacksonTypeRef())

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiModels.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiModels.kt
@@ -1,0 +1,26 @@
+package examples.okHttpClientPostWithoutRequestBody.client
+
+import okhttp3.Headers
+
+/**
+ * API 2xx success response returned by API call.
+ *
+ * @param <T> The type of data that is deserialized from response body
+ */
+data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T? = null)
+
+/**
+ * API non-2xx failure responses returned by API call.
+ */
+open class ApiException(override val message: String) : Exception(message)
+
+/**
+ * API 4xx failure responses returned by API call.
+ */
+data class ApiClientException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+
+/**
+ * API 5xx failure responses returned by API call.
+ */
+data class ApiServerException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiService.kt
@@ -1,0 +1,36 @@
+package examples.okHttpClientPostWithoutRequestBody.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import okhttp3.OkHttpClient
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+class ExampleService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    client: OkHttpClient
+) {
+    var circuitBreakerName: String = "exampleClient"
+
+    private val apiClient: ExampleClient = ExampleClient(objectMapper, baseUrl, client)
+
+    @Throws(ApiException::class)
+    fun postExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.postExample(additionalHeaders)
+        }
+}

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiService.kt
@@ -29,8 +29,20 @@ class ExampleService(
     private val apiClient: ExampleClient = ExampleClient(objectMapper, baseUrl, client)
 
     @Throws(ApiException::class)
+    fun putExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.putExample(additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
     fun postExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
             apiClient.postExample(additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    fun patchExample(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.patchExample(additionalHeaders)
         }
 }

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpResilience4jUtil.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpResilience4jUtil.kt
@@ -1,0 +1,13 @@
+package examples.okHttpClientPostWithoutRequestBody.client
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+
+fun <T> withCircuitBreaker(
+    circuitBreakerRegistry: CircuitBreakerRegistry,
+    apiClientName: String,
+    apiCall: () -> ApiResponse<T>
+): ApiResponse<T> {
+    val circuitBreaker = circuitBreakerRegistry.circuitBreaker(apiClientName)
+    return CircuitBreaker.decorateSupplier(circuitBreaker, apiCall).get()
+}

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
@@ -1,0 +1,65 @@
+package examples.okHttpClientPostWithoutRequestBody.client
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+@Suppress("unused")
+fun <T : Any> HttpUrl.Builder.queryParam(key: String, value: T?): HttpUrl.Builder = this.apply {
+    if (value != null) this.addQueryParameter(key, value.toString())
+}
+
+@Suppress("unused")
+fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
+}
+
+@Suppress("unused")
+fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+    if (values != null) {
+        if (explode) values.forEach { addQueryParameter(key, it) }
+        else addQueryParameter(key, values.joinToString(","))
+    }
+}
+
+@Suppress("unused")
+fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value)
+}
+
+@Throws(ApiException::class)
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+    client.newCall(this).execute().use { response ->
+        when {
+            response.isSuccessful ->
+                ApiResponse(response.code, response.headers, response.body?.deserialize(objectMapper, typeRef))
+            response.isBadRequest() ->
+                throw ApiClientException(response.code, response.headers, response.errorMessage())
+            response.isServerError() ->
+                throw ApiServerException(response.code, response.headers, response.errorMessage())
+            else -> throw ApiException("[${response.code}]: ${response.errorMessage()}")
+        }
+    }
+
+@Suppress("unused")
+fun String.pathParam(vararg params: Pair<String, Any>): String = params.asSequence()
+    .joinToString { param ->
+        this.replace(param.first, param.second.toString())
+    }
+
+fun <T> ResponseBody.deserialize(objectMapper: ObjectMapper, typeRef: TypeReference<T>): T? =
+    this.string().isNotBlankOrNull()?.let { objectMapper.readValue(it, typeRef) }
+
+fun String?.isNotBlankOrNull() = if (this.isNullOrBlank()) null else this
+
+private fun Response.errorMessage(): String = this.body?.string() ?: this.message
+
+private fun Response.isBadRequest(): Boolean = this.code in 400..499
+
+private fun Response.isServerError(): Boolean = this.code in 500..599

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/LoggingInterceptor.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/LoggingInterceptor.kt
@@ -1,0 +1,25 @@
+package examples.okHttpClientPostWithoutRequestBody.client
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class LoggingInterceptor : Interceptor {
+
+    private val logger: Logger = LoggerFactory.getLogger("GeneratedClient")
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        val t1 = System.nanoTime()
+        logger.info("Client Request: $request")
+
+        val response = chain.proceed(request)
+
+        val t2 = System.nanoTime()
+        logger.info("Client Response after ${(t2 - t1) / 100_000}ms: $response")
+
+        return response
+    }
+}

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/OAuth.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/OAuth.kt
@@ -1,0 +1,22 @@
+package examples.okHttpClientPostWithoutRequestBody.client
+
+import okhttp3.Authenticator
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+class OAuth2(val accessToken: () -> String) : Authenticator, Interceptor {
+
+    override fun authenticate(route: Route?, response: Response): Request =
+        response.request.newBuilder()
+            .header("Authorization", "Bearer ${accessToken().trim()}")
+            .build()
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header("Authorization", "Bearer ${accessToken().trim()}")
+            .build()
+        return chain.proceed(request)
+    }
+}


### PR DESCRIPTION
The `.` got lost. Also okhttp3 always once *some* payload, so in cases where no data should be sent, an empty buffer must be passed in.