### PR TITLE
Move additional properties map to data class constructor.

### DIFF
--- a/src/test/resources/examples/anyOfOneOfAllOf/models/Models.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/Models.kt
@@ -80,11 +80,10 @@ data class MoreNesting(
 data class OneOfAdditionalProps(
     @param:JsonProperty("second_nested_any_of_prop")
     @get:JsonProperty("second_nested_any_of_prop")
-    val secondNestedAnyOfProp: String? = null
-) {
+    val secondNestedAnyOfProp: String? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, Any> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Any> = properties
 

--- a/src/test/resources/examples/externalReferences/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/models/Models.kt
@@ -71,11 +71,10 @@ data class ExternalObjectTwo(
     @param:JsonProperty("list-others")
     @get:JsonProperty("list-others")
     @get:Valid
-    val listOthers: List<ExternalObjectThree>? = null
-) {
+    val listOthers: List<ExternalObjectThree>? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Map<String, ExternalObjectFour>> = properties
 

--- a/src/test/resources/examples/githubApi/models/Models.kt
+++ b/src/test/resources/examples/githubApi/models/Models.kt
@@ -30,11 +30,10 @@ data class BulkEntityDetails(
     @get:JsonProperty("entities")
     @get:NotNull
     @get:Valid
-    val entities: List<EntityDetails>
-) {
+    val entities: List<EntityDetails>,
     @get:JsonIgnore
     val properties: MutableMap<String, Any> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Any> = properties
 
@@ -120,11 +119,10 @@ data class EntityDetails(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     @get:NotNull
-    val id: String
-) {
+    val id: String,
     @get:JsonIgnore
     val properties: MutableMap<String, Any> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Any> = properties
 
@@ -142,11 +140,10 @@ data class Event(
     @param:JsonProperty("data")
     @get:JsonProperty("data")
     @get:NotNull
-    val data: Map<String, Any>
-) {
+    val data: Map<String, Any>,
     @get:JsonIgnore
     val properties: MutableMap<String, Any> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Any> = properties
 
@@ -162,11 +159,10 @@ data class EventResults(
     @get:NotNull
     @get:Size(min = 0)
     @get:Valid
-    val changeEvents: List<Event>
-) {
+    val changeEvents: List<Event>,
     @get:JsonIgnore
     val properties: MutableMap<String, Any> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Any> = properties
 

--- a/src/test/resources/examples/mapExamples/models/Models.kt
+++ b/src/test/resources/examples/mapExamples/models/Models.kt
@@ -35,11 +35,10 @@ data class ComplexObjectWithRefTypedMap(
     val text: String? = null,
     @param:JsonProperty("code")
     @get:JsonProperty("code")
-    val code: Int? = null
-) {
+    val code: Int? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, SomeRef> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, SomeRef> = properties
 
@@ -55,11 +54,10 @@ data class ComplexObjectWithTypedMap(
     val text: String? = null,
     @param:JsonProperty("code")
     @get:JsonProperty("code")
-    val code: Int? = null
-) {
+    val code: Int? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, ComplexObjectWithTypedMapValue> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, ComplexObjectWithTypedMapValue> = properties
 
@@ -84,11 +82,10 @@ data class ComplexObjectWithUntypedMap(
     val text: String? = null,
     @param:JsonProperty("code")
     @get:JsonProperty("code")
-    val code: Int? = null
-) {
+    val code: Int? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, Any> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Any> = properties
 
@@ -164,11 +161,10 @@ data class MapHolder(
     @param:JsonProperty("inlined_complex_object_with_typed_map")
     @get:JsonProperty("inlined_complex_object_with_typed_map")
     @get:Valid
-    val inlinedComplexObjectWithTypedMap: MapHolderInlinedComplexObjectWithTypedMap? = null
-) {
+    val inlinedComplexObjectWithTypedMap: MapHolderInlinedComplexObjectWithTypedMap? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Map<String, ExternalObjectFour>> = properties
 
@@ -184,11 +180,10 @@ data class MapHolderInlinedComplexObjectWithTypedMap(
     val text: String? = null,
     @param:JsonProperty("code")
     @get:JsonProperty("code")
-    val code: Int? = null
-) {
+    val code: Int? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, InlinedComplexObjectWithTypedMapValue> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, InlinedComplexObjectWithTypedMapValue> = properties
 
@@ -204,11 +199,10 @@ data class MapHolderInlinedComplexObjectWithUntypedMap(
     val text: String? = null,
     @param:JsonProperty("code")
     @get:JsonProperty("code")
-    val code: Int? = null
-) {
+    val code: Int? = null,
     @get:JsonIgnore
     val properties: MutableMap<String, Any> = mutableMapOf()
-
+) {
     @JsonAnyGetter
     fun get(): Map<String, Any> = properties
 


### PR DESCRIPTION
This will ensure that additional properties are taken into account with equality check. Previously data classes containing different additional properties were being reported as equal if all constructor parameters matched