### PR TITLE
Fix inline enum detection in arrays.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -26,7 +26,7 @@ import com.cjbooms.fabrikt.model.SchemaInfo
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getSuperType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isComplexTypedAdditionalProperties
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.isEnumDefinition
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedTypedAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfPolymorphicTypes
@@ -221,7 +221,7 @@ class JacksonModelGenerator(
                                         it.name.toModelClassName(enclosingModelName), props
                                     )
                                 }
-                            items.isEnumDefinition() ->
+                            items.isInlinedEnumDefinition() ->
                                 setOf(
                                     buildEnumClass(
                                         KotlinTypeInfo.from(items, "items", enclosingModelName) as KotlinTypeInfo.Enum

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -4,14 +4,13 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.getKeyIfSingleDiscriminat
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasNoDiscriminator
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isDiscriminatorProperty
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.isEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInLinedObjectUnderAllOf
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSimpleMapDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isRequired
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSimpleMapDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.toModelClassName
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
@@ -72,7 +71,7 @@ sealed class PropertyInfo {
                             property.value,
                             settings.markAsInherited,
                             this,
-                            if (property.value.isInlinedArrayDefinition() || property.value.itemsSchema.isEnumDefinition())
+                            if (property.value.isInlinedArrayDefinition() || property.value.itemsSchema.isInlinedEnumDefinition())
                                 enclosingSchema
                             else null
                         )

--- a/src/test/resources/examples/enumExamples/api.yaml
+++ b/src/test/resources/examples/enumExamples/api.yaml
@@ -30,7 +30,9 @@ components:
         enum_ref:
           $ref: '#/components/schemas/EnumObject'
         extensible_enum_ref:
-          $ref: '#/components/schemas/ExtensibleEnumObject'
+          $ref: '#/components/schemas/ExtensibleEnumObject'        
+        list_enums:
+          $ref: '#/components/schemas/ListEnums'
 
     EnumObject:
       type: string
@@ -51,5 +53,10 @@ components:
         - application/json
         - application/x.some-type+json    
         - application/x.some-other-type+json;version=2    
+          
+    ListEnums:
+      type: array
+      items: 
+        $ref: '#/components/schemas/ContentType'
 
 

--- a/src/test/resources/examples/enumExamples/models/Models.kt
+++ b/src/test/resources/examples/enumExamples/models/Models.kt
@@ -38,7 +38,10 @@ data class EnumHolder(
     val enumRef: EnumObject? = null,
     @param:JsonProperty("extensible_enum_ref")
     @get:JsonProperty("extensible_enum_ref")
-    val extensibleEnumRef: ExtensibleEnumObject? = null
+    val extensibleEnumRef: ExtensibleEnumObject? = null,
+    @param:JsonProperty("list_enums")
+    @get:JsonProperty("list_enums")
+    val listEnums: List<ContentType>? = null
 )
 
 enum class EnumHolderArrayOfEnums(


### PR DESCRIPTION
All enums inside arrays were being treated as inlined definitions, even when they are not.