### PR TITLE
Do not strip discriminator property in oneOf generation.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -21,6 +21,7 @@ data class ClassSettings(
         NONE,
         SUPER,
         SUB,
+        ONE_OF,
     }
 }
 
@@ -102,11 +103,16 @@ object PropertyUtils {
                     property.addAnnotation(JacksonMetadata.jacksonPropertyAnnotation(oasKey))
                     property.addValidationAnnotations(this, validationAnnotations)
                 }
+
+                ClassSettings.PolymorphyType.ONE_OF -> {
+                    property.addAnnotation(JacksonMetadata.jacksonPropertyAnnotation(oasKey))
+                    property.addValidationAnnotations(this, validationAnnotations)
+                }
             }
 
             if (isDiscriminatorFieldWithSingleKnownValue(classSettings, schemaName)) {
                 this as PropertyInfo.Field
-                if (classSettings.polymorphyType == ClassSettings.PolymorphyType.SUB) {
+                if (classSettings.polymorphyType in listOf(ClassSettings.PolymorphyType.SUB, ClassSettings.PolymorphyType.ONE_OF)) {
                     property.initializer(name)
                     property.addAnnotation(JacksonMetadata.jacksonParameterAnnotation(oasKey))
                     val constructorParameter: ParameterSpec.Builder = ParameterSpec.builder(name, wrappedType)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -798,14 +798,9 @@ class JacksonModelGenerator(
     private fun List<SchemaInfo>.filterByExternalRefResolutionMode(
         externalReferences: Map.Entry<String, MutableSet<String>>,
     ) = when (externalRefResolutionMode) {
-        ExternalReferencesResolutionMode.TARGETED -> this.filter { apiSchema ->
-            externalReferences.value.contains(
-                apiSchema.name
-            )
+            ExternalReferencesResolutionMode.TARGETED -> this.filter { apiSchema -> externalReferences.value.contains(apiSchema.name) }
+            else -> this
         }
-
-        else -> this
-    }
 }
 
 private val Map<String, Any>.hasJsonMergePatchExtension

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -76,6 +76,9 @@ class ModelGeneratorTest {
         if (testCaseName == "instantDateTime") {
             MutableSettings.addOption(CodeGenTypeOverride.DATETIME_AS_INSTANT)
         }
+        if (testCaseName == "discriminatedOneOf") {
+            MutableSettings.addOption(ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_OF)
+        }
         val basePackage = "examples.${testCaseName.replace("/", ".")}"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -65,8 +65,8 @@ class ModelGeneratorTest {
         ModelNameRegistry.clear()
     }
 
-    @Test
-    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("discriminatedOneOf")
+    // @Test
+    // fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("insert test case")
 
     @ParameterizedTest
     @MethodSource("testCases")

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -65,8 +65,8 @@ class ModelGeneratorTest {
         ModelNameRegistry.clear()
     }
 
-    // @Test
-    // fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("insert test case")
+    @Test
+    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("discriminatedOneOf")
 
     @ParameterizedTest
     @MethodSource("testCases")

--- a/src/test/resources/examples/discriminatedOneOf/models/Models.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/Models.kt
@@ -33,9 +33,19 @@ public data class SomeObj(
 )
 public sealed interface State
 
-public object StateA : State
+public data class StateA(
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    public val status: Status,
+) : State
 
-public object StateB : State
+public data class StateB(
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    public val status: Status,
+) : State
 
 public enum class Status(
     @JsonValue

--- a/src/test/resources/examples/discriminatedOneOf/models/Models.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/Models.kt
@@ -34,17 +34,17 @@ public data class SomeObj(
 public sealed interface State
 
 public data class StateA(
-    @param:JsonProperty("status")
     @get:JsonProperty("status")
     @get:NotNull
-    public val status: Status,
+    @param:JsonProperty("status")
+    public val status: Status = Status.A,
 ) : State
 
 public data class StateB(
-    @param:JsonProperty("status")
     @get:JsonProperty("status")
     @get:NotNull
-    public val status: Status,
+    @param:JsonProperty("status")
+    public val status: Status = Status.B,
 ) : State
 
 public enum class Status(


### PR DESCRIPTION
As per title and Issue #258 it does not seem correct to be stripping a declared property from the data classes.

Instead, adopt the same approach as allOf polymorphism and default the discriminator to the correct value