### PR TITLE
Support Instant as a datetime type (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ This section documents the available CLI parameters for controlling what gets ge
 |                              |   `CONTROLLERS` - Spring / Micronaut annotated HTTP controllers for each of the endpoints defined in the input.
 |                              |   `CLIENT` - Simple http rest client.
 |                              |   `QUARKUS_REFLECTION_CONFIG` - This options generates the reflection-config.json file for quarkus integration projects
+|   `--type-overrides`         | Allows to use specific object types for generator. For example 'Instance' for a date-time
+|                              | CHOOSE ANY OF:
+|                              |   INSTANT_FOR_DATETIME
+|                              |   LOCALDATETIME_FOR_DATETIME
 
 ### Command Line
 Fabrikt is packaged as an executable jar, allowing it to be integrated into any build tool. The CLI can be invoked as follows:

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
@@ -29,7 +29,7 @@ object CodeGen {
             codeGenArgs.controllerTarget,
             codeGenArgs.modelOptions,
             codeGenArgs.clientOptions,
-            codeGenArgs.typeOptions,
+            codeGenArgs.typeOverrides,
             codeGenArgs.srcPath,
             codeGenArgs.resourcesPath
         )
@@ -45,11 +45,11 @@ object CodeGen {
         controllerTarget: ControllerCodeGenTargetType,
         modelOptions: Set<ModelCodeGenOptionType>,
         clientOptions: Set<ClientCodeGenOptionType>,
-        typeOptions: Set<TypeCodeGenOptionType>,
+        typeOverrides: Set<CodeGenTypeOverride>,
         srcPath: Path,
         resourcesPath: Path,
     ) {
-        MutableSettings.updateSettings(codeGenTypes, controllerOptions, controllerTarget, modelOptions, clientOptions, typeOptions)
+        MutableSettings.updateSettings(codeGenTypes, controllerOptions, controllerTarget, modelOptions, clientOptions, typeOverrides)
 
         val suppliedApi = pathToApi.toFile().readText()
         val baseDir = pathToApi.parent

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
@@ -29,6 +29,7 @@ object CodeGen {
             codeGenArgs.controllerTarget,
             codeGenArgs.modelOptions,
             codeGenArgs.clientOptions,
+            codeGenArgs.typeOptions,
             codeGenArgs.srcPath,
             codeGenArgs.resourcesPath
         )
@@ -44,10 +45,11 @@ object CodeGen {
         controllerTarget: ControllerCodeGenTargetType,
         modelOptions: Set<ModelCodeGenOptionType>,
         clientOptions: Set<ClientCodeGenOptionType>,
+        typeOptions: Set<TypeCodeGenOptionType>,
         srcPath: Path,
         resourcesPath: Path,
     ) {
-        MutableSettings.updateSettings(codeGenTypes, controllerOptions, controllerTarget, modelOptions, clientOptions)
+        MutableSettings.updateSettings(codeGenTypes, controllerOptions, controllerTarget, modelOptions, clientOptions, typeOptions)
 
         val suppliedApi = pathToApi.toFile().readText()
         val baseDir = pathToApi.parent

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
@@ -121,11 +121,11 @@ class CodeGenArgs {
     var resourcesPath: Path = Destinations.MAIN_RESOURCES
 
     @Parameter(
-        names = ["--type-options"],
+        names = ["--type-overrides"],
         description = "Allows to use specific object types for generator. For example 'Instance' for a date-time",
         converter = TypeCodeGenOptionsConverter::class
     )
-    var typeOptions: Set<TypeCodeGenOptionType> = emptySet()
+    var typeOverrides: Set<CodeGenTypeOverride> = emptySet()
 }
 
 class CodeGenerationTypesConverter : IStringConverter<CodeGenerationType> {
@@ -150,8 +150,8 @@ class ClientCodeGenOptionConverter : IStringConverter<ClientCodeGenOptionType> {
         convertToEnumValue(value)
 }
 
-class TypeCodeGenOptionsConverter: IStringConverter<TypeCodeGenOptionType> {
-    override fun convert(value: String): TypeCodeGenOptionType = convertToEnumValue(value)
+class TypeCodeGenOptionsConverter: IStringConverter<CodeGenTypeOverride> {
+    override fun convert(value: String): CodeGenTypeOverride = convertToEnumValue(value)
 }
 
 class PackageNameValidator : IValueValidator<String> {

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
@@ -119,6 +119,13 @@ class CodeGenArgs {
         converter = PathConverter::class
     )
     var resourcesPath: Path = Destinations.MAIN_RESOURCES
+
+    @Parameter(
+        names = ["--type-options"],
+        description = "Allows to use specific object types for generator. For example 'Instance' for a date-time",
+        converter = TypeCodeGenOptionsConverter::class
+    )
+    var typeOptions: Set<TypeCodeGenOptionType> = emptySet()
 }
 
 class CodeGenerationTypesConverter : IStringConverter<CodeGenerationType> {
@@ -141,6 +148,10 @@ class ModelCodeGenOptionConverter : IStringConverter<ModelCodeGenOptionType> {
 class ClientCodeGenOptionConverter : IStringConverter<ClientCodeGenOptionType> {
     override fun convert(value: String): ClientCodeGenOptionType =
         convertToEnumValue(value)
+}
+
+class TypeCodeGenOptionsConverter: IStringConverter<TypeCodeGenOptionType> {
+    override fun convert(value: String): TypeCodeGenOptionType = convertToEnumValue(value)
 }
 
 class PackageNameValidator : IValueValidator<String> {

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -47,6 +47,7 @@ enum class ControllerCodeGenTargetType(val description: String) {
     override fun toString() = "`${super.toString()}` - $description"
 }
 
-enum class TypeCodeGenOptionType(val description: String) {
-    INSTANT_DATETIME_TYPE("Use Instance as a default datetime type, instead of OffsetDateTime")
+enum class CodeGenTypeOverride(val description: String) {
+    INSTANT_FOR_DATETIME("Use Instance as the datetime type, instead of OffsetDateTime"),
+    LOCALDATETIME_FOR_DATETIME("Use `LocalDateTime` as the datetime type, instead of `OffsetDateTime`")
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -46,3 +46,7 @@ enum class ControllerCodeGenTargetType(val description: String) {
 
     override fun toString() = "`${super.toString()}` - $description"
 }
+
+enum class TypeCodeGenOptionType(val description: String) {
+    INSTANT_DATETIME_TYPE("Use Instance as a default datetime type, instead of OffsetDateTime")
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
@@ -1,10 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
-import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
-import com.cjbooms.fabrikt.cli.CodeGenerationType
-import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
-import com.cjbooms.fabrikt.cli.ControllerCodeGenTargetType
-import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
+import com.cjbooms.fabrikt.cli.*
 
 object MutableSettings {
     private lateinit var generationTypes: MutableSet<CodeGenerationType>
@@ -12,26 +8,31 @@ object MutableSettings {
     private lateinit var controllerTarget: ControllerCodeGenTargetType
     private lateinit var modelOptions: MutableSet<ModelCodeGenOptionType>
     private lateinit var clientOptions: MutableSet<ClientCodeGenOptionType>
+    private lateinit var typeOptions: MutableSet<TypeCodeGenOptionType>
 
     fun updateSettings(
         genTypes: Set<CodeGenerationType> = emptySet(),
         controllerOptions: Set<ControllerCodeGenOptionType> = emptySet(),
         controllerTarget: ControllerCodeGenTargetType = ControllerCodeGenTargetType.SPRING,
         modelOptions: Set<ModelCodeGenOptionType> = emptySet(),
-        clientOptions: Set<ClientCodeGenOptionType> = emptySet()
+        clientOptions: Set<ClientCodeGenOptionType> = emptySet(),
+        typeOptions: Set<TypeCodeGenOptionType> = emptySet()
     ) {
         this.generationTypes = genTypes.toMutableSet()
         this.controllerOptions = controllerOptions.toMutableSet()
         this.controllerTarget = controllerTarget
         this.modelOptions = modelOptions.toMutableSet()
         this.clientOptions = clientOptions.toMutableSet()
+        this.typeOptions = typeOptions.toMutableSet()
     }
 
     fun addOption(option: ModelCodeGenOptionType) = modelOptions.add(option)
+    fun addOption(option: TypeCodeGenOptionType) = typeOptions.add(option)
 
     fun generationTypes() = this.generationTypes.toSet()
     fun controllerOptions() = this.controllerOptions.toSet()
     fun controllerTarget() = this.controllerTarget
     fun modelOptions() = this.modelOptions.toSet()
     fun clientOptions() = this.clientOptions.toSet()
+    fun typeOptions() = this.typeOptions.toSet()
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
@@ -1,6 +1,11 @@
 package com.cjbooms.fabrikt.generators
 
-import com.cjbooms.fabrikt.cli.*
+import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
+import com.cjbooms.fabrikt.cli.ControllerCodeGenTargetType
+import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
+import com.cjbooms.fabrikt.cli.CodeGenTypeOverride
 
 object MutableSettings {
     private lateinit var generationTypes: MutableSet<CodeGenerationType>
@@ -8,7 +13,7 @@ object MutableSettings {
     private lateinit var controllerTarget: ControllerCodeGenTargetType
     private lateinit var modelOptions: MutableSet<ModelCodeGenOptionType>
     private lateinit var clientOptions: MutableSet<ClientCodeGenOptionType>
-    private lateinit var typeOptions: MutableSet<TypeCodeGenOptionType>
+    private lateinit var typeOverrides: MutableSet<CodeGenTypeOverride>
 
     fun updateSettings(
         genTypes: Set<CodeGenerationType> = emptySet(),
@@ -16,23 +21,23 @@ object MutableSettings {
         controllerTarget: ControllerCodeGenTargetType = ControllerCodeGenTargetType.SPRING,
         modelOptions: Set<ModelCodeGenOptionType> = emptySet(),
         clientOptions: Set<ClientCodeGenOptionType> = emptySet(),
-        typeOptions: Set<TypeCodeGenOptionType> = emptySet()
+        typeOverrides: Set<CodeGenTypeOverride> = emptySet()
     ) {
         this.generationTypes = genTypes.toMutableSet()
         this.controllerOptions = controllerOptions.toMutableSet()
         this.controllerTarget = controllerTarget
         this.modelOptions = modelOptions.toMutableSet()
         this.clientOptions = clientOptions.toMutableSet()
-        this.typeOptions = typeOptions.toMutableSet()
+        this.typeOverrides = typeOverrides.toMutableSet()
     }
 
     fun addOption(option: ModelCodeGenOptionType) = modelOptions.add(option)
-    fun addOption(option: TypeCodeGenOptionType) = typeOptions.add(option)
+    fun addOption(override: CodeGenTypeOverride) = typeOverrides.add(override)
 
     fun generationTypes() = this.generationTypes.toSet()
     fun controllerOptions() = this.controllerOptions.toSet()
     fun controllerTarget() = this.controllerTarget
     fun modelOptions() = this.modelOptions.toSet()
     fun clientOptions() = this.clientOptions.toSet()
-    fun typeOptions() = this.typeOptions.toSet()
+    fun typeOverrides() = this.typeOverrides.toSet()
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -1,6 +1,6 @@
 package com.cjbooms.fabrikt.model
 
-import com.cjbooms.fabrikt.cli.TypeCodeGenOptionType
+import com.cjbooms.fabrikt.cli.CodeGenTypeOverride
 import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.model.OasType.Companion.toOasType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getEnumValues
@@ -23,6 +23,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
     object Date : KotlinTypeInfo(LocalDate::class)
     object DateTime : KotlinTypeInfo(OffsetDateTime::class)
     object Instant: KotlinTypeInfo(java.time.Instant::class)
+    object LocalDateTime: KotlinTypeInfo(java.time.LocalDateTime::class)
     object Double : KotlinTypeInfo(kotlin.Double::class)
     object Float : KotlinTypeInfo(kotlin.Float::class)
     object Numeric : KotlinTypeInfo(BigDecimal::class)
@@ -58,12 +59,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
         fun from(schema: Schema, oasKey: String = "", enclosingName: String = ""): KotlinTypeInfo =
             when (schema.toOasType(oasKey)) {
                 OasType.Date -> Date
-                OasType.DateTime -> if (MutableSettings.typeOptions().contains(TypeCodeGenOptionType.INSTANT_DATETIME_TYPE)
-                ) {
-                    Instant
-                } else {
-                    DateTime
-                }
+                OasType.DateTime -> getOverridableDateTimeType()
                 OasType.Text -> Text
                 OasType.Enum ->
                     Enum(schema.getEnumValues(), schema.toModelClassName(enclosingName.toModelClassName()))
@@ -98,5 +94,14 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                 OasType.Any -> AnyType
                 OasType.OneOfAny -> AnyType
             }
+
+        private fun getOverridableDateTimeType(): KotlinTypeInfo {
+            val typeOverrides = MutableSettings.typeOverrides()
+            return when {
+                typeOverrides.contains(CodeGenTypeOverride.INSTANT_FOR_DATETIME) -> Instant
+                typeOverrides.contains(CodeGenTypeOverride.LOCALDATETIME_FOR_DATETIME) -> LocalDateTime
+                else -> DateTime
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -1,5 +1,7 @@
 package com.cjbooms.fabrikt.model
 
+import com.cjbooms.fabrikt.cli.TypeCodeGenOptionType
+import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.model.OasType.Companion.toOasType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getEnumValues
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedTypedAdditionalProperties
@@ -20,6 +22,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
     object Text : KotlinTypeInfo(String::class)
     object Date : KotlinTypeInfo(LocalDate::class)
     object DateTime : KotlinTypeInfo(OffsetDateTime::class)
+    object Instant: KotlinTypeInfo(java.time.Instant::class)
     object Double : KotlinTypeInfo(kotlin.Double::class)
     object Float : KotlinTypeInfo(kotlin.Float::class)
     object Numeric : KotlinTypeInfo(BigDecimal::class)
@@ -55,7 +58,12 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
         fun from(schema: Schema, oasKey: String = "", enclosingName: String = ""): KotlinTypeInfo =
             when (schema.toOasType(oasKey)) {
                 OasType.Date -> Date
-                OasType.DateTime -> DateTime
+                OasType.DateTime -> if (MutableSettings.typeOptions().contains(TypeCodeGenOptionType.INSTANT_DATETIME_TYPE)
+                ) {
+                    Instant
+                } else {
+                    DateTime
+                }
                 OasType.Text -> Text
                 OasType.Enum ->
                     Enum(schema.getEnumValues(), schema.toModelClassName(enclosingName.toModelClassName()))

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -3,7 +3,7 @@ package com.cjbooms.fabrikt.generators
 import com.beust.jcommander.ParameterException
 import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
-import com.cjbooms.fabrikt.cli.TypeCodeGenOptionType
+import com.cjbooms.fabrikt.cli.CodeGenTypeOverride
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
 import com.cjbooms.fabrikt.model.Models
@@ -66,7 +66,7 @@ class ModelGeneratorTest {
         print("Testcase: $testCaseName")
         MutableSettings.addOption(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS)
         if (testCaseName == "instantDateTime") {
-            MutableSettings.addOption(TypeCodeGenOptionType.INSTANT_DATETIME_TYPE)
+            MutableSettings.addOption(CodeGenTypeOverride.INSTANT_FOR_DATETIME)
         }
         val basePackage = "examples.$testCaseName"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -3,6 +3,7 @@ package com.cjbooms.fabrikt.generators
 import com.beust.jcommander.ParameterException
 import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
+import com.cjbooms.fabrikt.cli.TypeCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
 import com.cjbooms.fabrikt.model.Models
@@ -46,6 +47,7 @@ class ModelGeneratorTest {
         "singleAllOf",
         "responsesSchema",
         "webhook",
+        "instantDateTime"
     )
 
     @BeforeEach
@@ -63,6 +65,9 @@ class ModelGeneratorTest {
     fun `correct models are generated for different OpenApi Specifications`(testCaseName: String) {
         print("Testcase: $testCaseName")
         MutableSettings.addOption(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS)
+        if (testCaseName == "instantDateTime") {
+            MutableSettings.addOption(TypeCodeGenOptionType.INSTANT_DATETIME_TYPE)
+        }
         val basePackage = "examples.$testCaseName"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))

--- a/src/test/resources/examples/instantDateTime/api.yaml
+++ b/src/test/resources/examples/instantDateTime/api.yaml
@@ -1,0 +1,99 @@
+openapi: "3.0.0"
+info:
+  title: "API Example"
+  version: "1.0"
+paths:
+  /example-path-1:
+    get:
+      summary: "GET example path 1"
+      parameters:
+        - $ref: "#/components/parameters/ListQueryParamExploded"
+        - $ref: "#/components/parameters/QueryParam"
+      responses:
+        200:
+          description: "successful operation"
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+          content:
+            application/vnd.custom.media+json:
+              schema:
+                $ref: "#/components/schemas/QueryResult"
+
+components:
+  parameters:
+    ListQueryParamExploded:
+      name: "explode_list_query_param"
+      in: "query"
+      schema:
+        type: "array"
+        items:
+          type: "string"
+          format: "date-time"
+          example: "2016-01-27T10:52:46.406Z"
+      required: false
+      allowEmptyValue: false
+
+
+    QueryParam:
+      name: "query_param2"
+      in: "query"
+      schema:
+        type: "string"
+        format: "date-time"
+        example: "2016-01-27T10:52:46.406Z"
+      required: false
+
+
+  headers:
+    Location:
+      description: "The Location header indicates the URL of a newly created resource"
+      schema:
+        type: "string"
+
+    CacheControl:
+      description: "The RFC7234 Cache Control header"
+      schema:
+        type: "string"
+      example: "must-revalidate, max-age=5"
+
+  requestBodies:
+    PostBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FirstModel"
+    PutBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FirstModel"
+
+  schemas:
+    QueryResult:
+      type: "object"
+      required:
+        - "items"
+      properties:
+        items:
+          type: "array"
+          minItems: 0
+          items:
+            $ref: "#/components/schemas/FirstModel"
+    FirstModel:
+      type: "object"
+      properties:
+        date:
+          type: "string"
+          format: "date-time"
+          example: "2016-01-27T10:52:46.406Z"
+        extra_first_attr:
+          description: "The attribute 1 for model 1"
+          type: array
+          items:
+            type: "string"
+            format: "date-time"
+            example: "2016-01-27T10:52:46.406Z"
+          readOnly: true

--- a/src/test/resources/examples/instantDateTime/models/Models.kt
+++ b/src/test/resources/examples/instantDateTime/models/Models.kt
@@ -1,0 +1,26 @@
+package examples.instantDateTime.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.Instant
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+import kotlin.collections.List
+
+data class FirstModel(
+    @param:JsonProperty("date")
+    @get:JsonProperty("date")
+    val date: Instant? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    val extraFirstAttr: List<Instant>? = null
+)
+
+data class QueryResult(
+    @param:JsonProperty("items")
+    @get:JsonProperty("items")
+    @get:NotNull
+    @get:Size(min = 0)
+    @get:Valid
+    val items: List<FirstModel>
+)


### PR DESCRIPTION
Adds a configuration parameter to allow builders to override the types generated by fabrikt. For example, builders can choose to have `Instant` generated instead of `OffsetDateTime` for OAS datetime format by specifying:
--type-overrides INSTANT_FOR_DATETIME