### PR TITLE
Map values should be nullable.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -59,10 +59,11 @@ object PropertyUtils {
 
             val value =
                 if (typeInfo is KotlinTypeInfo.MapTypeAdditionalProperties) {
-                    Map::class.asTypeName().parameterizedBy(String::class.asTypeName(), parameterizedType)
+                    Map::class.asTypeName()
+                        .parameterizedBy(String::class.asTypeName(), parameterizedType.copy(nullable = true))
                 } else {
                     parameterizedType
-                }
+                }.copy(nullable = true)
             classBuilder.addFunction(
                 FunSpec.builder("get")
                     .returns(Map::class.asTypeName().parameterizedBy(String::class.asTypeName(), value))

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/TypeFactory.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/TypeFactory.kt
@@ -13,8 +13,8 @@ object TypeFactory {
             String::class.asTypeName(),
             Map::class.asTypeName().parameterizedBy(
                 String::class.asTypeName(),
-                Any::class.asTypeName()
-            )
+                Any::class.asTypeName().copy(nullable = true)
+            ).copy(nullable = true)
         )
 
     fun createMutableMapOfMapsStringToStringType(type: TypeName) =
@@ -22,17 +22,22 @@ object TypeFactory {
             String::class.asTypeName(),
             Map::class.asTypeName().parameterizedBy(
                 String::class.asTypeName(),
-                type
-            )
+                type.copy(nullable = true)
+            ).copy(nullable = true)
         )
 
     fun createMutableMapOfStringToType(type: TypeName) =
         ClassName("kotlin.collections", "MutableMap").parameterizedBy(
             String::class.asTypeName(),
-            type
+            type.copy(nullable = true)
         )
 
     fun createMapOfStringToType(type: TypeName) =
