### PR TITLE
Support schemas having properties with an "allOf with single $ref" type (#246)

### DIFF
--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -49,10 +49,10 @@ class ModelGeneratorTest {
         "validationAnnotations",
         "wildCardTypes",
         "singleAllOf",
+        "singleAllOfProperty",
         "responsesSchema",
         "webhook",
         "instantDateTime",
-        "singleAllOf",
         "discriminatedOneOf",
     )
 

--- a/src/test/resources/examples/singleAllOfProperty/api.yaml
+++ b/src/test/resources/examples/singleAllOfProperty/api.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: "Dog API"
+  version: "1"
+
+paths: { }
+
+components:
+  schemas:
+
+    Dog:
+      type: object
+      properties:
+        owner:
+          description: "The registered owner of the dog."
+          allOf:
+            - $ref: "#/components/schemas/Person"
+        walker:
+          description: "The person walking the dog."
+          allOf:
+            - $ref: "#/components/schemas/Person"
+
+    Person:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string

--- a/src/test/resources/examples/singleAllOfProperty/models/Models.kt
+++ b/src/test/resources/examples/singleAllOfProperty/models/Models.kt
@@ -1,0 +1,24 @@
+package examples.singleAllOfProperty.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class Dog(
+    @param:JsonProperty("owner")
+    @get:JsonProperty("owner")
+    @get:Valid
+    public val owner: Person? = null,
+    @param:JsonProperty("walker")
+    @get:JsonProperty("walker")
+    @get:Valid
+    public val walker: Person? = null,
+)
+
+public data class Person(
+    @param:JsonProperty("name")
+    @get:JsonProperty("name")
+    @get:NotNull
+    public val name: String,
+)


### PR DESCRIPTION
Previously, a property with an `allOf` type with a single `$ref` would generate a model property with a type derived from the name of the property instead of the type referenced by $ref. This fixes #246.

This commit implements the first solution mentioned in #246, i.e.

```yaml
    Dog:
      type: object
      properties:
        owner:
          description: "The registered owner of the dog."
          allOf:
            - $ref: "#/components/schemas/Person"
        walker:
          description: "The person walking the dog."
          allOf:
            - $ref: "#/components/schemas/Person"

    Person:
      type: object
      required:
        - name
      properties:
        name:
          type: string
```
will generate data classes where the properties `owner` and `walker` have type `Person` instead of `Owner` and `Walker`.
```kotlin
public data class Dog(
    @param:JsonProperty("owner")
    @get:JsonProperty("owner")
    @get:Valid
    public val owner: Person? = null,
    @param:JsonProperty("walker")
    @get:JsonProperty("walker")
    @get:Valid
    public val walker: Person? = null,
)

public data class Person(
    @param:JsonProperty("name")
    @get:JsonProperty("name")
    @get:NotNull
    public val name: String,
)
```
