### PR TITLE
Support adding marker interface to oneOfs.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -258,6 +258,9 @@ object KaizenParserExtensions {
         oneOfSchemas.isNotEmpty() && allOfSchemas.isEmpty() && anyOfSchemas.isEmpty() && properties.isEmpty() &&
             oneOfSchemas.all { it.isObjectType() }
 
+    fun Schema.isOneOfSuperInterfaceWithDiscriminator() =
+        discriminator != null && discriminator.propertyName != null && isOneOfSuperInterface()
+
     private fun Schema.isInlinedAggregationOfExactlyOne() =
         combinedAnyOfAndAllOfSchemas().size == 1 && isInlinedPropertySchema()
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -163,23 +163,9 @@ object KaizenParserExtensions {
             return emptySet()
         }
         return allSchemas
-            .filter { it.discriminator != null && it.oneOfSchemas.isNotEmpty() }
+            .filter { it.oneOfSchemas.isNotEmpty() }
             .mapNotNull { schema ->
-                schema.discriminator.mappings
-                    .toList()
-                    .find { (_, ref) ->
-                        ref.endsWith("/${name}")
-                    }
-                    ?.let { (key, _) ->
-                        Pair(key!!, schema)
-                    }
-            }
-            .map { (_, parent) ->
-                val field = parent.discriminator.propertyName!!
-                if (!properties.containsKey(field)) {
-                    throw IllegalArgumentException("schema $name did not have discriminator property")
-                }
-                parent
+                if (schema.oneOfSchemas.toList().contains(this)) schema else null
             }
             .toSet()
     }
@@ -269,7 +255,8 @@ object KaizenParserExtensions {
         this.oneOfSchemas?.firstOrNull()?.allOfSchemas?.firstOrNull() != null
 
     fun Schema.isOneOfSuperInterface() =
-        discriminator != null && discriminator.propertyName != null && oneOfSchemas.isNotEmpty()
+        oneOfSchemas.isNotEmpty() && allOfSchemas.isEmpty() && anyOfSchemas.isEmpty() && properties.isEmpty() &&
+            oneOfSchemas.all { it.isObjectType() }
 
     private fun Schema.isInlinedAggregationOfExactlyOne() =
         combinedAnyOfAndAllOfSchemas().size == 1 && isInlinedPropertySchema()

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -56,6 +56,7 @@ class ModelGeneratorTest {
         "discriminatedOneOf",
         "openapi310",
         "binary",
+        "oneOfMarkerInterface",
     )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -67,8 +67,8 @@ class ModelGeneratorTest {
         ModelNameRegistry.clear()
     }
 
-    // @Test
-    // fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("insert test case")
+    @Test
+    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("oneOfMarkerInterface")
 
     @ParameterizedTest
     @MethodSource("testCases")
@@ -79,7 +79,7 @@ class ModelGeneratorTest {
         if (testCaseName == "instantDateTime") {
             MutableSettings.addOption(CodeGenTypeOverride.DATETIME_AS_INSTANT)
         }
-        if (testCaseName == "discriminatedOneOf") {
+        if (testCaseName == "discriminatedOneOf" || testCaseName == "oneOfMarkerInterface") {
             MutableSettings.addOption(ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_OF)
         }
         val basePackage = "examples.${testCaseName.replace("/", ".")}"

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -67,8 +67,8 @@ class ModelGeneratorTest {
         ModelNameRegistry.clear()
     }
 
-    @Test
-    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("oneOfMarkerInterface")
+    // @Test
+    // fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("insert test case")
 
     @ParameterizedTest
     @MethodSource("testCases")

--- a/src/test/resources/examples/oneOfMarkerInterface/api.yaml
+++ b/src/test/resources/examples/oneOfMarkerInterface/api.yaml
@@ -3,6 +3,11 @@ info:
 paths:
 components:
   schemas:
+    Container:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/State'
 
     State:
       oneOf:

--- a/src/test/resources/examples/oneOfMarkerInterface/api.yaml
+++ b/src/test/resources/examples/oneOfMarkerInterface/api.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+paths:
+components:
+  schemas:
+
+    State:
+      oneOf:
+        - $ref: '#/components/schemas/StateA'
+        - $ref: '#/components/schemas/StateB'
+
+    StateA:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+    StateB:
+      type: object
+      required:
+        - mode
+      properties:
+        mode:
+          type: string

--- a/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
+++ b/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
@@ -7,14 +7,12 @@ import kotlin.String
 public sealed interface State
 
 public data class StateA(
-    @param:JsonProperty("status")
     @get:JsonProperty("status")
     @get:NotNull
     public val status: String,
 ) : State
 
 public data class StateB(
-    @param:JsonProperty("mode")
     @get:JsonProperty("mode")
     @get:NotNull
     public val mode: String,

--- a/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
+++ b/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
@@ -1,0 +1,21 @@
+package examples.oneOfMarkerInterface.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public sealed interface State
+
+public data class StateA(
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    public val status: String,
+) : State
+
+public data class StateB(
+    @param:JsonProperty("mode")
+    @get:JsonProperty("mode")
+    @get:NotNull
+    public val mode: String,
+) : State

--- a/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
+++ b/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
@@ -1,15 +1,14 @@
 package examples.oneOfMarkerInterface.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
-import javax.validation.Valid
 import javax.validation.constraints.NotNull
+import kotlin.Any
 import kotlin.String
 
 public data class Container(
     @param:JsonProperty("state")
     @get:JsonProperty("state")
-    @get:Valid
-    public val state: State? = null,
+    public val state: Any? = null,
 )
 
 public sealed interface State

--- a/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
+++ b/src/test/resources/examples/oneOfMarkerInterface/models/Models.kt
@@ -1,8 +1,16 @@
 package examples.oneOfMarkerInterface.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.String
+
+public data class Container(
+    @param:JsonProperty("state")
+    @get:JsonProperty("state")
+    @get:Valid
+    public val state: State? = null,
+)
 
 public sealed interface State
 


### PR DESCRIPTION
While the discriminator property is needed to enable full polymorphism with Jackson, it should not be a blocker to  applying the sealed interface to classes that deserve it.

This PR allows the interface to be applied, without the Jackson polymorphism annotations:

```
public sealed interface State

public data class StateA(
    @get:JsonProperty("status")
    @get:NotNull
    public val status: String,
) : State

public data class StateB(
    @get:JsonProperty("mode")
    @get:NotNull
    public val mode: String,
) : State
```
Jackson won't be able to figure out which object to deserialise to, but it is beneficial to have the marker interface in code