+        Map::class.asClassName().parameterizedBy(
+            String::class.asTypeName(),
+            type.copy(nullable = true)
+        )
+    fun createMapOfStringToNonNullType(type: TypeName) =
         Map::class.asClassName().parameterizedBy(
             String::class.asTypeName(),
             type

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
@@ -60,7 +60,7 @@ class OkHttpEnhancedClientGenerator(
                         .addParameter(
                             ParameterSpec.builder(
                                 ADDITIONAL_HEADERS_PARAMETER_NAME,
-                                TypeFactory.createMapOfStringToType(String::class.asTypeName())
+                                TypeFactory.createMapOfStringToNonNullType(String::class.asTypeName())
                             )
                                 .defaultValue("emptyMap()")
                                 .build()

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -61,7 +61,7 @@ class OkHttpSimpleClientGenerator(
                         .addParameter(
                             ParameterSpec.builder(
                                 ADDITIONAL_HEADERS_PARAMETER_NAME,
-                                TypeFactory.createMapOfStringToType(String::class.asTypeName())
+                                TypeFactory.createMapOfStringToNonNullType(String::class.asTypeName())
                             )
                                 .defaultValue("emptyMap()")
                                 .build()

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
@@ -85,7 +85,7 @@ class OpenFeignInterfaceGenerator(
             .addParameter(
                 ParameterSpec.builder(
                     ADDITIONAL_HEADERS_PARAMETER_NAME,
-                    TypeFactory.createMapOfStringToType(String::class.asTypeName()),
+                    TypeFactory.createMapOfStringToNonNullType(String::class.asTypeName()),
                 )
                     .addAnnotation(OpenFeignAnnotations.HEADER_MAP)
                     .defaultValue("emptyMap()")

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonModelGenerator.kt
@@ -11,6 +11,7 @@ import com.cjbooms.fabrikt.generators.PropertyUtils.addToClass
 import com.cjbooms.fabrikt.generators.PropertyUtils.isNullable
 import com.cjbooms.fabrikt.generators.TypeFactory.createList
 import com.cjbooms.fabrikt.generators.TypeFactory.createMapOfMapsStringToStringAny
+import com.cjbooms.fabrikt.generators.TypeFactory.createMapOfStringToNonNullType
 import com.cjbooms.fabrikt.generators.TypeFactory.createMapOfStringToType
 import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfMapsStringToStringType
 import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfStringToType
@@ -408,7 +409,7 @@ class JacksonModelGenerator(
         )
         val companion = TypeSpec.companionObjectBuilder()
             .addProperty(
-                PropertySpec.builder("mapping", createMapOfStringToType(enumType))
+                PropertySpec.builder("mapping", createMapOfStringToNonNullType(enumType))
                     .initializer("values().associateBy(%T::value)", enumType)
                     .addModifiers(KModifier.PRIVATE)
                     .build(),

--- a/src/test/resources/examples/anyOfOneOfAllOf/models/Models.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/Models.kt
@@ -82,13 +82,13 @@ public data class OneOfAdditionalProps(
     @get:JsonProperty("second_nested_any_of_prop")
     public val secondNestedAnyOfProp: String? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
+    public val properties: MutableMap<String, Any?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Any> = properties
+    public fun `get`(): Map<String, Any?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Any) {
+    public fun `set`(name: String, `value`: Any?) {
         properties[name] = value
     }
 }

--- a/src/test/resources/examples/externalReferences/aggressive/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/aggressive/models/Models.kt
@@ -98,13 +98,13 @@ public data class ExternalObjectTwo(
     @get:Valid
     public val listOthers: List<ExternalObjectThree>? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf(),
+    public val properties: MutableMap<String, Map<String, ExternalObjectFour?>?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Map<String, ExternalObjectFour>> = properties
+    public fun `get`(): Map<String, Map<String, ExternalObjectFour?>?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Map<String, ExternalObjectFour>) {
+    public fun `set`(name: String, `value`: Map<String, ExternalObjectFour?>?) {
         properties[name] = value
     }
 }

--- a/src/test/resources/examples/externalReferences/targeted/models/Models.kt
+++ b/src/test/resources/examples/externalReferences/targeted/models/Models.kt
@@ -72,13 +72,13 @@ public data class ExternalObjectTwo(
     @get:Valid
     public val listOthers: List<ExternalObjectThree>? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf(),
+    public val properties: MutableMap<String, Map<String, ExternalObjectFour?>?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Map<String, ExternalObjectFour>> = properties
+    public fun `get`(): Map<String, Map<String, ExternalObjectFour?>?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Map<String, ExternalObjectFour>) {
+    public fun `set`(name: String, `value`: Map<String, ExternalObjectFour?>?) {
         properties[name] = value
     }
 }

--- a/src/test/resources/examples/githubApi/models/Models.kt
+++ b/src/test/resources/examples/githubApi/models/Models.kt
@@ -32,13 +32,13 @@ public data class BulkEntityDetails(
     @get:Valid
     public val entities: List<EntityDetails>,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
+    public val properties: MutableMap<String, Any?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Any> = properties
+    public fun `get`(): Map<String, Any?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Any) {
+    public fun `set`(name: String, `value`: Any?) {
         properties[name] = value
     }
 }
@@ -121,13 +121,13 @@ public data class EntityDetails(
     @get:NotNull
     public val id: String,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
+    public val properties: MutableMap<String, Any?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Any> = properties
+    public fun `get`(): Map<String, Any?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Any) {
+    public fun `set`(name: String, `value`: Any?) {
         properties[name] = value
     }
 }
@@ -140,15 +140,15 @@ public data class Event(
     @param:JsonProperty("data")
     @get:JsonProperty("data")
     @get:NotNull
-    public val `data`: Map<String, Any>,
+    public val `data`: Map<String, Any?>,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
+    public val properties: MutableMap<String, Any?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Any> = properties
+    public fun `get`(): Map<String, Any?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Any) {
+    public fun `set`(name: String, `value`: Any?) {
         properties[name] = value
     }
 }
@@ -161,13 +161,13 @@ public data class EventResults(
     @get:Valid
     public val changeEvents: List<Event>,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
+    public val properties: MutableMap<String, Any?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Any> = properties
+    public fun `get`(): Map<String, Any?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Any) {
+    public fun `set`(name: String, `value`: Any?) {
         properties[name] = value
     }
 }

--- a/src/test/resources/examples/jakartaValidationAnnotations/models/Models.kt
+++ b/src/test/resources/examples/jakartaValidationAnnotations/models/Models.kt
@@ -54,5 +54,5 @@ public data class ValidationAnnotations(
     @param:JsonProperty("qualities")
     @get:JsonProperty("qualities")
     @get:Valid
-    public val qualities: Map<String, QualitiesValue>? = null,
+    public val qualities: Map<String, QualitiesValue?>? = null,
 )

--- a/src/test/resources/examples/mapExamples/models/Models.kt
+++ b/src/test/resources/examples/mapExamples/models/Models.kt
@@ -26,7 +26,7 @@ public data class ComplexObjectWithMapsOfMaps(
     @param:JsonProperty("map-of-maps")
     @get:JsonProperty("map-of-maps")
     @get:Valid
-    public val mapOfMaps: Map<String, Map<String, BasicObject>>? = null,
+    public val mapOfMaps: Map<String, Map<String, BasicObject?>?>? = null,
 )
 
 public data class ComplexObjectWithRefTypedMap(
@@ -37,13 +37,13 @@ public data class ComplexObjectWithRefTypedMap(
     @get:JsonProperty("code")
     public val code: Int? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, SomeRef> = mutableMapOf(),
+    public val properties: MutableMap<String, SomeRef?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, SomeRef> = properties
+    public fun `get`(): Map<String, SomeRef?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: SomeRef) {
+    public fun `set`(name: String, `value`: SomeRef?) {
         properties[name] = value
     }
 }
@@ -56,13 +56,13 @@ public data class ComplexObjectWithTypedMap(
     @get:JsonProperty("code")
     public val code: Int? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, ComplexObjectWithTypedMapValue> = mutableMapOf(),
+    public val properties: MutableMap<String, ComplexObjectWithTypedMapValue?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, ComplexObjectWithTypedMapValue> = properties
+    public fun `get`(): Map<String, ComplexObjectWithTypedMapValue?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: ComplexObjectWithTypedMapValue) {
+    public fun `set`(name: String, `value`: ComplexObjectWithTypedMapValue?) {
         properties[name] = value
     }
 }
@@ -84,13 +84,13 @@ public data class ComplexObjectWithUntypedMap(
     @get:JsonProperty("code")
     public val code: Int? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
+    public val properties: MutableMap<String, Any?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Any> = properties
+    public fun `get`(): Map<String, Any?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Any) {
+    public fun `set`(name: String, `value`: Any?) {
         properties[name] = value
     }
 }
@@ -122,30 +122,30 @@ public data class InlinedTypedObjectMapValue(
 public data class MapHolder(
     @param:JsonProperty("wild_card")
     @get:JsonProperty("wild_card")
-    public val wildCard: Map<String, Any>? = null,
+    public val wildCard: Map<String, Any?>? = null,
     @param:JsonProperty("string_map")
     @get:JsonProperty("string_map")
-    public val stringMap: Map<String, String>? = null,
+    public val stringMap: Map<String, String?>? = null,
     @param:JsonProperty("typed_object_map")
     @get:JsonProperty("typed_object_map")
     @get:Valid
-    public val typedObjectMap: Map<String, TypedObjectMapValue>? = null,
+    public val typedObjectMap: Map<String, TypedObjectMapValue?>? = null,
     @param:JsonProperty("object_map")
     @get:JsonProperty("object_map")
-    public val objectMap: Map<String, Map<String, Any>>? = null,
+    public val objectMap: Map<String, Map<String, Any?>?>? = null,
     @param:JsonProperty("inlined_string_map")
     @get:JsonProperty("inlined_string_map")
-    public val inlinedStringMap: Map<String, String>? = null,
+    public val inlinedStringMap: Map<String, String?>? = null,
     @param:JsonProperty("inlined_object_map")
     @get:JsonProperty("inlined_object_map")
-    public val inlinedObjectMap: Map<String, Map<String, Any>>? = null,
+    public val inlinedObjectMap: Map<String, Map<String, Any?>?>? = null,
     @param:JsonProperty("inlined_unknown_map")
     @get:JsonProperty("inlined_unknown_map")
-    public val inlinedUnknownMap: Map<String, Any>? = null,
+    public val inlinedUnknownMap: Map<String, Any?>? = null,
     @param:JsonProperty("inlined_typed_object_map")
     @get:JsonProperty("inlined_typed_object_map")
     @get:Valid
-    public val inlinedTypedObjectMap: Map<String, InlinedTypedObjectMapValue>? = null,
+    public val inlinedTypedObjectMap: Map<String, InlinedTypedObjectMapValue?>? = null,
     @param:JsonProperty("complex_object_with_untyped_map")
     @get:JsonProperty("complex_object_with_untyped_map")
     @get:Valid
@@ -164,13 +164,13 @@ public data class MapHolder(
     @get:Valid
     public val inlinedComplexObjectWithTypedMap: MapHolderInlinedComplexObjectWithTypedMap? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Map<String, ExternalObjectFour>> = mutableMapOf(),
+    public val properties: MutableMap<String, Map<String, ExternalObjectFour?>?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Map<String, ExternalObjectFour>> = properties
+    public fun `get`(): Map<String, Map<String, ExternalObjectFour?>?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Map<String, ExternalObjectFour>) {
+    public fun `set`(name: String, `value`: Map<String, ExternalObjectFour?>?) {
         properties[name] = value
     }
 }
@@ -183,13 +183,14 @@ public data class MapHolderInlinedComplexObjectWithTypedMap(
     @get:JsonProperty("code")
     public val code: Int? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, InlinedComplexObjectWithTypedMapValue> = mutableMapOf(),
+    public val properties: MutableMap<String, InlinedComplexObjectWithTypedMapValue?> =
+        mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, InlinedComplexObjectWithTypedMapValue> = properties
+    public fun `get`(): Map<String, InlinedComplexObjectWithTypedMapValue?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: InlinedComplexObjectWithTypedMapValue) {
+    public fun `set`(name: String, `value`: InlinedComplexObjectWithTypedMapValue?) {
         properties[name] = value
     }
 }
@@ -202,13 +203,13 @@ public data class MapHolderInlinedComplexObjectWithUntypedMap(
     @get:JsonProperty("code")
     public val code: Int? = null,
     @get:JsonIgnore
-    public val properties: MutableMap<String, Any> = mutableMapOf(),
+    public val properties: MutableMap<String, Any?> = mutableMapOf(),
 ) {
     @JsonAnyGetter
-    public fun `get`(): Map<String, Any> = properties
+    public fun `get`(): Map<String, Any?> = properties
 
     @JsonAnySetter
-    public fun `set`(name: String, `value`: Any) {
+    public fun `set`(name: String, `value`: Any?) {
         properties[name] = value
     }
 }

--- a/src/test/resources/examples/wildCardTypes/models/Models.kt
+++ b/src/test/resources/examples/wildCardTypes/models/Models.kt
@@ -14,5 +14,5 @@ public data class WildCardTypes(
     @param:JsonProperty("meta")
     @get:JsonProperty("meta")
     @get:NotNull
-    public val meta: Map<String, Any>,
+    public val meta: Map<String, Any?>,
 )


### PR DESCRIPTION
From what I can see, there does not appear to be a way to specify that Map values should be null or non-null in an OpenApi3 specification. We therefore need to make all map values nullable. 

I have a case where I need to preserve nulls in an untyped object, and cannot achieve that without this change