### PR TITLE
Issue with default value for additional property (oneOf)

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -154,7 +154,8 @@ object KaizenParserExtensions {
     fun Schema.isDiscriminatorProperty(api: OpenApi3, prop: Map.Entry<String, Schema>): Boolean =
         discriminator?.propertyName == prop.key ||
             findOneOfSuperInterface(api.schemas.values.toList()).any { oneOf ->
-                oneOf.discriminator?.mappings?.values?.any { it.endsWith("/$name") } ?: false
+                oneOf.discriminator?.propertyName == prop.key
+                        && oneOf.discriminator?.mappings?.values?.any { it.endsWith("/$name") } ?: false
             }
 
     fun Schema.findOneOfSuperInterface(allSchemas: List<Schema>): Set<Schema> {

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -35,6 +35,12 @@ components:
       type: object
       required:
         - status
+        - mode
       properties:
         status:
           $ref: '#/components/schemas/Status'
+        mode:
+          type: string
+          enum:
+            - mode1
+            - mode2

--- a/src/test/resources/examples/discriminatedOneOf/models/Models.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/Models.kt
@@ -41,11 +41,29 @@ public data class StateA(
 ) : State
 
 public data class StateB(
+    @get:JsonProperty("mode")
+    @get:NotNull
+    public val mode: StateBMode,
     @get:JsonProperty("status")
     @get:NotNull
     @param:JsonProperty("status")
     public val status: Status = Status.B,
 ) : State
+
+public enum class StateBMode(
+    @JsonValue
+    public val `value`: String,
+) {
+    MODE1("mode1"),
+    MODE2("mode2"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, StateBMode> = values().associateBy(StateBMode::value)
+
+        public fun fromValue(`value`: String): StateBMode? = mapping[value]
+    }
+}
 
 public enum class Status(
     @JsonValue


### PR DESCRIPTION
After #268 was merged it seems like additional properties in the generated model has an incorrect default value.

The test for discriminatedOneOf illustrates the issue: StateBMode has it's default value set to a non existent enum value - which looks like the value of the discriminator field.

<img width="1289" alt="Screenshot 2024-03-06 at 14 42 29" src="https://github.com/cjbooms/fabrikt/assets/11440456/c1d8ea3e-8835-41a8-b265-e47513ea0ee5">

~~I would love to assist with a fix, but I am simply not familiar enough with the codebase to be able to identify where to start.~~

I have taken my best shot at fixing the issue. Let me know what you think.

I notice that the ordering of properties in the model is different from the order in the spec, but perhaps that's intentional?