### PR TITLE
Supported OpenApi 3.1.0 nullable changes.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
@@ -19,7 +19,7 @@ object YamlUtils {
         ObjectMapper(
             YAMLFactory()
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
-                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES),
         )
             .registerKotlinModule()
             .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
@@ -30,21 +30,48 @@ object YamlUtils {
         internalMapper.writeValueAsString(
             mergeNodes(
                 internalMapper.readTree(mainTree),
-                internalMapper.readTree(updateTree)
-            )
+                internalMapper.readTree(updateTree),
+            ),
         )!!
 
     fun parseOpenApi(input: String, inputDir: Path = Paths.get("").toAbsolutePath()): OpenApi3 =
         try {
-            OpenApi3Parser().parse(input, inputDir.toUri().toURL())
+            val root: JsonNode = objectMapper.readTree(input)
+            if (root["openapi"].asText() == "3.1.0") {
+                downgradeNullableSyntax(root)
+            }
+            OpenApi3Parser().parse(root, inputDir.toUri().toURL())
         } catch (ex: NullPointerException) {
             throw IllegalArgumentException(
                 "The Kaizen openapi-parser library threw a NPE exception when parsing this API. " +
                     "This is commonly due to an external schema reference that is unresolvable, " +
                     "possibly due to a lack of internet connection",
-                ex
+                ex,
             )
         }
+
+    private fun downgradeNullableSyntax(node: JsonNode) {
+        when {
+            node.isObject -> {
+                var requiresNullable = false
+                node.fields().forEach { (key, value) ->
+                    if (key == "type" && value.isArray && value.contains(objectMapper.valueToTree("null"))) {
+                        val nonNullValue = value.first { it.asText() != "null" }
+                        (node as ObjectNode).replace("type", nonNullValue)
+                        requiresNullable = true
+                    }
+                    downgradeNullableSyntax(value)
+                }
+                if (requiresNullable) {
+                    (node as ObjectNode).put("nullable", true)
+                }
+            }
+
+            node.isArray -> {
+                node.forEach { downgradeNullableSyntax(it) }
+            }
+        }
+    }
 
     /**
      * The below merge function has been shamelessly stolen from Stackoverflow: https://stackoverflow.com/a/32447591/1026785
@@ -56,14 +83,20 @@ object YamlUtils {
             val incomingNode = incomingTree.get(fieldName)
             if (currentNode is ArrayNode && incomingNode is ArrayNode) {
                 incomingNode.forEach {
-                    if (currentNode.contains(it)) mergeNodes(
-                        currentNode.get(currentNode.indexOf(it)),
-                        it
-                    )
-                    else currentNode.add(it)
+                    if (currentNode.contains(it)) {
+                        mergeNodes(
+                            currentNode.get(currentNode.indexOf(it)),
+                            it,
+                        )
+                    } else {
+                        currentNode.add(it)
+                    }
                 }
-            } else if (currentNode is ObjectNode) mergeNodes(currentNode, incomingNode)
-            else (currentTree as? ObjectNode)?.replace(fieldName, incomingNode)
+            } else if (currentNode is ObjectNode) {
+                mergeNodes(currentNode, incomingNode)
+            } else {
+                (currentTree as? ObjectNode)?.replace(fieldName, incomingNode)
+            }
         }
         return currentTree
     }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -54,6 +54,7 @@ class ModelGeneratorTest {
         "webhook",
         "instantDateTime",
         "discriminatedOneOf",
+        "openapi310",
     )
 
     @BeforeEach

--- a/src/test/resources/examples/openapi310/api.yaml
+++ b/src/test/resources/examples/openapi310/api.yaml
@@ -1,0 +1,14 @@
+openapi: 3.1.0
+components:
+  schemas:
+    NewNullableFormat:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type:
+            - string
+            - 'null'
+          description: The resolved version or `null` if there is no matching version.
+

--- a/src/test/resources/examples/openapi310/models/Models.kt
+++ b/src/test/resources/examples/openapi310/models/Models.kt
@@ -1,0 +1,12 @@
+package examples.openapi310.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class NewNullableFormat(
+    @param:JsonProperty("version")
+    @get:JsonProperty("version")
+    @get:NotNull
+    public val version: String,
+)


### PR DESCRIPTION
Fabrikt will now detect of the newer 3.1.0 specification is declared and automatically downgrade any of the json schema nullable types to the previous format. EG, this:
```
    NewNullableFormat:
      type: object
      required:
        - version
      properties:
        version:
          type:
            - string
            - 'null'
```
Will get converted to this:
```
    NewNullableFormat:
      type: object
      required:
        - version
      properties:
        version:
          type: string
          nullable: true
```

Related to #262 