### PR TITLE
Add an extension to allow the JsonInclude annotation to be added to a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This library was built to take advantage of the complex modeling features availa
  - Maps of Maps of Maps
  - GraalVM Native Reflection Registration
  - Json Merge Patch (via `JsonNullable`) (add `x-json-merge-patch: true` to schemas)
+ - Override Jackson Include NonNull (via `JsonInclude`) (add `x-jackson-include-non-null: true` to schemas)
 
 More than just bootstrapping, this library can be permanently integrated into a gradle or maven build and will ensure contract and code always match, even as APIs evolve in complexity. 
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
@@ -17,8 +17,14 @@ object JacksonMetadata {
     private val JSON_ANY_SETTER = ClassName("com.fasterxml.jackson.annotation", "JsonAnySetter")
     private val JSON_ANY_GETTER = ClassName("com.fasterxml.jackson.annotation", "JsonAnyGetter")
     private val JSON_IGNORE = ClassName("com.fasterxml.jackson.annotation", "JsonIgnore")
+    private val JSON_INCLUDE_CLASS = ClassName("com.fasterxml.jackson.annotation", "JsonInclude")
 
     val JSON_VALUE = AnnotationSpec.builder(JSON_VALUE_CLASS).build()
+    val JSON_INCLUDE = AnnotationSpec
+        .builder(JSON_INCLUDE_CLASS)
+        .useSiteTarget(AnnotationSpec.UseSiteTarget.PARAM)
+        .addMember("%T.Include.NON_NULL", JSON_INCLUDE_CLASS)
+        .build()
 
     fun jacksonPropertyAnnotation(name: String) = AnnotationSpec
         .builder(JSON_PROPERTY_CLASS)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -469,13 +469,13 @@ class JacksonModelGenerator(
                 properties.addToClass(
                     schemaName = schemaName,
                     classBuilder = classBuilder,
-                    classType = ClassSettings(ClassSettings.PolymorphyType.ONE_OF, extensions.hasJsonMergePatchExtension),
+                    classType = ClassSettings(ClassSettings.PolymorphyType.ONE_OF, extensions),
                 )
             } else {
                 properties.addToClass(
                     schemaName = schemaName,
                     classBuilder = classBuilder,
-                    classType = ClassSettings(ClassSettings.PolymorphyType.NONE, extensions.hasJsonMergePatchExtension),
+                    classType = ClassSettings(ClassSettings.PolymorphyType.NONE, extensions),
                 )
             }
         }
@@ -619,7 +619,7 @@ class JacksonModelGenerator(
             schemaName,
             constructorBuilder,
             this,
-            ClassSettings(ClassSettings.PolymorphyType.SUPER, extensions.hasJsonMergePatchExtension),
+            ClassSettings(ClassSettings.PolymorphyType.SUPER, extensions),
         )
 
         return this
@@ -671,7 +671,7 @@ class JacksonModelGenerator(
             schemaName,
             constructorBuilder,
             this,
-            ClassSettings(ClassSettings.PolymorphyType.SUB, extensions.hasJsonMergePatchExtension),
+            ClassSettings(ClassSettings.PolymorphyType.SUB, extensions),
         )
         return this
     }
@@ -783,6 +783,3 @@ class JacksonModelGenerator(
             else -> this
         }
 }
-
-private val Map<String, Any>.hasJsonMergePatchExtension
-    get() = this.containsKey("x-json-merge-patch")

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -38,7 +38,7 @@ class ModelGeneratorTest {
         "externalReferences/targeted",
         "githubApi",
         "inLinedObject",
-        "jsonMergePatch",
+        "customExtensions",
         "mapExamples",
         "mixingCamelSnakeLispCase",
         "oneOfPolymorphicModels",

--- a/src/test/resources/examples/customExtensions/api.yaml
+++ b/src/test/resources/examples/customExtensions/api.yaml
@@ -5,6 +5,25 @@ info:
   version: ""
 components:
   schemas:
+    ParentWithIncludeNonNullExtension:
+      x-jackson-include-non-null: true
+      type: object
+      required:
+        - simpleRequired
+      properties:
+        simpleNullable:
+          nullable: true
+          type: string
+        simpleRequired:
+          type: string
+        childWithout:
+          x-jackson-include-non-null: false
+          type: object
+          properties:
+            direct:
+              type: string
+
+
     NoMergePatchInline:
       type: object
       properties:

--- a/src/test/resources/examples/customExtensions/models/Models.kt
+++ b/src/test/resources/examples/customExtensions/models/Models.kt
@@ -1,5 +1,6 @@
-package examples.jsonMergePatch.models
+package examples.customExtensions.models
 
+import com.fasterxml.jackson.`annotation`.JsonInclude
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import org.openapitools.jackson.nullable.JsonNullable
 import javax.validation.Valid
@@ -106,6 +107,28 @@ public data class NullabilityCheck(
     @param:JsonProperty("nullable-with-default-required")
     @get:JsonProperty("nullable-with-default-required")
     public val nullableWithDefaultRequired: String?,
+)
+
+public data class ParentWithIncludeNonNullExtension(
+    @param:JsonProperty("simpleNullable")
+    @get:JsonProperty("simpleNullable")
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
+    public val simpleNullable: String? = null,
+    @param:JsonProperty("simpleRequired")
+    @get:JsonProperty("simpleRequired")
+    @get:NotNull
+    public val simpleRequired: String,
+    @param:JsonProperty("childWithout")
+    @get:JsonProperty("childWithout")
+    @get:Valid
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
+    public val childWithout: ParentWithIncludeNonNullExtensionChildWithout? = null,
+)
+
+public data class ParentWithIncludeNonNullExtensionChildWithout(
+    @param:JsonProperty("direct")
+    @get:JsonProperty("direct")
+    public val direct: String? = null,
 )
 
 public data class TopLevelLevelMergePatchInline(


### PR DESCRIPTION
This will allow the global Jackson include settings to be overridden on a class by class basis.