### PR TITLE
Move additionalProperties map out of constructor

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -46,11 +46,8 @@ object PropertyUtils {
         val property = PropertySpec.builder(name, wrappedType)
 
         if (this is PropertyInfo.AdditionalProperties) {
-            property.initializer(name)
+            property.initializer("mutableMapOf()")
             property.addAnnotation(JacksonMetadata.ignore)
-            val constructorParameter: ParameterSpec.Builder = ParameterSpec.builder(name, wrappedType)
-            constructorParameter.defaultValue("mutableMapOf()")
-            constructorBuilder.addParameter(constructorParameter.build())
 
             val value =
                 if (typeInfo is KotlinTypeInfo.MapTypeAdditionalProperties) {

--- a/src/test/resources/examples/anyOfOneOfAllOf/models/Models.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/Models.kt
@@ -81,9 +81,10 @@ public data class OneOfAdditionalProps(
     @param:JsonProperty("second_nested_any_of_prop")
     @get:JsonProperty("second_nested_any_of_prop")
     public val secondNestedAnyOfProp: String? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Any> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Any> = properties
 

--- a/src/test/resources/examples/externalReferences/aggressive/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/aggressive/models/Models.kt
@@ -97,9 +97,10 @@ public data class ExternalObjectTwo(
     @get:JsonProperty("list-others")
     @get:Valid
     public val listOthers: List<ExternalObjectThree>? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Map<String, ExternalObjectFour>> = properties
 

--- a/src/test/resources/examples/externalReferences/targeted/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/targeted/models/Models.kt
@@ -71,9 +71,10 @@ public data class ExternalObjectTwo(
     @get:JsonProperty("list-others")
     @get:Valid
     public val listOthers: List<ExternalObjectThree>? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Map<String, ExternalObjectFour>> = properties
 

--- a/src/test/resources/examples/githubApi/models/Models.kt
+++ b/src/test/resources/examples/githubApi/models/Models.kt
@@ -31,9 +31,10 @@ public data class BulkEntityDetails(
     @get:NotNull
     @get:Valid
     public val entities: List<EntityDetails>,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Any> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Any> = properties
 
@@ -120,9 +121,10 @@ public data class EntityDetails(
     @get:JsonProperty("id")
     @get:NotNull
     public val id: String,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Any> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Any> = properties
 
@@ -141,9 +143,10 @@ public data class Event(
     @get:JsonProperty("data")
     @get:NotNull
     public val `data`: Map<String, Any>,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Any> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Any> = properties
 
@@ -160,9 +163,10 @@ public data class EventResults(
     @get:Size(min = 0)
     @get:Valid
     public val changeEvents: List<Event>,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Any> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Any> = properties
 

--- a/src/test/resources/examples/mapExamples/models/Models.kt
+++ b/src/test/resources/examples/mapExamples/models/Models.kt
@@ -36,9 +36,10 @@ public data class ComplexObjectWithRefTypedMap(
     @param:JsonProperty("code")
     @get:JsonProperty("code")
     public val code: Int? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, SomeRef> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, SomeRef> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, SomeRef> = properties
 
@@ -55,9 +56,10 @@ public data class ComplexObjectWithTypedMap(
     @param:JsonProperty("code")
     @get:JsonProperty("code")
     public val code: Int? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, ComplexObjectWithTypedMapValue> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, ComplexObjectWithTypedMapValue> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, ComplexObjectWithTypedMapValue> = properties
 
@@ -83,9 +85,10 @@ public data class ComplexObjectWithUntypedMap(
     @param:JsonProperty("code")
     @get:JsonProperty("code")
     public val code: Int? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Any> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Any> = properties
 
@@ -163,9 +166,10 @@ public data class MapHolder(
     @get:JsonProperty("inlined_complex_object_with_typed_map")
     @get:Valid
     public val inlinedComplexObjectWithTypedMap: MapHolderInlinedComplexObjectWithTypedMap? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Map<String, ExternalObjectFour>> = properties
 
@@ -182,9 +186,10 @@ public data class MapHolderInlinedComplexObjectWithTypedMap(
     @param:JsonProperty("code")
     @get:JsonProperty("code")
     public val code: Int? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, InlinedComplexObjectWithTypedMapValue> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, InlinedComplexObjectWithTypedMapValue> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, InlinedComplexObjectWithTypedMapValue> = properties
 
@@ -201,9 +206,10 @@ public data class MapHolderInlinedComplexObjectWithUntypedMap(
     @param:JsonProperty("code")
     @get:JsonProperty("code")
     public val code: Int? = null,
-    @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
 ) {
+    @get:JsonIgnore
+    public val properties: MutableMap<String, Any> = mutableMapOf()
+
     @JsonAnyGetter
     public fun `get`(): Map<String, Any> = properties
 


### PR DESCRIPTION
Previously, fabrikt would generate a `properties` constructor argument when `additionalProperties` is `true` for an object schema. This would cause construction of such models when deserializing as jackson has no way of setting values in that map.

This pull request moves the map definition out of the constructor into a member, allowing the model to be constructed properly. Additional properties get inserted into and queried from the list using the already existing `@JsonAnySetter` and `@JsonAnyGetter` functions.