### PR TITLE
Move mutable settings out of constructor parameters in the generators…

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -62,10 +62,10 @@ class CodeGenerator(
     private fun resourceSet(resFiles: Collection<ResourceFile>) = setOf(ResourceSourceSet(resFiles, resourcesPath))
 
     private fun models(): Models =
-        JacksonModelGenerator(packages, sourceApi, MutableSettings.modelOptions(), MutableSettings.validationLibrary().annotations, MutableSettings.externalRefResolutionMode()).generate()
+        JacksonModelGenerator(packages, sourceApi).generate()
 
     private fun resources(models: Models): List<ResourceFile> =
-        listOfNotNull(QuarkusReflectionModelGenerator(models, MutableSettings.generationTypes()).generate())
+        listOfNotNull(QuarkusReflectionModelGenerator(models).generate())
 
     private fun controllers(): KotlinTypes {
         val generator =

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -6,7 +6,7 @@ import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.ClassSettings
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
-import com.cjbooms.fabrikt.generators.JavaxValidationAnnotations
+import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.generators.PropertyUtils.addToClass
 import com.cjbooms.fabrikt.generators.PropertyUtils.isNullable
 import com.cjbooms.fabrikt.generators.TypeFactory.createList
@@ -69,10 +69,10 @@ import java.net.URL
 class JacksonModelGenerator(
     private val packages: Packages,
     private val sourceApi: SourceApi,
-    private val options: Set<ModelCodeGenOptionType> = emptySet(),
-    private val validationAnnotations: ValidationAnnotations = JavaxValidationAnnotations,
-    private val externalRefResolutionMode: ExternalReferencesResolutionMode = ExternalReferencesResolutionMode.TARGETED,
 ) {
+    private val options = MutableSettings.modelOptions()
+    private val validationAnnotations: ValidationAnnotations = MutableSettings.validationLibrary().annotations
+    private val externalRefResolutionMode: ExternalReferencesResolutionMode = MutableSettings.externalRefResolutionMode()
     companion object {
         fun toModelType(basePackage: String, typeInfo: KotlinTypeInfo, isNullable: Boolean = false): TypeName {
             val className =

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/QuarkusReflectionModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/QuarkusReflectionModelGenerator.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.generators.model
 
 import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.model.Models
 import com.cjbooms.fabrikt.model.QuarkusReflectionModel
 import com.cjbooms.fabrikt.model.ResourceFile
@@ -10,8 +11,8 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 class QuarkusReflectionModelGenerator(
     private val models: Models,
-    private val generationTypes: Set<CodeGenerationType> = emptySet()
 ) {
+    private val generationTypes: Set<CodeGenerationType> = MutableSettings.generationTypes()
     companion object {
         const val RESOURCE_FILE_NAME = "reflection-config.json"
     }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -73,6 +73,7 @@ class ModelGeneratorTest {
     @MethodSource("testCases")
     fun `correct models are generated for different OpenApi Specifications`(testCaseName: String) {
         print("Testcase: $testCaseName")
+        MutableSettings.updateSettings()
         MutableSettings.addOption(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS)
         if (testCaseName == "instantDateTime") {
             MutableSettings.addOption(CodeGenTypeOverride.DATETIME_AS_INSTANT)
@@ -88,7 +89,6 @@ class ModelGeneratorTest {
         val models = JacksonModelGenerator(
             Packages(basePackage),
             sourceApi,
-            setOf(ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_OF),
         ).generate().toSingleFile()
 
         assertThat(models).isEqualTo(expectedModels)
@@ -99,11 +99,13 @@ class ModelGeneratorTest {
         val basePackage = "examples.jakartaValidationAnnotations"
         val spec = readTextResource("/examples/jakartaValidationAnnotations/api.yaml")
         val expectedJakartaModel = readTextResource("/examples/jakartaValidationAnnotations/models/Models.kt")
-        MutableSettings.updateSettings(genTypes = setOf(CodeGenerationType.HTTP_MODELS))
+        MutableSettings.updateSettings(
+            genTypes = setOf(CodeGenerationType.HTTP_MODELS),
+            validationLibrary = ValidationLibrary.JAKARTA_VALIDATION
+        )
         val models = JacksonModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
-            validationAnnotations = ValidationLibrary.JAKARTA_VALIDATION.annotations,
         ).generate()
 
         assertThat(models.files.size).isEqualTo(4)
@@ -131,11 +133,12 @@ class ModelGeneratorTest {
         val basePackage = "examples.javaSerializableModels"
         val spec = readTextResource("/examples/javaSerializableModels/api.yaml")
         val expectedModels = readTextResource("/examples/javaSerializableModels/models/Models.kt")
-
+        MutableSettings.updateSettings(
+            modelOptions = setOf(ModelCodeGenOptionType.JAVA_SERIALIZATION),
+        )
         val models = JacksonModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
-            setOf(ModelCodeGenOptionType.JAVA_SERIALIZATION),
         )
             .generate()
             .toSingleFile()
@@ -188,11 +191,13 @@ class ModelGeneratorTest {
         val basePackage = "examples.quarkusReflectionModels"
         val spec = readTextResource("/examples/quarkusReflectionModels/api.yaml")
         val expectedModels = readTextResource("/examples/quarkusReflectionModels/models/Models.kt")
+        MutableSettings.updateSettings(
+            modelOptions = setOf(ModelCodeGenOptionType.QUARKUS_REFLECTION),
+        )
 
         val models = JacksonModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
-            setOf(ModelCodeGenOptionType.QUARKUS_REFLECTION),
         )
             .generate()
             .toSingleFile()
@@ -205,11 +210,13 @@ class ModelGeneratorTest {
         val basePackage = "examples.micronautIntrospectedModels"
         val spec = readTextResource("/examples/micronautIntrospectedModels/api.yaml")
         val expectedModels = readTextResource("/examples/micronautIntrospectedModels/models/Models.kt")
+        MutableSettings.updateSettings(
+            modelOptions = setOf(ModelCodeGenOptionType.MICRONAUT_INTROSPECTION),
+        )
 
         val models = JacksonModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
-            setOf(ModelCodeGenOptionType.MICRONAUT_INTROSPECTION),
         )
             .generate()
             .toSingleFile()
@@ -222,11 +229,13 @@ class ModelGeneratorTest {
         val basePackage = "examples.micronautReflectionModels"
         val spec = readTextResource("/examples/micronautReflectionModels/api.yaml")
         val expectedModels = readTextResource("/examples/micronautReflectionModels/models/Models.kt")
+        MutableSettings.updateSettings(
+            modelOptions = setOf(ModelCodeGenOptionType.MICRONAUT_REFLECTION),
+        )
 
         val models = JacksonModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
-            setOf(ModelCodeGenOptionType.MICRONAUT_REFLECTION),
         )
             .generate()
             .toSingleFile()
@@ -239,11 +248,13 @@ class ModelGeneratorTest {
         val basePackage = "examples.companionObject"
         val spec = readTextResource("/examples/companionObject/api.yaml")
         val expectedModels = readTextResource("/examples/companionObject/models/Models.kt")
+        MutableSettings.updateSettings(
+            modelOptions = setOf(ModelCodeGenOptionType.INCLUDE_COMPANION_OBJECT),
+        )
 
         val models = JacksonModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
-            setOf(ModelCodeGenOptionType.INCLUDE_COMPANION_OBJECT),
         )
             .generate()
             .toSingleFile()

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -138,11 +138,13 @@ class OkHttpClientGeneratorTest {
         val expectedModel = readTextResource("/examples/externalReferences/aggressive/models/Models.kt")
         val expectedClient = readTextResource("/examples/externalReferences/aggressive/client/ApiClient.kt")
         val expectedClientCode = readTextResource("/examples/externalReferences/aggressive/client/ApiService.kt")
+        MutableSettings.updateSettings(
+            externalRefResolutionMode = ExternalReferencesResolutionMode.AGGRESSIVE,
+        )
 
         val models = JacksonModelGenerator(
             packages,
             sourceApi,
-            externalRefResolutionMode = ExternalReferencesResolutionMode.AGGRESSIVE
         ).generate().toSingleFile()
         val generator =
             OkHttpEnhancedClientGenerator(packages, sourceApi)

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
@@ -39,11 +39,13 @@ class ResourceGeneratorTest {
         val sourceApi = SourceApi(apiLocation!!.readText(), baseDir = Paths.get(apiLocation.toURI()))
         val expectedResource =
             javaClass.getResource("/examples/$testCaseName/resources/reflection-config.json")!!.readText()
-        val generationTypes = setOf(CodeGenerationType.QUARKUS_REFLECTION_CONFIG)
+        MutableSettings.updateSettings(
+            genTypes = setOf(CodeGenerationType.QUARKUS_REFLECTION_CONFIG),
+        )
 
-        val models = JacksonModelGenerator(Packages(basePackage), sourceApi, emptySet()).generate()
+        val models = JacksonModelGenerator(Packages(basePackage), sourceApi).generate()
 
-        val resources = QuarkusReflectionModelGenerator(models, generationTypes).generate()?.toSingleFile()
+        val resources = QuarkusReflectionModelGenerator(models).generate()?.toSingleFile()
 
         assertThat(resources).isEqualTo(expectedResource)
     }


### PR DESCRIPTION
…. Most of the time these are accessed in multiple locations, so having them overridden in the generators leads to inconsistent behaviour