### PR TITLE
Support allOf with a single object in combination with nullable

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -127,7 +127,7 @@ class JacksonModelGenerator(
 
                 else -> className
             }
-            return if (isNullable) typeName.copy(nullable = true) else typeName
+            return if (isNullable || typeInfo.nullable) typeName.copy(nullable = true) else typeName
         }
 
         private fun toClassName(basePackage: String, typeInfo: KotlinTypeInfo): ClassName =


### PR DESCRIPTION
This patch adds support for OpenAPI 3.0 style nullable references:

```yaml
foo:
  nullable: true
  allOf:
  - $ref: '#/components/schemas/Foo'
```

by special casing `allOf` with one entry and respecting either the allOfSchema or the "parent" schema being nullable.