### PR TITLE
Fix handling of default values.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/OasDefault.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/OasDefault.kt
@@ -1,0 +1,62 @@
+package com.cjbooms.fabrikt.generators
+
+import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeName
+import java.net.URI
+
+sealed class OasDefault {
+
+    abstract fun setDefault(paramSpecBuilder: ParameterSpec.Builder): ParameterSpec.Builder
+
+    data class StringValue(val strValue: String) : OasDefault() {
+        override fun setDefault(paramSpecBuilder: ParameterSpec.Builder): ParameterSpec.Builder {
+            return paramSpecBuilder.defaultValue("%S", strValue)
+        }
+    }
+
+    data class NumericValue(val numericValue: Number) : OasDefault() {
+        override fun setDefault(paramSpecBuilder: ParameterSpec.Builder): ParameterSpec.Builder {
+            return paramSpecBuilder.defaultValue("%L", numericValue)
+        }
+    }
+
+    data class UriValue(val strValue: String) : OasDefault() {
+        override fun setDefault(paramSpecBuilder: ParameterSpec.Builder): ParameterSpec.Builder {
+            return paramSpecBuilder.defaultValue("%T(\"$strValue\")", URI::class)
+        }
+    }
+
+    data class BooleanValue(val boolValue: Boolean) : OasDefault() {
+        override fun setDefault(paramSpecBuilder: ParameterSpec.Builder): ParameterSpec.Builder {
+            return paramSpecBuilder.defaultValue("%L", boolValue)
+        }
+    }
+
+    data class EnumValue(val type: TypeName, val enumValue: String) : OasDefault() {
+        override fun setDefault(paramSpecBuilder: ParameterSpec.Builder): ParameterSpec.Builder {
+            return paramSpecBuilder.defaultValue("%T.${enumValue.toUpperCase()}", type)
+        }
+    }
+
+    companion object {
+        fun from(typeInfo: KotlinTypeInfo, type: TypeName?, default: Any): OasDefault? {
+            return when (default) {
+                is String -> {
+                    when (typeInfo) {
+                        is KotlinTypeInfo.Enum -> {
+                            if (type != null && typeInfo.entries.contains(default)) OasDefault.EnumValue(type, default)
+                            else null
+                        }
+                        is KotlinTypeInfo.Text -> OasDefault.StringValue(default)
+                        is KotlinTypeInfo.Uri -> OasDefault.UriValue(default)
+                        else -> null
+                    }
+                }
+                is Number -> OasDefault.NumericValue(default)
+                is Boolean -> OasDefault.BooleanValue(default)
+                else -> null
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -8,6 +8,7 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleContentMediaType
 import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleResponseSchemas
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
+import com.cjbooms.fabrikt.generators.OasDefault
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.HeaderParam
@@ -86,7 +87,7 @@ object ClientGeneratorUtils {
         val specs = parameters.map {
             val builder = it.toParameterSpecBuilder()
             if (it is RequestParameter && it.defaultValue != null) {
-                builder.defaultValue("%S", it.defaultValue)
+                OasDefault.from(it.typeInfo, it.type, it.defaultValue)?.setDefault(builder)
             }
             builder.build()
         }

--- a/src/test/resources/examples/defaultValues/api.yaml
+++ b/src/test/resources/examples/defaultValues/api.yaml
@@ -24,3 +24,12 @@ components:
         string_phrase:
           type: string
           default: Cowabunga Dude
+        uri_type:
+          type: string
+          format: uri
+          description: |
+            An absolute URI that identifies the problem type.  When dereferenced,
+            it SHOULD provide human-readable documentation for the problem type
+            (e.g., using HTML).
+          default: 'about:blank'
+          example: 'https://zalando.github.io/problem/constraint-violation'

--- a/src/test/resources/examples/defaultValues/models/Models.kt
+++ b/src/test/resources/examples/defaultValues/models/Models.kt
@@ -2,6 +2,7 @@ package examples.defaultValues.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.net.URI
 import javax.validation.constraints.NotNull
 import kotlin.Boolean
 import kotlin.Int
@@ -28,7 +29,11 @@ data class PersonWithDefaults(
     @param:JsonProperty("string_phrase")
     @get:JsonProperty("string_phrase")
     @get:NotNull
-    val stringPhrase: String = "Cowabunga Dude"
+    val stringPhrase: String = "Cowabunga Dude",
+    @param:JsonProperty("uri_type")
+    @get:JsonProperty("uri_type")
+    @get:NotNull
+    val uriType: URI = URI("about:blank")
 )
 
 enum class PersonWithDefaultsEnumDefault(

--- a/src/test/resources/examples/okHttpClient/api.yaml
+++ b/src/test/resources/examples/okHttpClient/api.yaml
@@ -40,6 +40,7 @@ paths:
         - $ref: "#/components/parameters/PathParam"
         - $ref: "#/components/parameters/QueryParam2"
         - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/PaginationLimitParam"
       responses:
         200:
           description: "successful operation"
@@ -144,6 +145,16 @@ components:
           type: "string"
       required: false
       allowEmptyValue: false
+      
+    PaginationLimitParam:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 500
+      required: false
 
     QueryParam2:
       name: "query_param2"

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -101,12 +101,14 @@ class ExamplePath2Client(
      * GET example path 2
      *
      * @param pathParam The resource id
+     * @param limit
      * @param queryParam2
      * @param ifNoneMatch The RFC7232 If-None-Match header field
      */
     @Throws(ApiException::class)
     fun getExamplePath2PathParam(
         pathParam: String,
+        limit: Int = 500,
         queryParam2: Int?,
         ifNoneMatch: String?,
         additionalHeaders: Map<String, String> = emptyMap()
@@ -115,6 +117,7 @@ class ExamplePath2Client(
             .pathParam("{path_param}" to pathParam)
             .toHttpUrl()
             .newBuilder()
+            .queryParam("limit", limit)
             .queryParam("query_param2", queryParam2)
             .build()
 

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -77,12 +77,13 @@ class ExamplePath2Service(
     @Throws(ApiException::class)
     fun getExamplePath2PathParam(
         pathParam: String,
+        limit: Int = 500,
         queryParam2: Int?,
         ifNoneMatch: String?,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Content> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.getExamplePath2PathParam(pathParam, queryParam2, ifNoneMatch, additionalHeaders)
+            apiClient.getExamplePath2PathParam(pathParam, limit, queryParam2, ifNoneMatch, additionalHeaders)
         }
 
     @Throws(ApiException::class)


### PR DESCRIPTION
- URI format string types did correctly handle default values. It produced compile-time errors because of: `uriType: URI = "http://some-uri"`.
- Default handling of parameters in generated clients was also incorrect, this has code path now uses the same default handling logic which has been moved to a dedicated class.