### PR TITLE
Add Support for Path Level Parameters and avoid Name Clashes

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -175,36 +175,37 @@ object GeneratorUtils {
             }
             .sortedBy { it.type.isNullable }
 
-        val all = bodies + parameters + extraParameters
+        return detectAndAvoidNameClashes(bodies + parameters + extraParameters)
+    }
 
-        return if (all.map { it.name }.toSet().size != all.size) {
-            // at least one parameter name has been repeated,
-            // so avoid clashes by prefixing all names with their location
+    private fun detectAndAvoidNameClashes(parameters: List<IncomingParameter>): List<IncomingParameter> {
+        if (parameters.map { it.name }.toSet().size == parameters.size) {
+            return parameters
+        }
 
-            all.map { p ->
-                when (p) {
-                    is BodyParameter -> BodyParameter(
-                        "body_${p.oasName}".toKotlinParameterName(),
-                        p.description,
-                        p.type,
-                        p.schema,
-                    )
-                    is RequestParameter -> RequestParameter(
-                        "${p.parameterLocation}_${p.oasName}".toKotlinParameterName(),
-                        p.description,
-                        p.type,
-                        p.originalName,
-                        p.parameterLocation,
-                        p.typeInfo,
-                        p.minimum,
-                        p.maximum,
-                        p.isRequired,
-                        p.explode,
-                        p.defaultValue,
-                    )
-                }
+        return parameters.map { p ->
+            when (p) {
+                is BodyParameter -> BodyParameter(
+                    "body_${p.oasName}".toKotlinParameterName(),
+                    p.description,
+                    p.type,
+                    p.schema,
+                )
+                is RequestParameter -> RequestParameter(
+                    "${p.parameterLocation}_${p.oasName}".toKotlinParameterName(),
+                    p.description,
+                    p.type,
+                    p.originalName,
+                    p.parameterLocation,
+                    p.typeInfo,
+                    p.minimum,
+                    p.maximum,
+                    p.isRequired,
+                    p.explode,
+                    p.defaultValue,
+                )
             }
-        } else all
+        }
     }
 
     private fun isNullable(parameter: Parameter): Boolean = !parameter.isRequired && parameter.schema.default == null

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -6,6 +6,7 @@ import com.cjbooms.fabrikt.util.NormalisedString.camelCase
 import com.reprezen.kaizen.oasparser.model3.MediaType
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Parameter
+import com.reprezen.kaizen.oasparser.model3.Path
 import com.reprezen.kaizen.oasparser.model3.RequestBody
 import com.reprezen.kaizen.oasparser.model3.Response
 import com.reprezen.kaizen.oasparser.model3.Schema
@@ -70,10 +71,13 @@ object GeneratorUtils {
     fun RequestBody.toBodyRequestSchema(): List<Schema> =
         listOfNotNull(this.getPrimaryContentMediaType()?.value?.schema)
 
-    fun Operation.toKdoc(): CodeBlock {
+    fun mergeParameters(path: List<Parameter>, operation: List<Parameter>): List<Parameter> =
+        path.filter { pp -> !operation.any { op -> pp.name == op.name && pp.`in` == op.`in` } } + operation
+
+    fun Operation.toKdoc(path: Path): CodeBlock {
         val kdoc = CodeBlock.builder().add("${this.summary.orEmpty()}\n${this.description.orEmpty()}\n")
 
-        this.parameters.forEach {
+        mergeParameters(path.parameters, this.parameters).forEach {
             kdoc.add("@param %L %L\n", it.name.toKCodeName(), it.description.orEmpty()).build()
         }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -199,6 +199,7 @@ object GeneratorUtils {
                         p.minimum,
                         p.maximum,
                         p.isRequired,
+                        p.explode,
                         p.defaultValue,
                     )
                 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -1,14 +1,23 @@
 package com.cjbooms.fabrikt.generators.client
 
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaType
+import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaTypeKey
+import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleContentMediaTypes
 import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleResponseSchemas
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.ClientType
+import com.cjbooms.fabrikt.model.HeaderParam
+import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.model.RequestParameter
 import com.fasterxml.jackson.databind.JsonNode
 import com.reprezen.kaizen.oasparser.model3.Operation
+import com.reprezen.kaizen.oasparser.model3.Path
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
@@ -44,4 +53,44 @@ object ClientGeneratorUtils {
     fun simpleClientName(resourceName: String) = "$resourceName${ClientType.SIMPLE_CLIENT_SUFFIX}"
 
     fun enhancedClientName(resourceName: String) = "$resourceName${ClientType.ENHANCED_CLIENT_SUFFIX}"
+
+    fun deriveClientParameters(path: Path, operation: Operation, basePackage: String): List<IncomingParameter> {
+        fun needsAcceptHeaderParameter(path: Path, operation: Operation): Boolean {
+            val hasAcceptParameter = GeneratorUtils.mergeParameters(path.parameters, operation.parameters)
+                .any { parameter -> parameter.`in` == "header" && parameter.name.equals(ACCEPT_HEADER_NAME, ignoreCase = true) }
+            return operation.hasMultipleContentMediaTypes() == true && !hasAcceptParameter
+        }
+
+        val extra = if (needsAcceptHeaderParameter(path, operation)) listOf(
+            RequestParameter(
+                oasName = ACCEPT_HEADER_VARIABLE_NAME,
+                description = null,
+                type = toModelType(basePackage, KotlinTypeInfo.Text, false),
+                originalName = ACCEPT_HEADER_NAME,
+                parameterLocation = HeaderParam,
+                typeInfo = KotlinTypeInfo.Text,
+                minimum = null,
+                maximum = null,
+                isRequired = true,
+                defaultValue = operation.getPrimaryContentMediaTypeKey(),
+            )
+        ) else emptyList()
+
+        return operation.toIncomingParameters(
+            basePackage,
+            path.parameters,
+            extra,
+        )
+    }
+
+    fun FunSpec.Builder.addIncomingParameters(parameters: List<IncomingParameter>): FunSpec.Builder {
+        val specs = parameters.map {
+            val builder = it.toParameterSpecBuilder()
+            if (it is RequestParameter && it.defaultValue != null) {
+                builder.defaultValue("%S", it.defaultValue)
+            }
+            builder.build()
+        }
+        return this.addParameters(specs)
+    }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -14,6 +14,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
 
 object ClientGeneratorUtils {
+    const val ACCEPT_HEADER_NAME = "Accept"
     const val ACCEPT_HEADER_VARIABLE_NAME = "acceptHeader"
     const val ADDITIONAL_HEADERS_PARAMETER_NAME = "additionalHeaders"
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -1,19 +1,14 @@
 package com.cjbooms.fabrikt.generators.client
 
 import com.cjbooms.fabrikt.configurations.Packages
-import com.cjbooms.fabrikt.generators.GeneratorUtils.firstResponse
 import com.cjbooms.fabrikt.generators.GeneratorUtils.functionName
-import com.cjbooms.fabrikt.generators.GeneratorUtils.getHeaderParams
-import com.cjbooms.fabrikt.generators.GeneratorUtils.getPathParams
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaType
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaTypeKey
-import com.cjbooms.fabrikt.generators.GeneratorUtils.getQueryParams
 import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleContentMediaTypes
 import com.cjbooms.fabrikt.generators.GeneratorUtils.mergeParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.primaryPropertiesConstructor
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
-import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.TypeFactory
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ACCEPT_HEADER_NAME
@@ -28,7 +23,10 @@ import com.cjbooms.fabrikt.model.Destinations
 import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.HandlebarsTemplates
 import com.cjbooms.fabrikt.model.HeaderParam
+import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.model.PathParam
+import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
@@ -101,7 +99,7 @@ class OkHttpSimpleClientGenerator(
                                 resource,
                                 verb,
                                 operation,
-                                parameters.filterIsInstance<BodyParameter>(),
+                                parameters,
                             ).toStatement()
                         )
                         .returns(operation.toClientReturnType(packages))
@@ -166,7 +164,7 @@ data class SimpleClientOperationStatement(
     private val resource: String,
     private val verb: String,
     private val operation: Operation,
-    private val bodyParameters: List<BodyParameter>
+    private val parameters: List<IncomingParameter>
 ) {
     fun toStatement(): CodeBlock =
         CodeBlock.builder()
@@ -184,7 +182,13 @@ data class SimpleClientOperationStatement(
     }
 
     private fun CodeBlock.Builder.addPathParamStatement(): CodeBlock.Builder {
-        operation.getPathParams().map { this.add("\n.pathParam(%S to %N)", "{${it.name}}", it.name.toKCodeName()) }
+        parameters
+            .filterIsInstance<RequestParameter>()
+            .filter { it.parameterLocation == PathParam }
+            .forEach {
+                this.add("\n.pathParam(%S to %N)", "{${it.originalName}}", it.name)
+            }
+
         this.add("\n.%T()\n.newBuilder()", "toHttpUrl".toClassName("okhttp3.HttpUrl.Companion"))
         return this
     }
@@ -194,51 +198,41 @@ data class SimpleClientOperationStatement(
      * serialization](https://swagger.io/docs/specification/serialization) query parameters style values
      */
     private fun CodeBlock.Builder.addQueryParamStatement(): CodeBlock.Builder {
-        operation.getQueryParams().map {
-            when (KotlinTypeInfo.from(it.schema)) {
-                is KotlinTypeInfo.Array -> this.add(
-                    "\n.%T(%S, %N, %L)",
-                    "queryParam".toClassName(packages.client),
-                    it.name,
-                    it.name.toKCodeName(),
-                    if (it.explode == null || it.explode == true) "true" else "false"
-                )
-                else -> this.add(
-                    "\n.%T(%S, %N)",
-                    "queryParam".toClassName(packages.client),
-                    it.name,
-                    it.name.toKCodeName()
-                )
+        parameters
+            .filterIsInstance<RequestParameter>()
+            .filter { it.parameterLocation == QueryParam }
+            .forEach {
+                when (it.typeInfo) {
+                    is KotlinTypeInfo.Array -> this.add(
+                        "\n.%T(%S, %N, %L)",
+                        "queryParam".toClassName(packages.client),
+                        it.originalName,
+                        it.name,
+                        if (it.explode == null || it.explode == true) "true" else "false"
+                    )
+                    else -> this.add(
+                        "\n.%T(%S, %N)",
+                        "queryParam".toClassName(packages.client),
+                        it.originalName,
+                        it.name
+                    )
+                }
             }
-        }
         return this.add("\n.build()\n")
     }
 
     private fun CodeBlock.Builder.addHeaderParamStatement(): CodeBlock.Builder {
         this.add("\nval headerBuilder = Headers.Builder()")
-        var isAcceptSet = false
-        operation.getHeaderParams().map {
-            if (it.name == "Accept") isAcceptSet = true
-            val typeInfo = KotlinTypeInfo.from(it.schema)
-            this.add(
-                "\n.%T(%S, %L)", "header".toClassName(packages.client),
-                it.name,
-                it.name.toKCodeName() + if (typeInfo is KotlinTypeInfo.Enum) "?.value" else ""
-            )
-        }
-
-        if (!isAcceptSet) operation.firstResponse()?.let {
-            if (it.hasMultipleContentMediaTypes()) {
-                this.add("\n.%T(%S, %L)", "header".toClassName(packages.client), "Accept", ACCEPT_HEADER_VARIABLE_NAME)
-            } else {
+        parameters
+            .filterIsInstance<RequestParameter>()
+            .filter { it.parameterLocation == HeaderParam }
+            .forEach {
                 this.add(
-                    "\n.%T(%S, %S)",
-                    "header".toClassName(packages.client),
-                    "Accept",
-                    operation.getPrimaryContentMediaTypeKey()
+                    "\n.%T(%S, %L)", "header".toClassName(packages.client),
+                    it.originalName,
+                    it.name + if (it.typeInfo is KotlinTypeInfo.Enum) "?.value" else ""
                 )
             }
-        }
         this.add("\nadditionalHeaders.forEach { headerBuilder.header(it.key, it.value) }")
 
         return this.add("\nval httpHeaders: %T = headerBuilder.build()\n", "Headers".toClassName("okhttp3"))
@@ -265,7 +259,7 @@ data class SimpleClientOperationStatement(
     private fun CodeBlock.Builder.addRequestSerializerStatement(verb: String) {
         val requestBody = operation.requestBody
         val toRequestBody = "toRequestBody".toClassName("okhttp3.RequestBody.Companion")
-        bodyParameters.firstOrNull()?.let {
+        parameters.filterIsInstance<BodyParameter>().firstOrNull()?.let {
             this.add(
                 "\n.%N(objectMapper.writeValueAsString(%N).%T(%S.%T()))",
                 verb,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -53,7 +53,7 @@ class OkHttpSimpleClientGenerator(
                     FunSpec
                         .builder(functionName(operation, resource, verb))
                         .addModifiers(KModifier.PUBLIC)
-                        .addKdoc(operation.toKdoc())
+                        .addKdoc(operation.toKdoc(path))
                         .addAnnotation(
                             AnnotationSpec.builder(Throws::class)
                                 .addMember("%T::class", "ApiException".toClassName(packages.client)).build()

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -3,20 +3,15 @@ package com.cjbooms.fabrikt.generators.client
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils.functionName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaType
-import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaTypeKey
-import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleContentMediaTypes
-import com.cjbooms.fabrikt.generators.GeneratorUtils.mergeParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.primaryPropertiesConstructor
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
-import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.TypeFactory
-import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ACCEPT_HEADER_NAME
-import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ACCEPT_HEADER_VARIABLE_NAME
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ADDITIONAL_HEADERS_PARAMETER_NAME
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingParameters
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.toClientReturnType
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Destinations
@@ -33,7 +28,6 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
-import com.reprezen.kaizen.oasparser.model3.Path
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -51,25 +45,7 @@ class OkHttpSimpleClientGenerator(
         return api.openApi3.routeToPaths().map { (resourceName, paths) ->
             val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
-                    val extra = if (needsAcceptHeaderParameter(path, operation)) listOf(
-                        RequestParameter(
-                            oasName = ACCEPT_HEADER_VARIABLE_NAME,
-                            description = null,
-                            type = toModelType(packages.base, KotlinTypeInfo.Text, false),
-                            originalName = ACCEPT_HEADER_NAME,
-                            parameterLocation = HeaderParam,
-                            typeInfo = KotlinTypeInfo.Text,
-                            minimum = null,
-                            maximum = null,
-                            isRequired = true,
-                            defaultValue = operation.getPrimaryContentMediaTypeKey(),
-                        )
-                    ) else emptyList()
-                    val parameters = operation.toIncomingParameters(
-                        packages.base,
-                        path.parameters,
-                        extra,
-                    )
+                    val parameters = deriveClientParameters(path, operation, packages.base)
                     FunSpec
                         .builder(functionName(operation, resource, verb))
                         .addModifiers(KModifier.PUBLIC)
@@ -78,13 +54,7 @@ class OkHttpSimpleClientGenerator(
                             AnnotationSpec.builder(Throws::class)
                                 .addMember("%T::class", "ApiException".toClassName(packages.client)).build()
                         )
-                        .addParameters(parameters.map {
-                            val builder = it.toParameterSpecBuilder()
-                            if (it is RequestParameter && it.defaultValue != null) {
-                                builder.defaultValue("%S", it.defaultValue)
-                            }
-                            builder.build()
-                        })
+                        .addIncomingParameters(parameters)
                         .addParameter(
                             ParameterSpec.builder(
                                 ADDITIONAL_HEADERS_PARAMETER_NAME,
@@ -119,12 +89,6 @@ class OkHttpSimpleClientGenerator(
 
             ClientType(clientType, packages.base)
         }.toSet()
-    }
-
-    private fun needsAcceptHeaderParameter(path: Path, operation: Operation): Boolean {
-        val hasAcceptParameter = mergeParameters(path.parameters, operation.parameters)
-            .any { parameter -> parameter.`in` == "header" && parameter.name.equals(ACCEPT_HEADER_NAME, ignoreCase = true) }
-        return operation.hasMultipleContentMediaTypes() == true && !hasAcceptParameter
     }
 
     fun generateLibrary(): Collection<GeneratedFile> {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
@@ -1,5 +1,7 @@
 package com.cjbooms.fabrikt.generators.controller
 
+import com.cjbooms.fabrikt.generators.GeneratorUtils
+import com.cjbooms.fabrikt.generators.GeneratorUtils.mergeParameters
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ControllerType
@@ -51,7 +53,7 @@ object ControllerGeneratorUtils {
      * encapsulated here to ensure the order of parameters align between
      * services and controllers
      */
-    fun Operation.toIncomingParameters(basePackage: String): List<IncomingParameter> {
+    fun Operation.toIncomingParameters(basePackage: String, pathParameters: List<Parameter>): List<IncomingParameter> {
 
         val bodies = requestBody.contentMediaTypes.values
             .map {
@@ -62,7 +64,7 @@ object ControllerGeneratorUtils {
                 )
             }
 
-        val parameters = parameters
+        val parameters = mergeParameters(pathParameters, parameters)
             .map {
                 RequestParameter(
                     it.name,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
@@ -1,17 +1,10 @@
 package com.cjbooms.fabrikt.generators.controller
 
-import com.cjbooms.fabrikt.generators.GeneratorUtils
-import com.cjbooms.fabrikt.generators.GeneratorUtils.mergeParameters
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
-import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ControllerType
-import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
-import com.cjbooms.fabrikt.model.RequestParameter
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
 import com.reprezen.kaizen.oasparser.model3.Operation
-import com.reprezen.kaizen.oasparser.model3.Parameter
 import com.reprezen.kaizen.oasparser.model3.Response
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
@@ -47,37 +40,6 @@ object ControllerGeneratorUtils {
 
         return toResponseMapping[code]!!
     }
-
-    /**
-     * Returns a list of IncomingParameters, ordering logic should be
-     * encapsulated here to ensure the order of parameters align between
-     * services and controllers
-     */
-    fun Operation.toIncomingParameters(basePackage: String, pathParameters: List<Parameter>): List<IncomingParameter> {
-
-        val bodies = requestBody.contentMediaTypes.values
-            .map {
-                BodyParameter(
-                    it.schema.safeName(),
-                    toModelType(basePackage, KotlinTypeInfo.from(it.schema)),
-                    it.schema
-                )
-            }
-
-        val parameters = mergeParameters(pathParameters, parameters)
-            .map {
-                RequestParameter(
-                    it.name,
-                    toModelType(basePackage, KotlinTypeInfo.from(it.schema), isNullable(it)),
-                    it
-                )
-            }
-            .sortedBy { it.type.isNullable }
-
-        return bodies + parameters
-    }
-
-    private fun isNullable(parameter: Parameter): Boolean = !parameter.isRequired && parameter.schema.default == null
 
     fun controllerName(resourceName: String) = "$resourceName${ControllerType.SUFFIX}"
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -2,11 +2,11 @@ package com.cjbooms.fabrikt.generators.controller
 
 import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.controllerName
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.methodName
-import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.controller.metadata.JavaXAnnotations
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringAnnotations
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports
@@ -88,7 +88,7 @@ class SpringControllerInterfaceGenerator(
         val funcSpec = FunSpec
             .builder(methodName)
             .addModifiers(KModifier.ABSTRACT)
-            .addKdoc(op.toKdoc(path))
+            .addKdoc(op.toKdoc(parameters))
             .addSpringFunAnnotation(op, verb, path.pathString)
             .addSuspendModifier()
             .returns(SpringImports.RESPONSE_ENTITY.parameterizedBy(returnType))

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -1,7 +1,6 @@
 package com.cjbooms.fabrikt.generators.controller
 
 import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
-import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.controllerName
@@ -54,9 +53,9 @@ class SpringControllerInterfaceGenerator(
                 .filter { it.key.toUpperCase() != "HEAD" }
                 .map { op ->
                     buildFunction(
+                        path,
                         op.value,
                         op.key,
-                        path.pathString
                     )
                 }
         }.forEach { typeBuilder.addFunction(it) }
@@ -77,20 +76,20 @@ class SpringControllerInterfaceGenerator(
             .addAnnotation(SpringAnnotations.requestMappingBuilder().addMember("%S", basePath).build())
 
     private fun buildFunction(
+        path: Path,
         op: Operation,
         verb: String,
-        pathString: String
     ): FunSpec {
-        val methodName = methodName(op, verb, pathString.isSingleResource())
+        val methodName = methodName(op, verb, path.pathString.isSingleResource())
         val returnType = op.happyPathResponse(packages.base)
-        val parameters = op.toIncomingParameters(packages.base)
+        val parameters = op.toIncomingParameters(packages.base, path.parameters)
 
         // Main method builder
         val funcSpec = FunSpec
             .builder(methodName)
             .addModifiers(KModifier.ABSTRACT)
-            .addKdoc(op.toKdoc())
-            .addSpringFunAnnotation(op, verb, pathString)
+            .addKdoc(op.toKdoc(path))
+            .addSpringFunAnnotation(op, verb, path.pathString)
             .addSuspendModifier()
             .returns(SpringImports.RESPONSE_ENTITY.parameterizedBy(returnType))
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -82,7 +82,7 @@ class SpringControllerInterfaceGenerator(
     ): FunSpec {
         val methodName = methodName(op, verb, path.pathString.isSingleResource())
         val returnType = op.happyPathResponse(packages.base)
-        val parameters = op.toIncomingParameters(packages.base, path.parameters)
+        val parameters = op.toIncomingParameters(packages.base, path.parameters, emptyList())
 
         // Main method builder
         val funcSpec = FunSpec

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -112,7 +112,8 @@ class RequestParameter(
     val minimum: Number? = null,
     val maximum: Number? = null,
     val isRequired: Boolean = false,
-    val defaultValue: Any? = null
+    val explode: Boolean? = null,
+    val defaultValue: Any? = null,
 ) : IncomingParameter(oasName, description, type) {
     constructor(oasName: String, description: String?, type: TypeName, parameter: Parameter) : this(
         oasName = oasName,
@@ -124,6 +125,7 @@ class RequestParameter(
         maximum = parameter.schema.maximum,
         parameterLocation = RequestParameterLocation(parameter.`in`),
         isRequired = parameter.isRequired,
+        explode = parameter.explode,
         defaultValue = parameter.schema.default
     )
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -93,16 +93,18 @@ private fun <T : GeneratedType> groupClasses(allModels: Collection<T>): Map<T, L
  * The IncomingParameter class is intended to represent a given name and type
  * of an incoming request, be it either a header, url param, path param, or body
  */
-sealed class IncomingParameter(val oasName: String, val type: TypeName) {
+sealed class IncomingParameter(val oasName: String, val description: String?, val type: TypeName) {
     val name: String = oasName.toKotlinParameterName()
     fun toParameterSpecBuilder(): ParameterSpec.Builder =
         ParameterSpec.builder(name, type)
 }
 
-class BodyParameter(oasName: String, type: TypeName, val schema: Schema) : IncomingParameter(oasName, type)
+class BodyParameter(oasName: String, description: String?, type: TypeName, val schema: Schema) :
+    IncomingParameter(oasName, description, type)
 
 class RequestParameter(
     oasName: String,
+    description: String?,
     type: TypeName,
     val parameterLocation: RequestParameterLocation,
     val typeInfo: KotlinTypeInfo,
@@ -110,9 +112,10 @@ class RequestParameter(
     val maximum: Number? = null,
     val isRequired: Boolean = false,
     val defaultValue: Any? = null
-) : IncomingParameter(oasName, type) {
-    constructor(oasName: String, type: TypeName, parameter: Parameter) : this(
+) : IncomingParameter(oasName, description, type) {
+    constructor(oasName: String, description: String?, type: TypeName, parameter: Parameter) : this(
         oasName = oasName,
+        description = description,
         type = type,
         typeInfo = KotlinTypeInfo.from(parameter.schema, oasName),
         minimum = parameter.schema.minimum,

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -95,7 +95,7 @@ private fun <T : GeneratedType> groupClasses(allModels: Collection<T>): Map<T, L
  */
 sealed class IncomingParameter(val oasName: String, val description: String?, val type: TypeName) {
     val name: String = oasName.toKotlinParameterName()
-    fun toParameterSpecBuilder(): ParameterSpec.Builder =
+    open fun toParameterSpecBuilder(): ParameterSpec.Builder =
         ParameterSpec.builder(name, type)
 }
 
@@ -106,6 +106,7 @@ class RequestParameter(
     oasName: String,
     description: String?,
     type: TypeName,
+    var originalName: String,
     val parameterLocation: RequestParameterLocation,
     val typeInfo: KotlinTypeInfo,
     val minimum: Number? = null,
@@ -117,6 +118,7 @@ class RequestParameter(
         oasName = oasName,
         description = description,
         type = type,
+        originalName = parameter.name,
         typeInfo = KotlinTypeInfo.from(parameter.schema, oasName),
         minimum = parameter.schema.minimum,
         maximum = parameter.schema.maximum,

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/ParameterInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/ParameterInfo.kt
@@ -12,6 +12,12 @@ sealed class RequestParameterLocation {
     }
 }
 
-object QueryParam : RequestParameterLocation()
-object HeaderParam : RequestParameterLocation()
-object PathParam : RequestParameterLocation()
+object QueryParam : RequestParameterLocation() {
+    override fun toString() = "query"
+}
+object HeaderParam : RequestParameterLocation() {
+    override fun toString() = "header"
+}
+object PathParam : RequestParameterLocation() {
+    override fun toString() = "path"
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -30,6 +30,8 @@ class OkHttpClientGeneratorTest {
         "okHttpClient",
         "okHttpClientMultiMediaType",
         "okHttpClientPostWithoutRequestBody",
+        "pathLevelParameters",
+        "parameterNameClash",
     )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -30,7 +30,8 @@ class SpringControllerGeneratorTest {
     @Suppress("unused")
     private fun testCases(): Stream<String> = Stream.of(
         "githubApi",
-        "singleAllOf"
+        "singleAllOf",
+        "pathLevelParameters",
     )
 
     private fun setupGithubApiTestEnv() {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -32,6 +32,7 @@ class SpringControllerGeneratorTest {
         "githubApi",
         "singleAllOf",
         "pathLevelParameters",
+        "parameterNameClash",
     )
 
     private fun setupGithubApiTestEnv() {

--- a/src/test/resources/examples/githubApi/controllers/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/Controllers.kt
@@ -36,6 +36,8 @@ import kotlin.collections.List
 interface InternalEventsController {
     /**
      * Generate change events for a list of entities
+     *
+     * @param bulkEntityDetails
      */
     @RequestMapping(
         value = ["/internal/events"],
@@ -56,13 +58,13 @@ interface ContributorsController {
     /**
      * Page through all the Contributor resources matching the query filters
      *
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
      * @param includeInactive A query parameter to request both active and inactive entities
-     * @param limit Upper bound for number of results to be returned from query api. A default limit
-     * will be applied if this is not present
-     *
      * @param cursor An encoded value which represents a point in the data from where pagination will
      * commence. The pagination direction (either forward or backward) will also be encoded within the
      * cursor value. The cursor value will always be generated server side
@@ -84,6 +86,7 @@ interface ContributorsController {
     /**
      * Create a new Contributor
      *
+     * @param contributor
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
@@ -112,16 +115,16 @@ interface ContributorsController {
     /**
      * Get a Contributor by ID
      *
+     * @param id The unique id for the resource
+     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
+     * Will return a 404 if the status property does not match the query parameter."
+     *
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
-     * @param id The unique id for the resource
      * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
      * only operate on the resource if it does not match any of the provided entity-tags. If the provided
      * entity-tag is `*`, it is required that the resource does not exist at all.
-     *
-     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
-     * Will return a 404 if the status property does not match the query parameter."
      *
      */
     @RequestMapping(
@@ -140,14 +143,15 @@ interface ContributorsController {
     /**
      * Update an existing Contributor
      *
-     * @param xFlowId A custom header that will be passed onto any further requests and can be used
-     * for diagnosing.
-     *
+     * @param contributor
      * @param id The unique id for the resource
      * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
      * operate on the resource that matches at least one of the provided entity-tags. This allows clients
      * express a precondition that prevent the method from being applied if there have been any changes
      * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
      *
      * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
      * requests without accidentally performing the same operation twice. This is useful in cases such as
@@ -181,13 +185,13 @@ interface OrganisationsController {
     /**
      * Page through all the Organisation resources matching the query filters
      *
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
      * @param includeInactive A query parameter to request both active and inactive entities
-     * @param limit Upper bound for number of results to be returned from query api. A default limit
-     * will be applied if this is not present
-     *
      * @param cursor An encoded value which represents a point in the data from where pagination will
      * commence. The pagination direction (either forward or backward) will also be encoded within the
      * cursor value. The cursor value will always be generated server side
@@ -209,6 +213,7 @@ interface OrganisationsController {
     /**
      * Create a new Organisation
      *
+     * @param organisation
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
@@ -237,16 +242,16 @@ interface OrganisationsController {
     /**
      * Get a Organisation by ID
      *
+     * @param id The unique id for the resource
+     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
+     * Will return a 404 if the status property does not match the query parameter."
+     *
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
-     * @param id The unique id for the resource
      * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
      * only operate on the resource if it does not match any of the provided entity-tags. If the provided
      * entity-tag is `*`, it is required that the resource does not exist at all.
-     *
-     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
-     * Will return a 404 if the status property does not match the query parameter."
      *
      */
     @RequestMapping(
@@ -265,14 +270,15 @@ interface OrganisationsController {
     /**
      * Update an existing Organisation
      *
-     * @param xFlowId A custom header that will be passed onto any further requests and can be used
-     * for diagnosing.
-     *
+     * @param organisation
      * @param id The unique id for the resource
      * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
      * operate on the resource that matches at least one of the provided entity-tags. This allows clients
      * express a precondition that prevent the method from being applied if there have been any changes
      * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
      *
      * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
      * requests without accidentally performing the same operation twice. This is useful in cases such as
@@ -307,14 +313,14 @@ interface OrganisationsContributorsController {
      * Page through all the Contributor resources for this parent Organisation matching the query
      * filters
      *
-     * @param xFlowId A custom header that will be passed onto any further requests and can be used
-     * for diagnosing.
-     *
      * @param parentId The unique id for the parent resource
-     * @param includeInactive A query parameter to request both active and inactive entities
      * @param limit Upper bound for number of results to be returned from query api. A default limit
      * will be applied if this is not present
      *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param includeInactive A query parameter to request both active and inactive entities
      * @param cursor An encoded value which represents a point in the data from where pagination will
      * commence. The pagination direction (either forward or backward) will also be encoded within the
      * cursor value. The cursor value will always be generated server side
@@ -338,10 +344,10 @@ interface OrganisationsContributorsController {
      * Get a Contributor for this Organisation by ID
      *
      * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
-     * @param id The unique id for the resource
      * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
      * only operate on the resource if it does not match any of the provided entity-tags. If the provided
      * entity-tag is `*`, it is required that the resource does not exist at all.
@@ -363,14 +369,14 @@ interface OrganisationsContributorsController {
      * Add an existing Contributor to this Organisation
      *
      * @param parentId The unique id for the parent resource
-     * @param xFlowId A custom header that will be passed onto any further requests and can be used
-     * for diagnosing.
-     *
      * @param id The unique id for the resource
      * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
      * operate on the resource that matches at least one of the provided entity-tags. This allows clients
      * express a precondition that prevent the method from being applied if there have been any changes
      * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
      *
      * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
      * requests without accidentally performing the same operation twice. This is useful in cases such as
@@ -398,10 +404,10 @@ interface OrganisationsContributorsController {
      * Remove Contributor from this Organisation. Does not delete the underlying Contributor.
      *
      * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
-     * @param id The unique id for the resource
      */
     @RequestMapping(
         value = ["/organisations/{parent-id}/contributors/{id}"],
@@ -422,6 +428,9 @@ interface RepositoriesController {
     /**
      * Page through all the Repository resources matching the query filters
      *
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
@@ -430,9 +439,6 @@ interface RepositoriesController {
      * @param name Filters resources by the [name] property. Accepts comma-delimited values
      *
      * @param includeInactive A query parameter to request both active and inactive entities
-     * @param limit Upper bound for number of results to be returned from query api. A default limit
-     * will be applied if this is not present
-     *
      * @param cursor An encoded value which represents a point in the data from where pagination will
      * commence. The pagination direction (either forward or backward) will also be encoded within the
      * cursor value. The cursor value will always be generated server side
@@ -458,6 +464,7 @@ interface RepositoriesController {
     /**
      * Create a new Repository
      *
+     * @param repository
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
@@ -486,16 +493,16 @@ interface RepositoriesController {
     /**
      * Get a Repository by ID
      *
+     * @param id The unique id for the resource
+     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
+     * Will return a 404 if the status property does not match the query parameter."
+     *
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
-     * @param id The unique id for the resource
      * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
      * only operate on the resource if it does not match any of the provided entity-tags. If the provided
      * entity-tag is `*`, it is required that the resource does not exist at all.
-     *
-     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
-     * Will return a 404 if the status property does not match the query parameter."
      *
      */
     @RequestMapping(
@@ -514,14 +521,15 @@ interface RepositoriesController {
     /**
      * Update an existing Repository
      *
-     * @param xFlowId A custom header that will be passed onto any further requests and can be used
-     * for diagnosing.
-     *
+     * @param repository
      * @param id The unique id for the resource
      * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
      * operate on the resource that matches at least one of the provided entity-tags. This allows clients
      * express a precondition that prevent the method from being applied if there have been any changes
      * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
      *
      * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
      * requests without accidentally performing the same operation twice. This is useful in cases such as
@@ -556,14 +564,14 @@ interface RepositoriesPullRequestsController {
      * Page through all the PullRequest resources for this parent Repository matching the query
      * filters
      *
-     * @param xFlowId A custom header that will be passed onto any further requests and can be used
-     * for diagnosing.
-     *
      * @param parentId The unique id for the parent resource
-     * @param includeInactive A query parameter to request both active and inactive entities
      * @param limit Upper bound for number of results to be returned from query api. A default limit
      * will be applied if this is not present
      *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param includeInactive A query parameter to request both active and inactive entities
      * @param cursor An encoded value which represents a point in the data from where pagination will
      * commence. The pagination direction (either forward or backward) will also be encoded within the
      * cursor value. The cursor value will always be generated server side
@@ -586,6 +594,7 @@ interface RepositoriesPullRequestsController {
     /**
      * Create a new PullRequest for this parent Repository
      *
+     * @param pullRequest
      * @param parentId The unique id for the parent resource
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
@@ -617,10 +626,10 @@ interface RepositoriesPullRequestsController {
      * Get a PullRequest for this Repository by ID
      *
      * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
      * @param xFlowId A custom header that will be passed onto any further requests and can be used
      * for diagnosing.
      *
-     * @param id The unique id for the resource
      * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
      * only operate on the resource if it does not match any of the provided entity-tags. If the provided
      * entity-tag is `*`, it is required that the resource does not exist at all.
@@ -641,15 +650,16 @@ interface RepositoriesPullRequestsController {
     /**
      * Update the PullRequest owned by this Repository
      *
+     * @param pullRequest
      * @param parentId The unique id for the parent resource
-     * @param xFlowId A custom header that will be passed onto any further requests and can be used
-     * for diagnosing.
-     *
      * @param id The unique id for the resource
      * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
      * operate on the resource that matches at least one of the provided entity-tags. This allows clients
      * express a precondition that prevent the method from being applied if there have been any changes
      * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
      *
      * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
      * requests without accidentally performing the same operation twice. This is useful in cases such as

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -63,11 +63,12 @@ class ExamplePath1Client(
     /**
      * POST example path 1
      *
+     * @param content
      * @param explodeListQueryParam
      */
     @Throws(ApiException::class)
     fun postExamplePath1(
-        generatedType: Content,
+        content: Content,
         explodeListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit?> {
@@ -84,7 +85,7 @@ class ExamplePath1Client(
         val request: Request = Request.Builder()
             .url(httpUrl)
             .headers(httpHeaders)
-            .post(objectMapper.writeValueAsString(generatedType).toRequestBody("application/json".toMediaType()))
+            .post(objectMapper.writeValueAsString(content).toRequestBody("application/json".toMediaType()))
             .build()
 
         return request.execute(client, objectMapper, jacksonTypeRef())
@@ -171,6 +172,7 @@ class ExamplePath2Client(
     /**
      * PUT example path 2
      *
+     * @param firstModel
      * @param pathParam The resource id
      * @param ifMatch The RFC7232 If-Match header field
      */
@@ -211,16 +213,17 @@ class ExamplePath3SubresourceClient(
     /**
      * PUT example path 3
      *
-     * @param csvListQueryParam
+     * @param firstModel
      * @param pathParam The resource id
      * @param ifMatch The RFC7232 If-Match header field
+     * @param csvListQueryParam
      */
     @Throws(ApiException::class)
     fun putExamplePath3PathParamSubresource(
         firstModel: FirstModel,
-        csvListQueryParam: List<String>?,
         pathParam: String,
         ifMatch: String,
+        csvListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit?> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-3/{path_param}/subresource"

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -47,7 +47,6 @@ class ExamplePath1Client(
             .build()
 
         val headerBuilder = Headers.Builder()
-            .header("Accept", "application/vnd.custom.media+json")
         additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
         val httpHeaders: Headers = headerBuilder.build()
 
@@ -121,7 +120,6 @@ class ExamplePath2Client(
 
         val headerBuilder = Headers.Builder()
             .header("If-None-Match", ifNoneMatch)
-            .header("Accept", "application/json")
         additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
         val httpHeaders: Headers = headerBuilder.build()
 

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -46,12 +46,12 @@ class ExamplePath1Service(
 
     @Throws(ApiException::class)
     fun postExamplePath1(
-        generatedType: Content,
+        content: Content,
         explodeListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit?> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.postExamplePath1(generatedType, explodeListQueryParam, additionalHeaders)
+            apiClient.postExamplePath1(content, explodeListQueryParam, additionalHeaders)
         }
 }
 
@@ -134,12 +134,12 @@ class ExamplePath3SubresourceService(
     @Throws(ApiException::class)
     fun putExamplePath3PathParamSubresource(
         firstModel: FirstModel,
-        csvListQueryParam: List<String>?,
         pathParam: String,
         ifMatch: String,
+        csvListQueryParam: List<String>?,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit?> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.putExamplePath3PathParamSubresource(firstModel, csvListQueryParam, pathParam, ifMatch, additionalHeaders)
+            apiClient.putExamplePath3PathParamSubresource(firstModel, pathParam, ifMatch, csvListQueryParam, additionalHeaders)
         }
 }

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
@@ -28,6 +28,7 @@ class ExamplePath1Client(
      *
      * @param explodeListQueryParam
      * @param queryParam2
+     * @param acceptHeader
      */
     @Throws(ApiException::class)
     fun getExamplePath1(

--- a/src/test/resources/examples/parameterNameClash/api.yaml
+++ b/src/test/resources/examples/parameterNameClash/api.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  version: '1'
+  title: pathLevelParameters
+paths:
+  /example/{b}:
+    get:
+      parameters:
+        - in: path
+          name: b
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: b
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: example
+  /example:
+    post:
+      parameters:
+        - in: query
+          name: someObject
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: example
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SomeObject'
+      responses:
+        '204':
+          description: example
+components:
+  schemas:
+    SomeObject:
+      type: object
+      properties:
+        test:
+          type: string

--- a/src/test/resources/examples/parameterNameClash/client/ApiClient.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ApiClient.kt
@@ -1,0 +1,87 @@
+package examples.parameterNameClash.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import examples.parameterNameClash.models.SomeObject
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+@Suppress("unused")
+class ExampleClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val client: OkHttpClient
+) {
+    /**
+     *
+     *
+     * @param pathB
+     * @param queryB
+     */
+    @Throws(ApiException::class)
+    fun getExampleB(
+        pathB: String,
+        queryB: String,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): ApiResponse<Unit?> {
+        val httpUrl: HttpUrl = "$baseUrl/example/{b}"
+            .pathParam("{b}" to pathB)
+            .toHttpUrl()
+            .newBuilder()
+            .queryParam("b", queryB)
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .get()
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     *
+     *
+     * @param bodySomeObject example
+     * @param querySomeObject
+     */
+    @Throws(ApiException::class)
+    fun postExample(
+        bodySomeObject: SomeObject,
+        querySomeObject: String,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): ApiResponse<Unit?> {
+        val httpUrl: HttpUrl = "$baseUrl/example"
+            .toHttpUrl()
+            .newBuilder()
+            .queryParam("someObject", querySomeObject)
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .post(objectMapper.writeValueAsString(bodySomeObject).toRequestBody("application/json".toMediaType()))
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/parameterNameClash/client/ApiModels.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ApiModels.kt
@@ -1,0 +1,26 @@
+package examples.parameterNameClash.client
+
+import okhttp3.Headers
+
+/**
+ * API 2xx success response returned by API call.
+ *
+ * @param <T> The type of data that is deserialized from response body
+ */
+data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T? = null)
+
+/**
+ * API non-2xx failure responses returned by API call.
+ */
+open class ApiException(override val message: String) : Exception(message)
+
+/**
+ * API 4xx failure responses returned by API call.
+ */
+data class ApiClientException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+
+/**
+ * API 5xx failure responses returned by API call.
+ */
+data class ApiServerException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+

--- a/src/test/resources/examples/parameterNameClash/client/ApiService.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ApiService.kt
@@ -1,0 +1,51 @@
+package examples.parameterNameClash.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import examples.parameterNameClash.models.SomeObject
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import okhttp3.OkHttpClient
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+class ExampleService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    client: OkHttpClient
+) {
+    var circuitBreakerName: String = "exampleClient"
+
+    private val apiClient: ExampleClient = ExampleClient(objectMapper, baseUrl, client)
+
+    @Throws(ApiException::class)
+    fun getExampleB(
+        b: String,
+        b: String,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): ApiResponse<Unit?> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.getExampleB(b, b, additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    fun postExample(
+        someObject: SomeObject?,
+        someObject: String,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): ApiResponse<Unit?> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.postExample(someObject, someObject, additionalHeaders)
+        }
+}

--- a/src/test/resources/examples/parameterNameClash/client/ApiService.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ApiService.kt
@@ -31,21 +31,21 @@ class ExampleService(
 
     @Throws(ApiException::class)
     fun getExampleB(
-        b: String,
-        b: String,
+        pathB: String,
+        queryB: String,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit?> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.getExampleB(b, b, additionalHeaders)
+            apiClient.getExampleB(pathB, queryB, additionalHeaders)
         }
 
     @Throws(ApiException::class)
     fun postExample(
-        someObject: SomeObject?,
-        someObject: String,
+        bodySomeObject: SomeObject,
+        querySomeObject: String,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit?> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.postExample(someObject, someObject, additionalHeaders)
+            apiClient.postExample(bodySomeObject, querySomeObject, additionalHeaders)
         }
 }

--- a/src/test/resources/examples/parameterNameClash/client/HttpResilience4jUtil.kt
+++ b/src/test/resources/examples/parameterNameClash/client/HttpResilience4jUtil.kt
@@ -1,0 +1,13 @@
+package examples.parameterNameClash.client
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+
+fun <T> withCircuitBreaker(
+    circuitBreakerRegistry: CircuitBreakerRegistry,
+    apiClientName: String,
+    apiCall: () -> ApiResponse<T>
+): ApiResponse<T> {
+    val circuitBreaker = circuitBreakerRegistry.circuitBreaker(apiClientName)
+    return CircuitBreaker.decorateSupplier(circuitBreaker, apiCall).get()
+}

--- a/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
+++ b/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
@@ -1,0 +1,65 @@
+package examples.parameterNameClash.client
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+@Suppress("unused")
+fun <T : Any> HttpUrl.Builder.queryParam(key: String, value: T?): HttpUrl.Builder = this.apply {
+    if (value != null) this.addQueryParameter(key, value.toString())
+}
+
+@Suppress("unused")
+fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
+}
+
+@Suppress("unused")
+fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+    if (values != null) {
+        if (explode) values.forEach { addQueryParameter(key, it) }
+        else addQueryParameter(key, values.joinToString(","))
+    }
+}
+
+@Suppress("unused")
+fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value)
+}
+
+@Throws(ApiException::class)
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+    client.newCall(this).execute().use { response ->
+        when {
+            response.isSuccessful ->
+                ApiResponse(response.code, response.headers, response.body?.deserialize(objectMapper, typeRef))
+            response.isBadRequest() ->
+                throw ApiClientException(response.code, response.headers, response.errorMessage())
+            response.isServerError() ->
+                throw ApiServerException(response.code, response.headers, response.errorMessage())
+            else -> throw ApiException("[${response.code}]: ${response.errorMessage()}")
+        }
+    }
+
+@Suppress("unused")
+fun String.pathParam(vararg params: Pair<String, Any>): String = params.asSequence()
+    .joinToString { param ->
+        this.replace(param.first, param.second.toString())
+    }
+
+fun <T> ResponseBody.deserialize(objectMapper: ObjectMapper, typeRef: TypeReference<T>): T? =
+    this.string().isNotBlankOrNull()?.let { objectMapper.readValue(it, typeRef) }
+
+fun String?.isNotBlankOrNull() = if (this.isNullOrBlank()) null else this
+
+private fun Response.errorMessage(): String = this.body?.string() ?: this.message
+
+private fun Response.isBadRequest(): Boolean = this.code in 400..499
+
+private fun Response.isServerError(): Boolean = this.code in 500..599

--- a/src/test/resources/examples/parameterNameClash/client/LoggingInterceptor.kt
+++ b/src/test/resources/examples/parameterNameClash/client/LoggingInterceptor.kt
@@ -1,0 +1,25 @@
+package examples.parameterNameClash.client
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class LoggingInterceptor : Interceptor {
+
+    private val logger: Logger = LoggerFactory.getLogger("GeneratedClient")
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        val t1 = System.nanoTime()
+        logger.info("Client Request: $request")
+
+        val response = chain.proceed(request)
+
+        val t2 = System.nanoTime()
+        logger.info("Client Response after ${(t2 - t1) / 100_000}ms: $response")
+
+        return response
+    }
+}

--- a/src/test/resources/examples/parameterNameClash/client/OAuth.kt
+++ b/src/test/resources/examples/parameterNameClash/client/OAuth.kt
@@ -1,0 +1,22 @@
+package examples.parameterNameClash.client
+
+import okhttp3.Authenticator
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+class OAuth2(val accessToken: () -> String) : Authenticator, Interceptor {
+
+    override fun authenticate(route: Route?, response: Response): Request =
+        response.request.newBuilder()
+            .header("Authorization", "Bearer ${accessToken().trim()}")
+            .build()
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header("Authorization", "Bearer ${accessToken().trim()}")
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/src/test/resources/examples/parameterNameClash/controllers/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/Controllers.kt
@@ -1,0 +1,60 @@
+package examples.parameterNameClash.controllers
+
+import examples.parameterNameClash.models.SomeObject
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import javax.validation.Valid
+import kotlin.String
+import kotlin.Unit
+
+@Controller
+@Validated
+@RequestMapping("")
+interface ExampleController {
+    /**
+     *
+     *
+     * @param pathB
+     * @param queryB
+     */
+    @RequestMapping(
+        value = ["/example/{b}"],
+        produces = [],
+        method = [RequestMethod.GET]
+    )
+    fun getById(
+        @PathVariable(value = "pathB", required = true) pathB: String,
+        @RequestParam(
+            value =
+            "queryB",
+            required = true
+        ) queryB: String
+    ): ResponseEntity<Unit>
+
+    /**
+     *
+     *
+     * @param bodySomeObject example
+     * @param querySomeObject
+     */
+    @RequestMapping(
+        value = ["/example"],
+        produces = [],
+        method = [RequestMethod.POST],
+        consumes = ["application/json"]
+    )
+    fun post(
+        @RequestBody @Valid
+        bodySomeObject: SomeObject,
+        @RequestParam(
+            value = "querySomeObject",
+            required = true
+        ) querySomeObject: String
+    ): ResponseEntity<Unit>
+}

--- a/src/test/resources/examples/parameterNameClash/models/Models.kt
+++ b/src/test/resources/examples/parameterNameClash/models/Models.kt
@@ -1,0 +1,10 @@
+package examples.parameterNameClash.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import kotlin.String
+
+data class SomeObject(
+    @param:JsonProperty("test")
+    @get:JsonProperty("test")
+    val test: String? = null
+)

--- a/src/test/resources/examples/pathLevelParameters/api.yaml
+++ b/src/test/resources/examples/pathLevelParameters/api.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  version: '1'
+  title: pathLevelParameters
+paths:
+  /example:
+    parameters:
+      - in: query
+        name: a
+        required: true
+        schema:
+          type: string
+    get:
+      parameters:
+        - in: query
+          name: b
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: example

--- a/src/test/resources/examples/pathLevelParameters/client/ApiClient.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiClient.kt
@@ -1,0 +1,53 @@
+package examples.pathLevelParameters.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+@Suppress("unused")
+class ExampleClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val client: OkHttpClient
+) {
+    /**
+     *
+     *
+     * @param a
+     * @param b
+     */
+    @Throws(ApiException::class)
+    fun getExample(
+        a: String,
+        b: String,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): ApiResponse<Unit?> {
+        val httpUrl: HttpUrl = "$baseUrl/example"
+            .toHttpUrl()
+            .newBuilder()
+            .queryParam("a", a)
+            .queryParam("b", b)
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .get()
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/pathLevelParameters/client/ApiModels.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiModels.kt
@@ -1,0 +1,26 @@
+package examples.pathLevelParameters.client
+
+import okhttp3.Headers
+
+/**
+ * API 2xx success response returned by API call.
+ *
+ * @param <T> The type of data that is deserialized from response body
+ */
+data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T? = null)
+
+/**
+ * API non-2xx failure responses returned by API call.
+ */
+open class ApiException(override val message: String) : Exception(message)
+
+/**
+ * API 4xx failure responses returned by API call.
+ */
+data class ApiClientException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+
+/**
+ * API 5xx failure responses returned by API call.
+ */
+data class ApiServerException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+

--- a/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
@@ -29,8 +29,12 @@ class ExampleService(
     private val apiClient: ExampleClient = ExampleClient(objectMapper, baseUrl, client)
 
     @Throws(ApiException::class)
-    fun getExample(b: String, additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+    fun getExample(
+        a: String,
+        b: String,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): ApiResponse<Unit?> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.getExample(b, additionalHeaders)
+            apiClient.getExample(a, b, additionalHeaders)
         }
 }

--- a/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
@@ -1,0 +1,36 @@
+package examples.pathLevelParameters.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import okhttp3.OkHttpClient
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+class ExampleService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    client: OkHttpClient
+) {
+    var circuitBreakerName: String = "exampleClient"
+
+    private val apiClient: ExampleClient = ExampleClient(objectMapper, baseUrl, client)
+
+    @Throws(ApiException::class)
+    fun getExample(b: String, additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<Unit?> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.getExample(b, additionalHeaders)
+        }
+}

--- a/src/test/resources/examples/pathLevelParameters/client/HttpResilience4jUtil.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/HttpResilience4jUtil.kt
@@ -1,0 +1,13 @@
+package examples.pathLevelParameters.client
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+
+fun <T> withCircuitBreaker(
+    circuitBreakerRegistry: CircuitBreakerRegistry,
+    apiClientName: String,
+    apiCall: () -> ApiResponse<T>
+): ApiResponse<T> {
+    val circuitBreaker = circuitBreakerRegistry.circuitBreaker(apiClientName)
+    return CircuitBreaker.decorateSupplier(circuitBreaker, apiCall).get()
+}

--- a/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
@@ -1,0 +1,65 @@
+package examples.pathLevelParameters.client
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+@Suppress("unused")
+fun <T : Any> HttpUrl.Builder.queryParam(key: String, value: T?): HttpUrl.Builder = this.apply {
+    if (value != null) this.addQueryParameter(key, value.toString())
+}
+
+@Suppress("unused")
+fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
+}
+
+@Suppress("unused")
+fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+    if (values != null) {
+        if (explode) values.forEach { addQueryParameter(key, it) }
+        else addQueryParameter(key, values.joinToString(","))
+    }
+}
+
+@Suppress("unused")
+fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value)
+}
+
+@Throws(ApiException::class)
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T?> =
+    client.newCall(this).execute().use { response ->
+        when {
+            response.isSuccessful ->
+                ApiResponse(response.code, response.headers, response.body?.deserialize(objectMapper, typeRef))
+            response.isBadRequest() ->
+                throw ApiClientException(response.code, response.headers, response.errorMessage())
+            response.isServerError() ->
+                throw ApiServerException(response.code, response.headers, response.errorMessage())
+            else -> throw ApiException("[${response.code}]: ${response.errorMessage()}")
+        }
+    }
+
+@Suppress("unused")
+fun String.pathParam(vararg params: Pair<String, Any>): String = params.asSequence()
+    .joinToString { param ->
+        this.replace(param.first, param.second.toString())
+    }
+
+fun <T> ResponseBody.deserialize(objectMapper: ObjectMapper, typeRef: TypeReference<T>): T? =
+    this.string().isNotBlankOrNull()?.let { objectMapper.readValue(it, typeRef) }
+
+fun String?.isNotBlankOrNull() = if (this.isNullOrBlank()) null else this
+
+private fun Response.errorMessage(): String = this.body?.string() ?: this.message
+
+private fun Response.isBadRequest(): Boolean = this.code in 400..499
+
+private fun Response.isServerError(): Boolean = this.code in 500..599

--- a/src/test/resources/examples/pathLevelParameters/client/LoggingInterceptor.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/LoggingInterceptor.kt
@@ -1,0 +1,25 @@
+package examples.pathLevelParameters.client
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class LoggingInterceptor : Interceptor {
+
+    private val logger: Logger = LoggerFactory.getLogger("GeneratedClient")
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        val t1 = System.nanoTime()
+        logger.info("Client Request: $request")
+
+        val response = chain.proceed(request)
+
+        val t2 = System.nanoTime()
+        logger.info("Client Response after ${(t2 - t1) / 100_000}ms: $response")
+
+        return response
+    }
+}

--- a/src/test/resources/examples/pathLevelParameters/client/OAuth.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/OAuth.kt
@@ -1,0 +1,22 @@
+package examples.pathLevelParameters.client
+
+import okhttp3.Authenticator
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+class OAuth2(val accessToken: () -> String) : Authenticator, Interceptor {
+
+    override fun authenticate(route: Route?, response: Response): Request =
+        response.request.newBuilder()
+            .header("Authorization", "Bearer ${accessToken().trim()}")
+            .build()
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header("Authorization", "Bearer ${accessToken().trim()}")
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/src/test/resources/examples/pathLevelParameters/controllers/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/Controllers.kt
@@ -1,0 +1,35 @@
+package examples.pathLevelParameters.controllers
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import kotlin.String
+import kotlin.Unit
+
+@Controller
+@Validated
+@RequestMapping("")
+interface ExampleController {
+    /**
+     *
+     *
+     * @param a
+     * @param b
+     */
+    @RequestMapping(
+        value = ["/example"],
+        produces = [],
+        method = [RequestMethod.GET]
+    )
+    fun get(
+        @RequestParam(value = "a", required = true) a: String,
+        @RequestParam(
+            value = "b",
+            required =
+            true
+        ) b: String
+    ): ResponseEntity<Unit>
+}


### PR DESCRIPTION
This PR does 3 things actually:

1. support path level parameters (including the override mechanic)
2. adds bodies to generated kdocs
3. renames all parameters if a name conflict is detected by prefixing all parameters with the location (body for request bodies)

Compatibility:

In some places the parameter order changed which is probably breaking.

