### PR TITLE
Add null parameter defaults when not required.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -86,8 +86,9 @@ object ClientGeneratorUtils {
     fun FunSpec.Builder.addIncomingParameters(parameters: List<IncomingParameter>): FunSpec.Builder {
         val specs = parameters.map {
             val builder = it.toParameterSpecBuilder()
-            if (it is RequestParameter && it.defaultValue != null) {
-                OasDefault.from(it.typeInfo, it.type, it.defaultValue)?.setDefault(builder)
+            if (it is RequestParameter) {
+                if (it.defaultValue != null) OasDefault.from(it.typeInfo, it.type, it.defaultValue)?.setDefault(builder)
+                else if (!it.isRequired) builder.defaultValue("null")
             }
             builder.build()
         }

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -35,8 +35,8 @@ class ExamplePath1Client(
      */
     @Throws(ApiException::class)
     fun getExamplePath1(
-        explodeListQueryParam: List<String>?,
-        queryParam2: Int?,
+        explodeListQueryParam: List<String>? = null,
+        queryParam2: Int? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<QueryResult> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-1"
@@ -68,7 +68,7 @@ class ExamplePath1Client(
     @Throws(ApiException::class)
     fun postExamplePath1(
         content: Content,
-        explodeListQueryParam: List<String>?,
+        explodeListQueryParam: List<String>? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-1"
@@ -109,8 +109,8 @@ class ExamplePath2Client(
     fun getExamplePath2PathParam(
         pathParam: String,
         limit: Int = 500,
-        queryParam2: Int?,
-        ifNoneMatch: String?,
+        queryParam2: Int? = null,
+        ifNoneMatch: String? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Content> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-2/{path_param}"
@@ -145,8 +145,8 @@ class ExamplePath2Client(
     @Throws(ApiException::class)
     fun headOperationIdExample(
         pathParam: String,
-        queryParam3: Boolean?,
-        ifNoneMatch: String?,
+        queryParam3: Boolean? = null,
+        ifNoneMatch: String? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-2/{path_param}"
@@ -224,7 +224,7 @@ class ExamplePath3SubresourceClient(
         firstModel: FirstModel,
         pathParam: String,
         ifMatch: String,
-        csvListQueryParam: List<String>?,
+        csvListQueryParam: List<String>? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-3/{path_param}/subresource"

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -36,8 +36,8 @@ class ExamplePath1Service(
 
     @Throws(ApiException::class)
     fun getExamplePath1(
-        explodeListQueryParam: List<String>?,
-        queryParam2: Int?,
+        explodeListQueryParam: List<String>? = null,
+        queryParam2: Int? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
@@ -47,7 +47,7 @@ class ExamplePath1Service(
     @Throws(ApiException::class)
     fun postExamplePath1(
         content: Content,
-        explodeListQueryParam: List<String>?,
+        explodeListQueryParam: List<String>? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
@@ -78,8 +78,8 @@ class ExamplePath2Service(
     fun getExamplePath2PathParam(
         pathParam: String,
         limit: Int = 500,
-        queryParam2: Int?,
-        ifNoneMatch: String?,
+        queryParam2: Int? = null,
+        ifNoneMatch: String? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Content> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
@@ -89,8 +89,8 @@ class ExamplePath2Service(
     @Throws(ApiException::class)
     fun headOperationIdExample(
         pathParam: String,
-        queryParam3: Boolean?,
-        ifNoneMatch: String?,
+        queryParam3: Boolean? = null,
+        ifNoneMatch: String? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
@@ -137,7 +137,7 @@ class ExamplePath3SubresourceService(
         firstModel: FirstModel,
         pathParam: String,
         ifMatch: String,
-        csvListQueryParam: List<String>?,
+        csvListQueryParam: List<String>? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiClient.kt
@@ -32,8 +32,8 @@ class ExamplePath1Client(
      */
     @Throws(ApiException::class)
     fun getExamplePath1(
-        explodeListQueryParam: List<String>?,
-        queryParam2: Int?,
+        explodeListQueryParam: List<String>? = null,
+        queryParam2: Int? = null,
         acceptHeader: String = "application/vnd.custom.media+xml",
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<QueryResult> {
@@ -74,9 +74,9 @@ class ExamplePath2Client(
      */
     @Throws(ApiException::class)
     fun getExamplePath2(
-        explodeListQueryParam: List<String>?,
-        queryParam2: Int?,
-        accept: ContentType?,
+        explodeListQueryParam: List<String>? = null,
+        queryParam2: Int? = null,
+        accept: ContentType? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<QueryResult> {
         val httpUrl: HttpUrl = "$baseUrl/example-path-2"
@@ -114,7 +114,7 @@ class MultipleResponseSchemasClient(
      */
     @Throws(ApiException::class)
     fun getMultipleResponseSchemas(
-        accept: ContentType?,
+        accept: ContentType? = null,
         additionalHeaders: Map<String, String> =
             emptyMap()
     ): ApiResponse<JsonNode> {

--- a/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClientMultiMediaType/client/ApiService.kt
@@ -34,8 +34,8 @@ class ExamplePath1Service(
 
     @Throws(ApiException::class)
     fun getExamplePath1(
-        explodeListQueryParam: List<String>?,
-        queryParam2: Int?,
+        explodeListQueryParam: List<String>? = null,
+        queryParam2: Int? = null,
         acceptHeader: String = "application/vnd.custom.media+xml",
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<QueryResult> =
@@ -65,9 +65,9 @@ class ExamplePath2Service(
 
     @Throws(ApiException::class)
     fun getExamplePath2(
-        explodeListQueryParam: List<String>?,
-        queryParam2: Int?,
-        accept: ContentType?,
+        explodeListQueryParam: List<String>? = null,
+        queryParam2: Int? = null,
+        accept: ContentType? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
@@ -100,7 +100,7 @@ class MultipleResponseSchemasService(
 
     @Throws(ApiException::class)
     fun getMultipleResponseSchemas(
-        accept: ContentType?,
+        accept: ContentType? = null,
         additionalHeaders: Map<String, String> =
             emptyMap()
     ): ApiResponse<JsonNode> =


### PR DESCRIPTION
If the spec says a parameter is not required, then the client APIs should provide default null values to save the builder from doing so.