### PR TITLE
Throw Runtime exceptions.

### DIFF
--- a/src/main/resources/templates/client-code/api-models.kt.hbs
+++ b/src/main/resources/templates/client-code/api-models.kt.hbs
@@ -12,7 +12,7 @@ data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T
 /**
  * API non-2xx failure responses returned by API call.
  */
-open class ApiException(override val message: String) : Exception(message)
+open class ApiException(override val message: String) : RuntimeException(message)
 
 /**
  * API 4xx failure responses returned by API call.

--- a/src/test/resources/examples/okHttpClient/client/ApiModels.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiModels.kt
@@ -12,7 +12,7 @@ data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T
 /**
  * API non-2xx failure responses returned by API call.
  */
-open class ApiException(override val message: String) : Exception(message)
+open class ApiException(override val message: String) : RuntimeException(message)
 
 /**
  * API 4xx failure responses returned by API call.

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiModels.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiModels.kt
@@ -12,7 +12,7 @@ data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T
 /**
  * API non-2xx failure responses returned by API call.
  */
-open class ApiException(override val message: String) : Exception(message)
+open class ApiException(override val message: String) : RuntimeException(message)
 
 /**
  * API 4xx failure responses returned by API call.

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiModels.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/ApiModels.kt
@@ -12,7 +12,7 @@ data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T
 /**
  * API non-2xx failure responses returned by API call.
  */
-open class ApiException(override val message: String) : Exception(message)
+open class ApiException(override val message: String) : RuntimeException(message)
 
 /**
  * API 4xx failure responses returned by API call.

--- a/src/test/resources/examples/parameterNameClash/client/ApiModels.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ApiModels.kt
@@ -12,7 +12,7 @@ data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T
 /**
  * API non-2xx failure responses returned by API call.
  */
-open class ApiException(override val message: String) : Exception(message)
+open class ApiException(override val message: String) : RuntimeException(message)
 
 /**
  * API 4xx failure responses returned by API call.

--- a/src/test/resources/examples/pathLevelParameters/client/ApiModels.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiModels.kt
@@ -12,7 +12,7 @@ data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T
 /**
  * API non-2xx failure responses returned by API call.
  */
-open class ApiException(override val message: String) : Exception(message)
+open class ApiException(override val message: String) : RuntimeException(message)
 
 /**
  * API 4xx failure responses returned by API call.


### PR DESCRIPTION
The exception classes generated by Fabrikt for the client are not triggering Spring's [@Transactional](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/annotation/Transactional.html) to rollback transactions.

This is because the Fabrikt generated exceptions extend Exception instead of RuntimeException.

> In its default configuration, the Spring Framework’s transaction infrastructure code only marks a transaction for rollback in the case of runtime, unchecked exceptions; that is, when the thrown exception is an instance or subclass of RuntimeException.