### PR TITLE
Issue 20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,19 +53,19 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.1.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.1.0")
     testImplementation("org.assertj:assertj-core:3.14.0")
-
-    // Below dependencies are solely present so code examples in the test resources dir compile
-    testImplementation("javax.validation:validation-api:2.0.1.Final")
-    testImplementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    testImplementation("org.springframework:spring-webmvc:5.1.9.RELEASE")
-    testImplementation("org.springframework.security:spring-security-web:5.4.0")
-    testImplementation("io.micronaut:micronaut-core:3.8.4")
-    testImplementation("io.micronaut:micronaut-http:3.8.4")
-    testCompileOnly("io.micronaut.security:micronaut-security:3.8.3")
-    testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
     testImplementation("com.pinterest.ktlint:ktlint-core:0.41.0")
     testImplementation("com.pinterest:ktlint:0.41.0")
-    testImplementation("org.openapitools:jackson-databind-nullable:0.2.6")
+
+    // Below dependencies are solely present so code examples in the test resources dir compile
+    testCompileOnly("javax.validation:validation-api:2.0.1.Final")
+    testCompileOnly("jakarta.validation:jakarta.validation-api:3.0.2")
+    testCompileOnly("org.springframework:spring-webmvc:5.1.9.RELEASE")
+    testCompileOnly("org.springframework.security:spring-security-web:5.4.0")
+    testCompileOnly("io.micronaut:micronaut-core:3.8.4")
+    testCompileOnly("io.micronaut:micronaut-http:3.8.4")
+    testCompileOnly("io.micronaut.security:micronaut-security:3.8.3")
+    testCompileOnly("com.squareup.okhttp3:okhttp:4.9.1")
+    testCompileOnly("org.openapitools:jackson-databind-nullable:0.2.6")
 }
 
 tasks {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -6,6 +6,7 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.SecuritySupport
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
+import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponseObject
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.methodName
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
 import com.cjbooms.fabrikt.generators.controller.metadata.JavaXAnnotations
@@ -133,8 +134,8 @@ class MicronautControllerInterfaceGenerator(
         val globalSecurity =
             api.openApi3.securityRequirements.securitySupport()
 
-        val produces = op.responses
-            .flatMap { it.value.contentMediaTypes.keys }
+        val produces = op.happyPathResponseObject()
+            .contentMediaTypes.keys
             .toTypedArray()
 
         val consumes = op.requestBody

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -170,7 +170,7 @@ class MicronautControllerInterfaceGenerator(
                     .builder(MicronautImports.PRODUCES)
                     .addMember(
                         "value = %L",
-                        produces.joinToString(
+                        produces.distinct().joinToString(
                             prefix = "[",
                             postfix = "]",
                             separator = ", ",

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -128,14 +128,16 @@ class SpringControllerInterfaceGenerator(
                 .addMember("value = [%S]", path)
                 .addMember(
                     "produces = %L",
-                    produces.joinToString(prefix = "[", postfix = "]", separator = ", ", transform = { "\"$it\"" }),
+                    produces.distinct()
+                        .joinToString(prefix = "[", postfix = "]", separator = ", ", transform = { "\"$it\"" }),
                 )
                 .addMember("method = [RequestMethod.%L]", verb.toUpperCase())
 
         if (consumes.isNotEmpty()) {
             funcAnnotation.addMember(
                 "consumes = %L",
-                consumes.joinToString(prefix = "[", postfix = "]", separator = ", ", transform = { "\"$it\"" }),
+                consumes.distinct()
+                    .joinToString(prefix = "[", postfix = "]", separator = ", ", transform = { "\"$it\"" }),
             )
         }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -5,6 +5,7 @@ import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
+import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponseObject
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.methodName
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
 import com.cjbooms.fabrikt.generators.controller.metadata.JavaXAnnotations
@@ -84,6 +85,7 @@ class SpringControllerInterfaceGenerator(
                             .addAnnotation(SpringAnnotations.requestBodyBuilder().build())
                             .addAnnotation(JavaXAnnotations.validBuilder().build())
                             .build()
+
                     is RequestParameter ->
                         it
                             .toParameterSpecBuilder()
@@ -114,8 +116,8 @@ class SpringControllerInterfaceGenerator(
     }
 
     private fun FunSpec.Builder.addSpringFunAnnotation(op: Operation, verb: String, path: String): FunSpec.Builder {
-        val produces = op.responses
-            .flatMap { it.value.contentMediaTypes.keys }
+        val produces = op.happyPathResponseObject()
+            .contentMediaTypes.keys
             .toTypedArray()
 
         val consumes = op.requestBody

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
@@ -51,7 +51,7 @@ data class SourceApi(
         val globalResponses =
             openApi3.responses.entries.flatMap { response ->
                 response.value.contentMediaTypes.entries.map { content ->
-                    response.key to content.value.schema
+                    "${response.key}${content.key.contentTypeSuffix()}" to content.value.schema
                 }
             }
         allSchemas = (globalSchemas + globalParameters + globalRequests + globalResponses).map { (key, schema) ->

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/NormalisedString.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/NormalisedString.kt
@@ -10,6 +10,9 @@ object NormalisedString {
             .split("_")
             .joinToString("") { it.capitalized() }
 
+    fun String.contentTypeSuffix(): String =
+        substringAfter("/").pascalCase()
+
     private fun String.replaceSpecialCharacters() =
         Regex("[^A-Za-z0-9øæåØÆÅ]").replace(this, "_")
 
@@ -38,8 +41,11 @@ object NormalisedString {
         return all { if (it.isLetter()) it.isLowerCase() else true } && pieces.all { SourceVersion.isIdentifier(it) }
     }
 }
+
 // Replace deprecated Kotlin String functions with concise equivalents
 fun String.toUpperCase() = uppercase(Locale.getDefault())
 fun String.toLowerCase() = lowercase(Locale.getDefault())
-fun String.capitalized() = replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+fun String.capitalized() =
+    replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
 fun String.decapitalized() = replaceFirstChar { it.lowercase(Locale.getDefault()) }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
@@ -34,6 +34,8 @@ class MicronautControllerGeneratorTest {
         "singleAllOf",
         "pathLevelParameters",
         "parameterNameClash",
+        "responsesSchema",
+        "requestsSchema",
     )
 
     private fun setupGithubApiTestEnv() {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -49,6 +49,7 @@ class ModelGeneratorTest {
         "wildCardTypes",
         "singleAllOf",
         "responsesSchema",
+        "requestsSchema",
         "webhook",
         "instantDateTime",
         "singleAllOf",

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -33,6 +33,8 @@ class SpringControllerGeneratorTest {
         "singleAllOf",
         "pathLevelParameters",
         "parameterNameClash",
+        "responsesSchema",
+        "requestsSchema",
     )
 
     private fun setupGithubApiTestEnv() {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -47,8 +47,8 @@ class SpringControllerGeneratorTest {
         MutableSettings.updateSettings(genTypes = setOf(CodeGenerationType.CONTROLLERS))
     }
 
-    // @Test
-    // fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("singleAllOf")
+    @Test
+    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("responsesSchema")
 
     @ParameterizedTest
     @MethodSource("testCases")

--- a/src/test/resources/examples/githubApi/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/micronaut/Controllers.kt
@@ -42,7 +42,7 @@ interface InternalEventsController {
      */
     @Post(uri = "/internal/events")
     @Consumes(value = ["application/json"])
-    @Produces(value = ["application/json", "application/problem+json"])
+    @Produces(value = ["application/json"])
     fun post(
         @Body @Valid
         bulkEntityDetails: BulkEntityDetails

--- a/src/test/resources/examples/githubApi/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/spring/Controllers.kt
@@ -41,7 +41,7 @@ interface InternalEventsController {
      */
     @RequestMapping(
         value = ["/internal/events"],
-        produces = ["application/json", "application/problem+json"],
+        produces = ["application/json"],
         method = [RequestMethod.POST],
         consumes = ["application/json"]
     )

--- a/src/test/resources/examples/githubApi/models/Models.kt
+++ b/src/test/resources/examples/githubApi/models/Models.kt
@@ -43,7 +43,7 @@ data class BulkEntityDetails(
     }
 }
 
-data class BulkEventGenerationBody(
+data class BulkEventGenerationBodyJson(
     @param:JsonProperty("entities")
     @get:JsonProperty("entities")
     @get:NotNull
@@ -102,7 +102,7 @@ data class Contributor(
     val name: String? = null
 )
 
-data class ContributorBody(
+data class ContributorBodyJson(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     val id: String? = null,
@@ -276,7 +276,7 @@ data class Organisation(
     val hooks: List<Webhook>? = null
 )
 
-data class OrganisationBody(
+data class OrganisationBodyJson(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     val id: String? = null,
@@ -397,7 +397,7 @@ data class PullRequest(
     val author: Author? = null
 )
 
-data class PullRequestBody(
+data class PullRequestBodyJson(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     val id: String? = null,
@@ -521,7 +521,7 @@ data class Repository(
     val tags: List<String>? = null
 )
 
-data class RepositoryBody(
+data class RepositoryBodyJson(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     val id: String? = null,

--- a/src/test/resources/examples/githubApi/models/Models.kt
+++ b/src/test/resources/examples/githubApi/models/Models.kt
@@ -43,7 +43,66 @@ data class BulkEntityDetails(
     }
 }
 
+data class BulkEventGenerationBody(
+    @param:JsonProperty("entities")
+    @get:JsonProperty("entities")
+    @get:NotNull
+    @get:Valid
+    val entities: List<EntityDetails>,
+    @get:JsonIgnore
+    val properties: MutableMap<String, Any> = mutableMapOf()
+) {
+    @JsonAnyGetter
+    fun get(): Map<String, Any> = properties
+
+    @JsonAnySetter
+    fun set(name: String, value: Any) {
+        properties[name] = value
+    }
+}
+
 data class Contributor(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    val id: String? = null,
+    @param:JsonProperty("audit_actor")
+    @get:JsonProperty("audit_actor")
+    val auditActor: String? = null,
+    @param:JsonProperty("created")
+    @get:JsonProperty("created")
+    val created: OffsetDateTime? = null,
+    @param:JsonProperty("created_by")
+    @get:JsonProperty("created_by")
+    val createdBy: String? = null,
+    @param:JsonProperty("created_by_uid")
+    @get:JsonProperty("created_by_uid")
+    val createdByUid: String? = null,
+    @param:JsonProperty("modified")
+    @get:JsonProperty("modified")
+    val modified: OffsetDateTime? = null,
+    @param:JsonProperty("modified_by")
+    @get:JsonProperty("modified_by")
+    val modifiedBy: String? = null,
+    @param:JsonProperty("modified_by_uid")
+    @get:JsonProperty("modified_by_uid")
+    val modifiedByUid: String? = null,
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    val status: ContributorStatus,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    val etag: String? = null,
+    @param:JsonProperty("username")
+    @get:JsonProperty("username")
+    @get:NotNull
+    val username: String,
+    @param:JsonProperty("name")
+    @get:JsonProperty("name")
+    val name: String? = null
+)
+
+data class ContributorBody(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     val id: String? = null,
@@ -217,6 +276,51 @@ data class Organisation(
     val hooks: List<Webhook>? = null
 )
 
+data class OrganisationBody(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    val id: String? = null,
+    @param:JsonProperty("audit_actor")
+    @get:JsonProperty("audit_actor")
+    val auditActor: String? = null,
+    @param:JsonProperty("created")
+    @get:JsonProperty("created")
+    val created: OffsetDateTime? = null,
+    @param:JsonProperty("created_by")
+    @get:JsonProperty("created_by")
+    val createdBy: String? = null,
+    @param:JsonProperty("created_by_uid")
+    @get:JsonProperty("created_by_uid")
+    val createdByUid: String? = null,
+    @param:JsonProperty("modified")
+    @get:JsonProperty("modified")
+    val modified: OffsetDateTime? = null,
+    @param:JsonProperty("modified_by")
+    @get:JsonProperty("modified_by")
+    val modifiedBy: String? = null,
+    @param:JsonProperty("modified_by_uid")
+    @get:JsonProperty("modified_by_uid")
+    val modifiedByUid: String? = null,
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    val status: OrganisationStatus,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    val etag: String? = null,
+    @param:JsonProperty("name")
+    @get:JsonProperty("name")
+    @get:NotNull
+    val name: String,
+    @param:JsonProperty("icon")
+    @get:JsonProperty("icon")
+    val icon: String? = null,
+    @param:JsonProperty("hooks")
+    @get:JsonProperty("hooks")
+    @get:Valid
+    val hooks: List<Webhook>? = null
+)
+
 data class OrganisationQueryResult(
     @param:JsonProperty("prev")
     @get:JsonProperty("prev")
@@ -293,6 +397,51 @@ data class PullRequest(
     val author: Author? = null
 )
 
+data class PullRequestBody(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    val id: String? = null,
+    @param:JsonProperty("audit_actor")
+    @get:JsonProperty("audit_actor")
+    val auditActor: String? = null,
+    @param:JsonProperty("created")
+    @get:JsonProperty("created")
+    val created: OffsetDateTime? = null,
+    @param:JsonProperty("created_by")
+    @get:JsonProperty("created_by")
+    val createdBy: String? = null,
+    @param:JsonProperty("created_by_uid")
+    @get:JsonProperty("created_by_uid")
+    val createdByUid: String? = null,
+    @param:JsonProperty("modified")
+    @get:JsonProperty("modified")
+    val modified: OffsetDateTime? = null,
+    @param:JsonProperty("modified_by")
+    @get:JsonProperty("modified_by")
+    val modifiedBy: String? = null,
+    @param:JsonProperty("modified_by_uid")
+    @get:JsonProperty("modified_by_uid")
+    val modifiedByUid: String? = null,
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    val status: PullRequestStatus,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    val etag: String? = null,
+    @param:JsonProperty("title")
+    @get:JsonProperty("title")
+    @get:NotNull
+    val title: String,
+    @param:JsonProperty("description")
+    @get:JsonProperty("description")
+    val description: String? = null,
+    @param:JsonProperty("author")
+    @get:JsonProperty("author")
+    @get:Valid
+    val author: Author? = null
+)
+
 data class PullRequestQueryResult(
     @param:JsonProperty("prev")
     @get:JsonProperty("prev")
@@ -325,6 +474,54 @@ enum class PullRequestStatus(
 }
 
 data class Repository(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    val id: String? = null,
+    @param:JsonProperty("audit_actor")
+    @get:JsonProperty("audit_actor")
+    val auditActor: String? = null,
+    @param:JsonProperty("created")
+    @get:JsonProperty("created")
+    val created: OffsetDateTime? = null,
+    @param:JsonProperty("created_by")
+    @get:JsonProperty("created_by")
+    val createdBy: String? = null,
+    @param:JsonProperty("created_by_uid")
+    @get:JsonProperty("created_by_uid")
+    val createdByUid: String? = null,
+    @param:JsonProperty("modified")
+    @get:JsonProperty("modified")
+    val modified: OffsetDateTime? = null,
+    @param:JsonProperty("modified_by")
+    @get:JsonProperty("modified_by")
+    val modifiedBy: String? = null,
+    @param:JsonProperty("modified_by_uid")
+    @get:JsonProperty("modified_by_uid")
+    val modifiedByUid: String? = null,
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    val status: RepositoryStatus,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    val etag: String? = null,
+    @param:JsonProperty("slug")
+    @get:JsonProperty("slug")
+    @get:NotNull
+    val slug: String,
+    @param:JsonProperty("name")
+    @get:JsonProperty("name")
+    @get:NotNull
+    val name: String,
+    @param:JsonProperty("visibility")
+    @get:JsonProperty("visibility")
+    val visibility: RepositoryVisibility? = null,
+    @param:JsonProperty("tags")
+    @get:JsonProperty("tags")
+    val tags: List<String>? = null
+)
+
+data class RepositoryBody(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     val id: String? = null,

--- a/src/test/resources/examples/githubApi/resources/reflection-config.json
+++ b/src/test/resources/examples/githubApi/resources/reflection-config.json
@@ -158,4 +158,44 @@
   "allPublicMethods" : true,
   "allDeclaredFields" : true,
   "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.BulkEventGenerationBody",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.ContributorBody",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.OrganisationBody",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.RepositoryBody",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
+}, {
+  "name" : "examples.githubApi.models.PullRequestBody",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allPublicFields" : true
 } ]

--- a/src/test/resources/examples/instantDateTime/models/Models.kt
+++ b/src/test/resources/examples/instantDateTime/models/Models.kt
@@ -16,6 +16,24 @@ data class FirstModel(
     val extraFirstAttr: List<Instant>? = null
 )
 
+data class PostBody(
+    @param:JsonProperty("date")
+    @get:JsonProperty("date")
+    val date: Instant? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    val extraFirstAttr: List<Instant>? = null
+)
+
+data class PutBody(
+    @param:JsonProperty("date")
+    @get:JsonProperty("date")
+    val date: Instant? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    val extraFirstAttr: List<Instant>? = null
+)
+
 data class QueryResult(
     @param:JsonProperty("items")
     @get:JsonProperty("items")

--- a/src/test/resources/examples/instantDateTime/models/Models.kt
+++ b/src/test/resources/examples/instantDateTime/models/Models.kt
@@ -16,7 +16,7 @@ data class FirstModel(
     val extraFirstAttr: List<Instant>? = null
 )
 
-data class PostBody(
+data class PostBodyJson(
     @param:JsonProperty("date")
     @get:JsonProperty("date")
     val date: Instant? = null,
@@ -25,7 +25,7 @@ data class PostBody(
     val extraFirstAttr: List<Instant>? = null
 )
 
-data class PutBody(
+data class PutBodyJson(
     @param:JsonProperty("date")
     @get:JsonProperty("date")
     val date: Instant? = null,

--- a/src/test/resources/examples/javaSerializableModels/models/Models.kt
+++ b/src/test/resources/examples/javaSerializableModels/models/Models.kt
@@ -103,6 +103,31 @@ data class FirstModel(
     override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
 
+data class PutBody(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    val extraFirstAttr: List<String>? = null
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag), Serializable {
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
+}
+
 data class QueryResult(
     @param:JsonProperty("items")
     @get:JsonProperty("items")

--- a/src/test/resources/examples/javaSerializableModels/models/Models.kt
+++ b/src/test/resources/examples/javaSerializableModels/models/Models.kt
@@ -103,7 +103,7 @@ data class FirstModel(
     override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
 
-data class PutBody(
+data class PutBodyJson(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     override val id: String? = null,

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -3,6 +3,7 @@ package examples.okHttpClient.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import examples.okHttpClient.models.Content
+import examples.okHttpClient.models.ContentJson
 import examples.okHttpClient.models.FirstModel
 import examples.okHttpClient.models.QueryResult
 import okhttp3.Headers
@@ -62,12 +63,12 @@ class ExamplePath1Client(
     /**
      * POST example path 1
      *
-     * @param content
+     * @param contentJson
      * @param explodeListQueryParam
      */
     @Throws(ApiException::class)
     fun postExamplePath1(
-        content: Content,
+        contentJson: ContentJson,
         explodeListQueryParam: List<String>? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): ApiResponse<Unit> {
@@ -84,7 +85,7 @@ class ExamplePath1Client(
         val request: Request = Request.Builder()
             .url(httpUrl)
             .headers(httpHeaders)
-            .post(objectMapper.writeValueAsString(content).toRequestBody("application/json".toMediaType()))
+            .post(objectMapper.writeValueAsString(contentJson).toRequestBody("application/json".toMediaType()))
             .build()
 
         return request.execute(client, objectMapper, jacksonTypeRef())

--- a/src/test/resources/examples/okHttpClient/models/Models.kt
+++ b/src/test/resources/examples/okHttpClient/models/Models.kt
@@ -102,7 +102,7 @@ data class FirstModel(
     override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
 
-data class PutBody(
+data class PutBodyJson(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     override val id: String? = null,

--- a/src/test/resources/examples/okHttpClient/models/Models.kt
+++ b/src/test/resources/examples/okHttpClient/models/Models.kt
@@ -102,6 +102,31 @@ data class FirstModel(
     override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
 }
 
+data class PutBody(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    val extraFirstAttr: List<String>? = null
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag) {
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    override val modelType: ContentModelType = ContentModelType.FIRST_MODEL
+}
+
 data class QueryResult(
     @param:JsonProperty("items")
     @get:JsonProperty("items")

--- a/src/test/resources/examples/requestsSchema/api.yaml
+++ b/src/test/resources/examples/requestsSchema/api.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+paths:
+  /foo:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/DummyRequest'
+      responses:
+        200:
+          {}
+components:
+  requestBodies:
+    DummyRequest:
+      description: Request body
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              age:
+                type: integer
+    MultiContent:
+      description: Request body
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              a:
+                type: string
+        application/json2:
+          schema:
+            type: object
+            properties:
+              x:
+                type: integer

--- a/src/test/resources/examples/requestsSchema/api.yaml
+++ b/src/test/resources/examples/requestsSchema/api.yaml
@@ -29,7 +29,7 @@ components:
             properties:
               a:
                 type: string
-        application/json2:
+        application/my-custom+json:
           schema:
             type: object
             properties:

--- a/src/test/resources/examples/requestsSchema/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/requestsSchema/controllers/micronaut/Controllers.kt
@@ -1,6 +1,6 @@
 package examples.requestsSchema.controllers
 
-import examples.requestsSchema.models.DummyRequest
+import examples.requestsSchema.models.DummyRequestJson
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Consumes
@@ -20,6 +20,6 @@ interface FooController {
     @Consumes(value = ["application/json"])
     fun post(
         @Body @Valid
-        dummyRequest: DummyRequest
+        dummyRequest: DummyRequestJson
     ): HttpResponse<Unit>
 }

--- a/src/test/resources/examples/requestsSchema/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/requestsSchema/controllers/micronaut/Controllers.kt
@@ -1,0 +1,25 @@
+package examples.requestsSchema.controllers
+
+import examples.requestsSchema.models.DummyRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import javax.validation.Valid
+import kotlin.Unit
+
+@Controller
+interface FooController {
+    /**
+     *
+     *
+     * @param dummyRequest Request body
+     */
+    @Post(uri = "/foo")
+    @Consumes(value = ["application/json"])
+    fun post(
+        @Body @Valid
+        dummyRequest: DummyRequest
+    ): HttpResponse<Unit>
+}

--- a/src/test/resources/examples/requestsSchema/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/requestsSchema/controllers/micronaut/Controllers.kt
@@ -14,12 +14,12 @@ interface FooController {
     /**
      *
      *
-     * @param dummyRequest Request body
+     * @param dummyRequestJson Request body
      */
     @Post(uri = "/foo")
     @Consumes(value = ["application/json"])
     fun post(
         @Body @Valid
-        dummyRequest: DummyRequestJson
+        dummyRequestJson: DummyRequestJson
     ): HttpResponse<Unit>
 }

--- a/src/test/resources/examples/requestsSchema/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/requestsSchema/controllers/spring/Controllers.kt
@@ -1,6 +1,6 @@
 package examples.requestsSchema.controllers
 
-import examples.requestsSchema.models.DummyRequest
+import examples.requestsSchema.models.DummyRequestJson
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
@@ -27,6 +27,6 @@ interface FooController {
     )
     fun post(
         @RequestBody @Valid
-        dummyRequest: DummyRequest
+        dummyRequest: DummyRequestJson
     ): ResponseEntity<Unit>
 }

--- a/src/test/resources/examples/requestsSchema/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/requestsSchema/controllers/spring/Controllers.kt
@@ -1,0 +1,32 @@
+package examples.requestsSchema.controllers
+
+import examples.requestsSchema.models.DummyRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import javax.validation.Valid
+import kotlin.Unit
+
+@Controller
+@Validated
+@RequestMapping("")
+interface FooController {
+    /**
+     *
+     *
+     * @param dummyRequest Request body
+     */
+    @RequestMapping(
+        value = ["/foo"],
+        produces = [],
+        method = [RequestMethod.POST],
+        consumes = ["application/json"]
+    )
+    fun post(
+        @RequestBody @Valid
+        dummyRequest: DummyRequest
+    ): ResponseEntity<Unit>
+}

--- a/src/test/resources/examples/requestsSchema/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/requestsSchema/controllers/spring/Controllers.kt
@@ -17,7 +17,7 @@ interface FooController {
     /**
      *
      *
-     * @param dummyRequest Request body
+     * @param dummyRequestJson Request body
      */
     @RequestMapping(
         value = ["/foo"],
@@ -27,6 +27,6 @@ interface FooController {
     )
     fun post(
         @RequestBody @Valid
-        dummyRequest: DummyRequestJson
+        dummyRequestJson: DummyRequestJson
     ): ResponseEntity<Unit>
 }

--- a/src/test/resources/examples/requestsSchema/models/Models.kt
+++ b/src/test/resources/examples/requestsSchema/models/Models.kt
@@ -1,0 +1,26 @@
+package examples.requestsSchema.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import kotlin.Int
+import kotlin.String
+
+data class DummyRequest(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    val id: String? = null,
+    @param:JsonProperty("age")
+    @get:JsonProperty("age")
+    val age: Int? = null
+)
+
+data class MultiContent0(
+    @param:JsonProperty("a")
+    @get:JsonProperty("a")
+    val a: String? = null
+)
+
+data class MultiContent1(
+    @param:JsonProperty("x")
+    @get:JsonProperty("x")
+    val x: Int? = null
+)

--- a/src/test/resources/examples/requestsSchema/models/Models.kt
+++ b/src/test/resources/examples/requestsSchema/models/Models.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import kotlin.Int
 import kotlin.String
 
-data class DummyRequest(
+data class DummyRequestJson(
     @param:JsonProperty("id")
     @get:JsonProperty("id")
     val id: String? = null,
@@ -13,13 +13,13 @@ data class DummyRequest(
     val age: Int? = null
 )
 
-data class MultiContent0(
+data class MultiContentJson(
     @param:JsonProperty("a")
     @get:JsonProperty("a")
     val a: String? = null
 )
 
-data class MultiContent1(
+data class MultiContentMyCustomJson(
     @param:JsonProperty("x")
     @get:JsonProperty("x")
     val x: Int? = null

--- a/src/test/resources/examples/responsesSchema/api.yaml
+++ b/src/test/resources/examples/responsesSchema/api.yaml
@@ -1,4 +1,12 @@
 openapi: 3.0.0
+paths:
+  /foo:
+    post:
+      responses:
+        200:
+          $ref: '#/components/responses/SuccessResponse'
+        500:
+          $ref: '#/components/responses/ErrorResponse'
 components:
   responses:
     ErrorResponse:
@@ -15,7 +23,7 @@ components:
                 type: string
               code:
                 type: integer
-    SucccessResponse:
+    SuccessResponse:
       description: "Response on success"
       content:
         application/json:

--- a/src/test/resources/examples/responsesSchema/api.yaml
+++ b/src/test/resources/examples/responsesSchema/api.yaml
@@ -12,7 +12,7 @@ components:
     ErrorResponse:
       description: "Response on error"
       content:
-        application/json:
+        application/problem+json:
           schema:
             type: object
             required:

--- a/src/test/resources/examples/responsesSchema/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/responsesSchema/controllers/micronaut/Controllers.kt
@@ -1,0 +1,17 @@
+package examples.responsesSchema.controllers
+
+import examples.responsesSchema.models.SuccessResponse
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
+
+@Controller
+interface FooController {
+    /**
+     *
+     */
+    @Post(uri = "/foo")
+    @Produces(value = ["application/json"])
+    fun post(): HttpResponse<SuccessResponse>
+}

--- a/src/test/resources/examples/responsesSchema/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/responsesSchema/controllers/micronaut/Controllers.kt
@@ -1,6 +1,6 @@
 package examples.responsesSchema.controllers
 
-import examples.responsesSchema.models.SuccessResponse
+import examples.responsesSchema.models.SuccessResponseJson
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Post
@@ -13,5 +13,5 @@ interface FooController {
      */
     @Post(uri = "/foo")
     @Produces(value = ["application/json"])
-    fun post(): HttpResponse<SuccessResponse>
+    fun post(): HttpResponse<SuccessResponseJson>
 }

--- a/src/test/resources/examples/responsesSchema/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/responsesSchema/controllers/spring/Controllers.kt
@@ -1,6 +1,6 @@
 package examples.responsesSchema.controllers
 
-import examples.responsesSchema.models.SuccessResponse
+import examples.responsesSchema.models.SuccessResponseJson
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
@@ -19,5 +19,5 @@ interface FooController {
         produces = ["application/json"],
         method = [RequestMethod.POST]
     )
-    fun post(): ResponseEntity<SuccessResponse>
+    fun post(): ResponseEntity<SuccessResponseJson>
 }

--- a/src/test/resources/examples/responsesSchema/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/responsesSchema/controllers/spring/Controllers.kt
@@ -1,0 +1,23 @@
+package examples.responsesSchema.controllers
+
+import examples.responsesSchema.models.SuccessResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+
+@Controller
+@Validated
+@RequestMapping("")
+interface FooController {
+    /**
+     *
+     */
+    @RequestMapping(
+        value = ["/foo"],
+        produces = ["application/json"],
+        method = [RequestMethod.POST]
+    )
+    fun post(): ResponseEntity<SuccessResponse>
+}

--- a/src/test/resources/examples/responsesSchema/models/Models.kt
+++ b/src/test/resources/examples/responsesSchema/models/Models.kt
@@ -16,7 +16,7 @@ data class ErrorResponse(
     val code: Int
 )
 
-data class SucccessResponse(
+data class SuccessResponse(
     @param:JsonProperty("message")
     @get:JsonProperty("message")
     @get:NotNull

--- a/src/test/resources/examples/responsesSchema/models/Models.kt
+++ b/src/test/resources/examples/responsesSchema/models/Models.kt
@@ -5,7 +5,7 @@ import javax.validation.constraints.NotNull
 import kotlin.Int
 import kotlin.String
 
-data class ErrorResponse(
+data class ErrorResponseProblemJson(
     @param:JsonProperty("message")
     @get:JsonProperty("message")
     @get:NotNull
@@ -16,7 +16,7 @@ data class ErrorResponse(
     val code: Int
 )
 
-data class SuccessResponse(
+data class SuccessResponseJson(
     @param:JsonProperty("message")
     @get:JsonProperty("message")
     @get:NotNull


### PR DESCRIPTION
From @atollk, with the minor change of the suffix to make it more intuitive.

> I added generation for models from the requestBodies section.
>
> I also changed a few dependencies from testImplementation to testCompileOnly to make it clear that they're not used for actually running the tests and applied a minor change which causes the media types of annotations on controller functions to be unique (i.e. you won't have produces = ["application/json", "application/json", "application/json"] anymore)