### PR TITLE
General dependency update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,10 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.6.0" // Apply the Kotlin JVM plugin to add support for Kotlin.
-    id("com.github.johnrengelman.shadow") version "4.0.1"
-    id("org.jetbrains.dokka") version "0.10.1"
-    id("com.palantir.git-version") version "0.12.3"
+    id("org.jetbrains.kotlin.jvm") version "1.8.20" // Apply the Kotlin JVM plugin to add support for Kotlin.
+    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("org.jetbrains.dokka") version "1.8.10"
+    id("com.palantir.git-version") version "3.0.0"
     id("maven-publish")
     id("signing")
 
@@ -37,7 +37,7 @@ dependencies {
 
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("com.github.jknack:handlebars:4.1.0")
+    implementation("com.github.jknack:handlebars:4.3.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
@@ -45,9 +45,9 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
     implementation("com.beust:jcommander:1.82")
     implementation("com.reprezen.kaizen:openapi-parser:4.0.4") { exclude(group = "junit") }
-    implementation("com.reprezen.jsonoverlay:jsonoverlay:4.0.3")
-    implementation("com.squareup:kotlinpoet:1.3.0") { exclude(module = "kotlin-stdlib-jre7") }
-    implementation("com.google.flogger:flogger:0.4")
+    implementation("com.reprezen.jsonoverlay:jsonoverlay:4.0.4")
+    implementation("com.squareup:kotlinpoet:1.12.0") { exclude(module = "kotlin-stdlib-jre7") }
+    implementation("com.google.flogger:flogger:0.7.4")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.1.0")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.1.0")
@@ -56,12 +56,12 @@ dependencies {
     // Below dependencies are solely present so code examples in the test resources dir compile
     testImplementation("javax.validation:validation-api:2.0.1.Final")
     testImplementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    testImplementation("org.springframework:spring-webmvc:5.1.9.RELEASE")
-    testImplementation("io.micronaut:micronaut-core:3.8.4")
-    testImplementation("io.micronaut:micronaut-http:3.8.4")
-    testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
-    testImplementation("com.pinterest.ktlint:ktlint-core:0.41.0")
-    testImplementation("com.pinterest:ktlint:0.41.0")
+    testImplementation("org.springframework:spring-webmvc:6.0.0")
+    testImplementation("io.micronaut:micronaut-core:3.8.7")
+    testImplementation("io.micronaut:micronaut-http:3.8.7")
+    testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
+    testImplementation("com.pinterest.ktlint:ktlint-core:0.48.2")
+    testImplementation("com.pinterest:ktlint:0.48.2")
 }
 
 tasks {
@@ -77,9 +77,8 @@ tasks {
         archiveClassifier.set("")
     }
 
-    val dokka by getting(DokkaTask::class) {
-        outputFormat = "html"
-        outputDirectory = "$buildDir/dokka"
+    val dokka = getByName<DokkaTask>("dokkaHtml") {
+        outputDirectory.set(file("$buildDir/dokka"))
     }
 
     create("sourcesJar", Jar::class) {
@@ -98,7 +97,7 @@ tasks {
     create("printCodeGenUsage", JavaExec::class) {
         dependsOn(shadowJar)
         classpath = project.files("./build/libs/$executableName-$version.jar")
-        main = "com.cjbooms.fabrikt.cli.CodeGen"
+        mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
         args = listOf("--help")
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -112,7 +112,7 @@ object GeneratorUtils {
 
     private fun Schema.toClassName() = KotlinTypeInfo.from(this).modelKClass.asTypeName()
 
-    fun String.toClassName(basePackage: String) = ClassName(packageName = basePackage, simpleName = this)
+    fun String.toClassName(basePackage: String) = ClassName(packageName = basePackage, this)
 
     fun RequestBody.getPrimaryContentMediaType(): Map.Entry<String, MediaType>? =
         this.contentMediaTypes.entries.firstOrNull()


### PR DESCRIPTION
I am interested in taking on issue #89, to support `kotlinx.serialization`.

In preparation, I checked out `master` and observed that dependencies were generally somewhat out-of-date.  I've updated them here before adding support for the latest `kotlinx.serialization` version.

A couple of minor changes arose to account for the new dependencies:

1. Dokka now prefers to expose a task-per-output-format, than have a single output format selected.  I imagine this is to support output of multiple formats.  The way the task is acquired for the `kotlinDocJar` task then had to change.
2. Kotlin Poet now supports multple 'simpleName's; I'm not sure why to be honest but fixing our usage was a simple case of removing the single argument label.

Unit tests passing locally ✅ 