### PR TITLE
fix: missing types from other spec file

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -150,7 +150,6 @@ class JacksonModelGenerator(
             val api = OpenApi3Parser().parse(externalReferences.key)
             val schemas = api.schemas.entries.map { it.key to it.value }
                 .map { (key, schema) -> SchemaInfo(key, schema) }
-                .filter { apiSchema -> externalReferences.value.contains(apiSchema.name) }
             val externalModels = createModels(api, schemas)
             externalModels.forEach { additionalModel ->
                 if (models.none { it.name == additionalModel.name }) models.add(additionalModel)

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -16,6 +16,7 @@ import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.Linter
 import com.cjbooms.fabrikt.util.ResourceHelper.readTextResource
 import com.squareup.kotlinpoet.FileSpec
+import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
@@ -33,6 +34,7 @@ class OkHttpClientGeneratorTest {
         "okHttpClientPostWithoutRequestBody",
         "pathLevelParameters",
         "parameterNameClash",
+        "externalReferences"
     )
 
     @BeforeEach
@@ -48,7 +50,8 @@ class OkHttpClientGeneratorTest {
     @MethodSource("fullApiTestCases")
     fun `correct api simple client is generated from a full API definition`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
-        val sourceApi = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
+        val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
 
         val expectedModel = readTextResource("/examples/$testCaseName/models/Models.kt")
         val expectedClient = readTextResource("/examples/$testCaseName/client/ApiClient.kt")

--- a/src/test/resources/examples/externalReferences/api.yaml
+++ b/src/test/resources/examples/externalReferences/api.yaml
@@ -1,8 +1,24 @@
 openapi: 3.0.0
-paths: {}
 info:
   title: ""
   version: ""
+paths:
+  /hello:
+    get:
+      operationId: helloWorld
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            $ref: './external-models.yaml#/components/schemas/Language'
+      responses:
+        200:
+          description: "world"
+          content:
+            application/json:
+              schema:
+                $ref: './external-models.yaml#/components/schemas/Content'
 components:
   schemas:
     ContainingExternalReference:
@@ -10,5 +26,12 @@ components:
       properties:
         some-external-reference:
           $ref: './external-models.yaml#/components/schemas/ExternalObject'
+    Answer:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          $ref: './external-models.yaml#/components/schemas/Content'
 
 

--- a/src/test/resources/examples/externalReferences/client/ApiClient.kt
+++ b/src/test/resources/examples/externalReferences/client/ApiClient.kt
@@ -1,0 +1,49 @@
+package examples.externalReferences.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import examples.externalReferences.models.Content
+import examples.externalReferences.models.Language
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+@Suppress("unused")
+class HelloClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val client: OkHttpClient
+) {
+    /**
+     *
+     *
+     * @param language
+     */
+    @Throws(ApiException::class)
+    fun helloWorld(language: Language, additionalHeaders: Map<String, String> = emptyMap()):
+        ApiResponse<Content> {
+        val httpUrl: HttpUrl = "$baseUrl/hello"
+            .pathParam("{language}" to language)
+            .toHttpUrl()
+            .newBuilder()
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .get()
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/externalReferences/client/ApiModels.kt
+++ b/src/test/resources/examples/externalReferences/client/ApiModels.kt
@@ -1,0 +1,26 @@
+package examples.externalReferences.client
+
+import okhttp3.Headers
+
+/**
+ * API 2xx success response returned by API call.
+ *
+ * @param <T> The type of data that is deserialized from response body
+ */
+data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T? = null)
+
+/**
+ * API non-2xx failure responses returned by API call.
+ */
+open class ApiException(override val message: String) : RuntimeException(message)
+
+/**
+ * API 4xx failure responses returned by API call.
+ */
+data class ApiClientException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+
+/**
+ * API 5xx failure responses returned by API call.
+ */
+data class ApiServerException(val statusCode: Int, val headers: Headers, override val message: String) : ApiException(message)
+

--- a/src/test/resources/examples/externalReferences/client/HttpUtil.kt
+++ b/src/test/resources/examples/externalReferences/client/HttpUtil.kt
@@ -1,0 +1,65 @@
+package examples.externalReferences.client
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+@Suppress("unused")
+fun <T : Any> HttpUrl.Builder.queryParam(key: String, value: T?): HttpUrl.Builder = this.apply {
+    if (value != null) this.addQueryParameter(key, value.toString())
+}
+
+@Suppress("unused")
+fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
+}
+
+@Suppress("unused")
+fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+    if (values != null) {
+        if (explode) values.forEach { addQueryParameter(key, it) }
+        else addQueryParameter(key, values.joinToString(","))
+    }
+}
+
+@Suppress("unused")
+fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value)
+}
+
+@Throws(ApiException::class)
+fun <T> Request.execute(client: OkHttpClient, objectMapper: ObjectMapper, typeRef: TypeReference<T>): ApiResponse<T> =
+    client.newCall(this).execute().use { response ->
+        when {
+            response.isSuccessful ->
+                ApiResponse(response.code, response.headers, response.body?.deserialize(objectMapper, typeRef))
+            response.isBadRequest() ->
+                throw ApiClientException(response.code, response.headers, response.errorMessage())
+            response.isServerError() ->
+                throw ApiServerException(response.code, response.headers, response.errorMessage())
+            else -> throw ApiException("[${response.code}]: ${response.errorMessage()}")
+        }
+    }
+
+@Suppress("unused")
+fun String.pathParam(vararg params: Pair<String, Any>): String = params.asSequence()
+    .joinToString { param ->
+        this.replace(param.first, param.second.toString())
+    }
+
+fun <T> ResponseBody.deserialize(objectMapper: ObjectMapper, typeRef: TypeReference<T>): T? =
+    this.string().isNotBlankOrNull()?.let { objectMapper.readValue(it, typeRef) }
+
+fun String?.isNotBlankOrNull() = if (this.isNullOrBlank()) null else this
+
+private fun Response.errorMessage(): String = this.body?.string() ?: this.message
+
+private fun Response.isBadRequest(): Boolean = this.code in 400..499
+
+private fun Response.isServerError(): Boolean = this.code in 500..599

