### PR TITLE
Fix typo in README gradle example section

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ tasks {
 }
 
 dependencies {
-     fabric("com.cjbooms:fabrikt:+") // This should be pinned  
+     fabrikt("com.cjbooms:fabrikt:+") // This should be pinned  
      ...
 }
 ```


### PR DESCRIPTION
Fix minor typo in gradle example while referencing the created configuration alias.