### PR TITLE
Add support for nullable keyword.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -189,7 +189,7 @@ object PropertyUtils {
     }
 
     fun PropertyInfo.isNullable() = when (this) {
-        is PropertyInfo.Field -> !isRequired && schema.default == null
+        is PropertyInfo.Field -> !isRequired && schema.default == null || schema.isNullable
         else -> !isRequired
     }
 

--- a/src/test/resources/examples/jsonMergePatch/models/Models.kt
+++ b/src/test/resources/examples/jsonMergePatch/models/Models.kt
@@ -91,7 +91,6 @@ public data class NullabilityCheck(
     public val notNullWithDefaultNotRequired: JsonNullable<String> = JsonNullable.of(""),
     @param:JsonProperty("nullable-with-default-not-required")
     @get:JsonProperty("nullable-with-default-not-required")
-    @get:NotNull
     public val nullableWithDefaultNotRequired: JsonNullable<String?> = JsonNullable.of(""),
     @param:JsonProperty("not-null-no-default-required")
     @get:JsonProperty("not-null-no-default-required")
@@ -99,16 +98,14 @@ public data class NullabilityCheck(
     public val notNullNoDefaultRequired: String,
     @param:JsonProperty("nullable-no-default-required")
     @get:JsonProperty("nullable-no-default-required")
-    @get:NotNull
-    public val nullableNoDefaultRequired: String,
+    public val nullableNoDefaultRequired: String?,
     @param:JsonProperty("not-null-with-default-required")
     @get:JsonProperty("not-null-with-default-required")
     @get:NotNull
     public val notNullWithDefaultRequired: String,
     @param:JsonProperty("nullable-with-default-required")
     @get:JsonProperty("nullable-with-default-required")
-    @get:NotNull
-    public val nullableWithDefaultRequired: String,
+    public val nullableWithDefaultRequired: String?,
 )
 
 public data class TopLevelLevelMergePatchInline(

--- a/src/test/resources/examples/openapi310/models/Models.kt
+++ b/src/test/resources/examples/openapi310/models/Models.kt
@@ -1,12 +1,10 @@
 package examples.openapi310.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
-import javax.validation.constraints.NotNull
 import kotlin.String
 
 public data class NewNullableFormat(
     @param:JsonProperty("version")
     @get:JsonProperty("version")
-    @get:NotNull
-    public val version: String,
+    public val version: String?,
 )

--- a/src/test/resources/examples/optionalVsRequired/api.yaml
+++ b/src/test/resources/examples/optionalVsRequired/api.yaml
@@ -5,9 +5,13 @@ components:
       type: object
       required:
       - name
+      - requiredNullable
       properties:
         name:
           type: string
         gender:
           type: string
           format: uuid
+        requiredNullable:
+          type: string
+          nullable: true

--- a/src/test/resources/examples/optionalVsRequired/models/Models.kt
+++ b/src/test/resources/examples/optionalVsRequired/models/Models.kt
@@ -13,4 +13,7 @@ public data class OptionalVsRequired(
     @param:JsonProperty("gender")
     @get:JsonProperty("gender")
     public val gender: UUID? = null,
+    @param:JsonProperty("requiredNullable")
+    @get:JsonProperty("requiredNullable")
+    public val requiredNullable: String?,
 )


### PR DESCRIPTION
If a required property has its schema flagged as nullable, it is no longer flagged as a non null.