### PR TITLE
Fix inline schema definitions inherited from a parent.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -318,7 +318,7 @@ class JacksonModelGenerator(
                     }
 
                 is PropertyInfo.Field ->
-                    if (it.typeInfo is KotlinTypeInfo.Enum) {
+                    if (it.typeInfo is KotlinTypeInfo.Enum && !it.isInherited) {
                         setOf(buildEnumClass(it.typeInfo as KotlinTypeInfo.Enum))
                     } else {
                         emptySet()

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -186,7 +186,11 @@ sealed class PropertyInfo {
         val enclosingSchema: Schema?
     ) : PropertyInfo(), CollectionValidation {
         override val typeInfo: KotlinTypeInfo =
-            KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toEnclosingSchemaInfo())
+            if (isInherited) {
+                KotlinTypeInfo.from(schema, oasKey, parentSchema.toEnclosingSchemaInfo())
+            } else {
+                KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toEnclosingSchemaInfo())
+            }
         override val minItems: Int? = schema.minItems
         override val maxItems: Int? = schema.maxItems
     }
@@ -220,7 +224,11 @@ sealed class PropertyInfo {
         val enclosingSchema: Schema?
     ) : PropertyInfo() {
         override val typeInfo: KotlinTypeInfo =
-            KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toEnclosingSchemaInfo())
+            if (isInherited) {
+                KotlinTypeInfo.from(schema, oasKey, parentSchema.toEnclosingSchemaInfo())
+            } else {
+                KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toEnclosingSchemaInfo())
+            }
     }
 
     data class AdditionalProperties(

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
@@ -17,6 +17,18 @@ components:
       properties:
         some_enum:
           $ref: '#/components/schemas/ChildDiscriminator'
+        inline_obj:
+          type: object
+          properties:
+            str:
+              type: string
+        inline_array:
+          type: array
+          items:
+            type: object
+            properties:
+              str:
+                type: string
 
     ChildDiscriminator:
       type: string

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/api.yaml
@@ -29,6 +29,12 @@ components:
             properties:
               str:
                 type: string
+        inline_enum:
+          type: string
+          enum:
+            - one
+            - two
+            - three
 
     ChildDiscriminator:
       type: string

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
@@ -34,9 +34,24 @@ import kotlin.collections.Map
     ),
     JsonSubTypes.Type(value = DiscriminatedChild3::class, name = "obj_three"),
 )