--- a/src/test/resources/examples/externalReferences/external-models.yaml
+++ b/src/test/resources/examples/externalReferences/external-models.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.0
-paths: {}
+paths: { }
 info:
   title: ""
   version: ""
@@ -9,10 +9,10 @@ components:
       type: object
       properties:
         another:
-          $ref: "#/components/schemas/ExternalObjectTwo"        
+          $ref: "#/components/schemas/ExternalObjectTwo"
         one_of:
           $ref: "#/components/schemas/ExternalOneOf"
-          
+
     ExternalObjectTwo:
       type: object
       required:
@@ -27,7 +27,7 @@ components:
         minProperties: 1
         additionalProperties:
           $ref: '#/components/schemas/ExternalObjectFour'
-   
+
     ExternalObjectThree:
       type: object
       required:
@@ -41,20 +41,20 @@ components:
             - two
             - three
         description:
-          type: string   
-          
+          type: string
+
     ExternalObjectFour:
       type: object
       properties:
         blah:
-          type: string     
-          
+          type: string
+
     IgnoredExternalObjectFive:
       type: object
       properties:
         blah:
           type: string
-    
+
     ExternalOneOf:
       oneOf:
         - $ref: '#/components/schemas/OneOfOne'
@@ -67,7 +67,7 @@ components:
       properties:
         discriminator:
           type: string
-          
+
     OneOfOne:
       allOf:
         - $ref: '#/components/schemas/ParentOneOf'
@@ -82,4 +82,41 @@ components:
         - type: object
           properties:
             oneOfTwo:
+              type: string
+
+    Language:
+      type: string
+      enum:
+        - ENGLISH
+        - DUTCH
+        - GERMAN
+    Content:
+      type: object
+      properties:
+        contentType:
+          type: string
+          enum:
+            - HTML
+            - MD
+      discriminator:
+        propertyName:
+          contentType
+        mapping:
+          HTML: '#/components/schemas/ContentHTML'
+          MD: '#/components/schemas/ContentMD'
+    ContentHTML:
+      allOf:
+        - $ref: '#/components/schemas/Content'
+        - type: object
+          properties:
+            header:
+              type: string
+            body:
+              type: string
+    ContentMD:
+      allOf:
+        - $ref: '#/components/schemas/Content'
+        - type: object
+          properties:
+            richText:
               type: string

--- a/src/test/resources/examples/externalReferences/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/models/Models.kt
@@ -14,12 +14,77 @@ import kotlin.collections.List
 import kotlin.collections.Map
 import kotlin.collections.MutableMap
 
