### PR TITLE
Support json merge patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This library was built to take advantage of the complex modeling features availa
  - Polymorphism (`@JsonSubTypes`)
  - Maps of Maps of Maps
  - GraalVM Native Reflection Registration
+ - Json Merge Patch (via `JsonNullable`) (add `x-json-merge-patch: true` to schemas)
 
 More than just bootstrapping, this library can be permanently integrated into a gradle or maven build and will ensure contract and code always match, even as APIs evolve in complexity. 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.1.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.1.0")
     testImplementation("org.assertj:assertj-core:3.14.0")
+
     // Below dependencies are solely present so code examples in the test resources dir compile
     testImplementation("javax.validation:validation-api:2.0.1.Final")
     testImplementation("jakarta.validation:jakarta.validation-api:3.0.2")
@@ -62,6 +63,7 @@ dependencies {
     testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
     testImplementation("com.pinterest.ktlint:ktlint-core:0.41.0")
     testImplementation("com.pinterest:ktlint:0.41.0")
+    testImplementation("org.openapitools:jackson-databind-nullable:0.2.6")
 }
 
 tasks {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -4,8 +4,15 @@ import com.cjbooms.fabrikt.generators.JavaxValidationAnnotations.fieldValid
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.PropertyInfo
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asTypeName
 
 data class ClassSettings(
     val polymorphyType: PolymorphyType,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -16,10 +16,16 @@ import com.cjbooms.fabrikt.generators.ValidationAnnotations
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.JSON_VALUE
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.basePolymorphicType
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.polymorphicSubTypes
-import com.cjbooms.fabrikt.model.*
 import com.cjbooms.fabrikt.model.Destinations.modelsPackage
+import com.cjbooms.fabrikt.model.GeneratedType
+import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.model.ModelType
+import com.cjbooms.fabrikt.model.Models
+import com.cjbooms.fabrikt.model.PropertyInfo
 import com.cjbooms.fabrikt.model.PropertyInfo.Companion.HTTP_SETTINGS
 import com.cjbooms.fabrikt.model.PropertyInfo.Companion.topLevelProperties
+import com.cjbooms.fabrikt.model.SchemaInfo
+import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getSuperType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isComplexTypedAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
@@ -40,7 +46,16 @@ import com.reprezen.kaizen.oasparser.OpenApi3Parser
 import com.reprezen.kaizen.oasparser.model3.Discriminator
 import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import com.reprezen.kaizen.oasparser.model3.Schema
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asTypeName
 import java.io.Serializable
 import java.net.MalformedURLException
 import java.net.URL
@@ -415,7 +430,8 @@ class JacksonModelGenerator(
                 validationAnnotations
             )
         }
-        if (constructorBuilder.parameters.isNotEmpty() && classBuilder.modifiers.isEmpty()) classBuilder.addModifiers(KModifier.DATA)
+        if (constructorBuilder.parameters.isNotEmpty() && classBuilder.modifiers.isEmpty()) classBuilder.addModifiers(
+            KModifier.DATA)
         return classBuilder.primaryConstructor(constructorBuilder.build())
     }
 

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -37,6 +37,7 @@ class ModelGeneratorTest {
         "externalReferences",
         "githubApi",
         "inLinedObject",
+        "jsonMergePatch",
         "mapExamples",
         "mixingCamelSnakeLispCase",
         "oneOfPolymorphicModels",

--- a/src/test/resources/examples/jsonMergePatch/api.yaml
+++ b/src/test/resources/examples/jsonMergePatch/api.yaml
@@ -1,0 +1,76 @@
+openapi: 3.0.0
+paths: { }
+info:
+  title: ""
+  version: ""
+components:
+  schemas:
+    NoMergePatchInline:
+      type: object
+      properties:
+        inner:
+          type: object
+          properties:
+            p:
+              type: string
+    TopLevelLevelMergePatchInline:
+      type: object
+      x-json-merge-patch: true
+      properties:
+        inner:
+          type: object
+          properties:
+            p:
+              type: string
+    InnerOnlyMergePatchInline:
+      type: object
+      properties:
+        inner:
+          type: object
+          x-json-merge-patch: true
+          properties:
+            p:
+              type: string
+    NestedMergePatchInline:
+      type: object
+      x-json-merge-patch: true
+      properties:
+        inner:
+          type: object
+          x-json-merge-patch: true
+          properties:
+            p:
+              type: string
+    NoMergePatchRef:
+      type: object
+      properties:
+        inner:
+          $ref: '#/components/schemas/InnerNotMergePatch'
+    TopLevelLevelMergePatchRef:
+      type: object
+      x-json-merge-patch: true
+      properties:
+        inner:
+          $ref: '#/components/schemas/InnerNotMergePatch'
+    InnerOnlyMergePatchRef:
+      type: object
+      properties:
+        inner:
+          $ref: '#/components/schemas/InnerMergePatch'
+    NestedMergePatchRef:
+      type: object
+      x-json-merge-patch: true
+      properties:
+        inner:
+          $ref: '#/components/schemas/InnerMergePatch'
+    InnerMergePatch:
+      type: object
+      x-json-merge-patch: true
+      properties:
+        p:
+          type: string
+    InnerNotMergePatch:
+      type: object
+      properties:
+        p:
+          type: string

--- a/src/test/resources/examples/jsonMergePatch/models/Models.kt
+++ b/src/test/resources/examples/jsonMergePatch/models/Models.kt
@@ -1,0 +1,98 @@
+package examples.jsonMergePatch.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.openapitools.jackson.nullable.JsonNullable
+import javax.validation.Valid
+import kotlin.String
+
+data class InnerMergePatch(
+    @param:JsonProperty("p")
+    @get:JsonProperty("p")
+    val p: JsonNullable<String> = JsonNullable.undefined()
+)
+
+data class InnerNotMergePatch(
+    @param:JsonProperty("p")
+    @get:JsonProperty("p")
+    val p: String? = null
+)
+
+data class InnerOnlyMergePatchInline(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: InnerOnlyMergePatchInlineInner? = null
+)
+
+data class InnerOnlyMergePatchInlineInner(
+    @param:JsonProperty("p")
+    @get:JsonProperty("p")
+    val p: JsonNullable<String> = JsonNullable.undefined()
+)
+
+data class InnerOnlyMergePatchRef(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: InnerMergePatch? = null
+)
+
+data class NestedMergePatchInline(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: JsonNullable<NestedMergePatchInlineInner> = JsonNullable.undefined()
+)
+
+data class NestedMergePatchInlineInner(
+    @param:JsonProperty("p")
+    @get:JsonProperty("p")
+    val p: JsonNullable<String> = JsonNullable.undefined()
+)
+
+data class NestedMergePatchRef(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: JsonNullable<InnerMergePatch> = JsonNullable.undefined()
+)
+
+data class NoMergePatchInline(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: NoMergePatchInlineInner? = null
+)
+
+data class NoMergePatchInlineInner(
+    @param:JsonProperty("p")
+    @get:JsonProperty("p")
+    val p: String? = null
+)
+
+data class NoMergePatchRef(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: InnerNotMergePatch? = null
+)
+
+data class TopLevelLevelMergePatchInline(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: JsonNullable<TopLevelLevelMergePatchInlineInner> = JsonNullable.undefined()
+)
+
+data class TopLevelLevelMergePatchInlineInner(
+    @param:JsonProperty("p")
+    @get:JsonProperty("p")
+    val p: String? = null
+)
+
+data class TopLevelLevelMergePatchRef(
+    @param:JsonProperty("inner")
+    @get:JsonProperty("inner")
+    @get:Valid
+    val inner: JsonNullable<InnerNotMergePatch> = JsonNullable.undefined()
+)


### PR DESCRIPTION
Fixes #184 

I added support for an extension called `x-json-merge-patch`. Schemas annotated with that extension wrap all their fields in a `JsonNullable`. The effect applies to all nested objects as well but not to `$ref`ed types. This is the usual behavior as described in RFC 7386 but also allows for custom behavior, should the need exist.

I'm not sure why or how one would combine this feature with discriminator-based polymorphism, so I didn't write any tests for it, but in theory, I added support for that as well.