-public sealed class ChildDefinition() {
+public sealed class ChildDefinition(
+    public open val inlineObj: ChildDefinitionInlineObj? = null,
+    public open val inlineArray: List<ChildDefinitionInlineArray>? = null,
+) {
     public abstract val someEnum: ChildDiscriminator
 }
+
+public data class ChildDefinitionInlineArray(
+    @param:JsonProperty("str")
+    @get:JsonProperty("str")
+    public val str: String? = null,
+)
+
+public data class ChildDefinitionInlineObj(
+    @param:JsonProperty("str")
+    @get:JsonProperty("str")
+    public val str: String? = null,
+)
 
 public enum class ChildDiscriminator(
     @JsonValue
@@ -57,6 +72,14 @@ public enum class ChildDiscriminator(
 }
 
 public data class DiscriminatedChild1(
+    @param:JsonProperty("inline_obj")
+    @get:JsonProperty("inline_obj")
+    @get:Valid
+    override val inlineObj: ChildDefinitionInlineObj? = null,
+    @param:JsonProperty("inline_array")
+    @get:JsonProperty("inline_array")
+    @get:Valid
+    override val inlineArray: List<ChildDefinitionInlineArray>? = null,
     @param:JsonProperty("some_prop")
     @get:JsonProperty("some_prop")
     public val someProp: String? = null,
@@ -64,23 +87,39 @@ public data class DiscriminatedChild1(
     @get:NotNull
     @param:JsonProperty("some_enum")
     override val someEnum: ChildDiscriminator = ChildDiscriminator.OBJ_ONE_ONLY,
-) : ChildDefinition()
+) : ChildDefinition(inlineObj, inlineArray)
 
 public data class DiscriminatedChild2(
     @get:JsonProperty("some_enum")
     @get:NotNull
     override val someEnum: ChildDiscriminator,
+    @param:JsonProperty("inline_obj")
+    @get:JsonProperty("inline_obj")
+    @get:Valid
+    override val inlineObj: ChildDefinitionInlineObj? = null,
+    @param:JsonProperty("inline_array")
+    @get:JsonProperty("inline_array")
+    @get:Valid
+    override val inlineArray: List<ChildDefinitionInlineArray>? = null,
     @param:JsonProperty("some_prop")
     @get:JsonProperty("some_prop")
     public val someProp: String? = null,
-) : ChildDefinition()
+) : ChildDefinition(inlineObj, inlineArray)
 
 public data class DiscriminatedChild3(
+    @param:JsonProperty("inline_obj")
+    @get:JsonProperty("inline_obj")
+    @get:Valid
+    override val inlineObj: ChildDefinitionInlineObj? = null,
+    @param:JsonProperty("inline_array")
+    @get:JsonProperty("inline_array")
+    @get:Valid
+    override val inlineArray: List<ChildDefinitionInlineArray>? = null,
     @get:JsonProperty("some_enum")
     @get:NotNull
     @param:JsonProperty("some_enum")
     override val someEnum: ChildDiscriminator = ChildDiscriminator.OBJ_THREE,
-) : ChildDefinition()
+) : ChildDefinition(inlineObj, inlineArray)
 
 public data class Responses(
     @param:JsonProperty("entries")

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/models/Models.kt
@@ -37,6 +37,7 @@ import kotlin.collections.Map
 public sealed class ChildDefinition(
     public open val inlineObj: ChildDefinitionInlineObj? = null,
     public open val inlineArray: List<ChildDefinitionInlineArray>? = null,
+    public open val inlineEnum: ChildDefinitionInlineEnum? = null,
 ) {
     public abstract val someEnum: ChildDiscriminator
 }
@@ -46,6 +47,23 @@ public data class ChildDefinitionInlineArray(
     @get:JsonProperty("str")
     public val str: String? = null,
 )
+
+public enum class ChildDefinitionInlineEnum(
+    @JsonValue
+    public val `value`: String,
+) {
+    ONE("one"),
+    TWO("two"),
+    THREE("three"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, ChildDefinitionInlineEnum> =
+            values().associateBy(ChildDefinitionInlineEnum::value)
+
+        public fun fromValue(`value`: String): ChildDefinitionInlineEnum? = mapping[value]
+    }
+}
 
 public data class ChildDefinitionInlineObj(
     @param:JsonProperty("str")
@@ -80,6 +98,9 @@ public data class DiscriminatedChild1(
     @get:JsonProperty("inline_array")
     @get:Valid
     override val inlineArray: List<ChildDefinitionInlineArray>? = null,
+    @param:JsonProperty("inline_enum")
+    @get:JsonProperty("inline_enum")
+    override val inlineEnum: ChildDefinitionInlineEnum? = null,
     @param:JsonProperty("some_prop")
     @get:JsonProperty("some_prop")
     public val someProp: String? = null,
@@ -87,7 +108,7 @@ public data class DiscriminatedChild1(
     @get:NotNull
     @param:JsonProperty("some_enum")
     override val someEnum: ChildDiscriminator = ChildDiscriminator.OBJ_ONE_ONLY,
-) : ChildDefinition(inlineObj, inlineArray)
+) : ChildDefinition(inlineObj, inlineArray, inlineEnum)
 
 public data class DiscriminatedChild2(
     @get:JsonProperty("some_enum")
@@ -101,10 +122,13 @@ public data class DiscriminatedChild2(
     @get:JsonProperty("inline_array")
     @get:Valid
     override val inlineArray: List<ChildDefinitionInlineArray>? = null,
+    @param:JsonProperty("inline_enum")
+    @get:JsonProperty("inline_enum")
+    override val inlineEnum: ChildDefinitionInlineEnum? = null,
     @param:JsonProperty("some_prop")
     @get:JsonProperty("some_prop")
     public val someProp: String? = null,
-) : ChildDefinition(inlineObj, inlineArray)
+) : ChildDefinition(inlineObj, inlineArray, inlineEnum)
 
 public data class DiscriminatedChild3(
     @param:JsonProperty("inline_obj")
@@ -115,11 +139,14 @@ public data class DiscriminatedChild3(
     @get:JsonProperty("inline_array")
     @get:Valid
     override val inlineArray: List<ChildDefinitionInlineArray>? = null,
+    @param:JsonProperty("inline_enum")
+    @get:JsonProperty("inline_enum")
+    override val inlineEnum: ChildDefinitionInlineEnum? = null,
     @get:JsonProperty("some_enum")
     @get:NotNull
     @param:JsonProperty("some_enum")
     override val someEnum: ChildDiscriminator = ChildDiscriminator.OBJ_THREE,
-) : ChildDefinition(inlineObj, inlineArray)
+) : ChildDefinition(inlineObj, inlineArray, inlineEnum)
 
 public data class Responses(
     @param:JsonProperty("entries")


### PR DESCRIPTION
When an inline schema is inherited, the child should reference the parent definition, and not build ain incompatible child version