+public data class Answer(
+    @param:JsonProperty("content")
+    @get:JsonProperty("content")
+    @get:NotNull
+    @get:Valid
+    public val content: Content,
+)
+
 public data class ContainingExternalReference(
     @param:JsonProperty("some-external-reference")
     @get:JsonProperty("some-external-reference")
     @get:Valid
     public val someExternalReference: ExternalObject? = null,
 )
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "contentType",
+    visible = true,
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = ContentHTML::class, name = "HTML"),
+    JsonSubTypes.Type(
+        value =
+        ContentMD::class,
+        name = "MD",
+    ),
+)
+public sealed class Content() {
+    public abstract val contentType: ContentContentType
+}
+
+public enum class ContentContentType(
+    @JsonValue
+    public val `value`: String,
+) {
+    HTML("HTML"),
+    MD("MD"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, ContentContentType> =
+            values().associateBy(ContentContentType::value)
+
+        public fun fromValue(`value`: String): ContentContentType? = mapping[value]
+    }
+}
+
+public data class ContentHTML(
+    @param:JsonProperty("header")
+    @get:JsonProperty("header")
+    public val `header`: String? = null,
+    @param:JsonProperty("body")
+    @get:JsonProperty("body")
+    public val body: String? = null,
+    @get:JsonProperty("contentType")
+    @get:NotNull
+    @param:JsonProperty("contentType")
+    override val contentType: ContentContentType = ContentContentType.HTML,
+) : Content()
+
+public data class ContentMD(
+    @param:JsonProperty("richText")
+    @get:JsonProperty("richText")
+    public val richText: String? = null,
+    @get:JsonProperty("contentType")
+    @get:NotNull
+    @param:JsonProperty("contentType")
+    override val contentType: ContentContentType = ContentContentType.MD,
+) : Content()
 
 public data class ExternalObject(
     @param:JsonProperty("another")
@@ -80,6 +145,28 @@ public data class ExternalObjectTwo(
     @JsonAnySetter
     public fun `set`(name: String, `value`: Map<String, ExternalObjectFour>) {
         properties[name] = value
+    }
+}
+
+public data class IgnoredExternalObjectFive(
+    @param:JsonProperty("blah")
+    @get:JsonProperty("blah")
+    public val blah: String? = null,
+)
+
+public enum class Language(
+    @JsonValue
+    public val `value`: String,
+) {
+    ENGLISH("ENGLISH"),
+    DUTCH("DUTCH"),
+    GERMAN("GERMAN"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, Language> = values().associateBy(Language::value)
+
+        public fun fromValue(`value`: String): Language? = mapping[value]
     }
 }
 


### PR DESCRIPTION
Hi 👋 

Still enjoying your great library 💯  And we are adding it more and more to our projects.

We've encountered one issue of an Open API Spec contained in multiple files via external references.
Currently, not all types are generated if the model is from an external spec file.
More specifically, models from external spec files are filtered out by:
```
.filter { apiSchema -> externalReferences.value.contains(apiSchema.name) }
```


We've found that it can cause issues in at least the following cases:

**1. Parameter contains  external reference** 
With a spec like,
```
paths:
  /hello:
    get:
      operationId: helloWorld
      parameters:
        - name: language
          in: path
          required: true
          schema:
            $ref: './external-models.yaml#/components/schemas/Language'
```
the `Language` type wouldn't be created as it is currently filtered out.

***2. Schema in external file contains reference to another schema in the external file***
When an external spec file, contains another reference in the same file it will also be filtered out. That is, suppose that defined `Content` is referenced from `api.yaml` but defined in `external-models.yaml` like so:
```
    Content:
      type: object
      properties:
        contentType:
          type: string
          enum:
            - HTML
            - MD
      discriminator:
        propertyName:
          contentType
        mapping:
          HTML: '#/components/schemas/ContentHTML'
          MD: '#/components/schemas/ContentMD'
    ContentHTML:
      allOf:
        - $ref: '#/components/schemas/Content'
        - type: object
          properties:
            header:
              type: string
            body:
              type: string
    ContentMD:
      allOf:
        - $ref: '#/components/schemas/Content'
        - type: object
          properties:
            richText:
              type: string
```
Then `ContentHTML` and `ContentMD` will not be generated as it will be filtered out as well.


This PR therefore proposes to remove the filtering. The downside is that it generates more code, but at at least it would work in more scenarios. What do you think?

In any case, thanks again for this awesome library 👍 