### PR TITLE
Allow configuration of Map value nullability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                               |   `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
 |                               |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
 |                               |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
+|                               |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
 |   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir |
 |   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources` |
 |   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin` |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -43,6 +43,7 @@ enum class ModelCodeGenOptionType(val description: String) {
     MICRONAUT_REFLECTION("This option adds @ReflectiveAccess to the generated models. Requires dependency \"'io.micronaut:micronaut-core:+\""),
     INCLUDE_COMPANION_OBJECT("This option adds a companion object to the generated models."),
     SEALED_INTERFACES_FOR_ONE_OF("This option enables the generation of interfaces for discriminated oneOf types"),
+    NON_NULL_MAP_VALUES("This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable"),
     ;
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
+import com.cjbooms.fabrikt.generators.TypeFactory.maybeMakeMapValueNullable
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.PropertyInfo
@@ -60,10 +61,10 @@ object PropertyUtils {
             val value =
                 if (typeInfo is KotlinTypeInfo.MapTypeAdditionalProperties) {
                     Map::class.asTypeName()
-                        .parameterizedBy(String::class.asTypeName(), parameterizedType.copy(nullable = true))
+                        .parameterizedBy(String::class.asTypeName(), parameterizedType.maybeMakeMapValueNullable())
                 } else {
                     parameterizedType
-                }.copy(nullable = true)
+                }.maybeMakeMapValueNullable()
             classBuilder.addFunction(
                 FunSpec.builder("get")
                     .returns(Map::class.asTypeName().parameterizedBy(String::class.asTypeName(), value))

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/TypeFactory.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/TypeFactory.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
+import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
@@ -13,8 +14,8 @@ object TypeFactory {
             String::class.asTypeName(),
             Map::class.asTypeName().parameterizedBy(
                 String::class.asTypeName(),
-                Any::class.asTypeName().copy(nullable = true)
-            ).copy(nullable = true)
+                Any::class.asTypeName().maybeMakeMapValueNullable()
+            ).maybeMakeMapValueNullable()
         )
 
     fun createMutableMapOfMapsStringToStringType(type: TypeName) =
@@ -22,21 +23,22 @@ object TypeFactory {
             String::class.asTypeName(),
             Map::class.asTypeName().parameterizedBy(
                 String::class.asTypeName(),
-                type.copy(nullable = true)
-            ).copy(nullable = true)
+                type.maybeMakeMapValueNullable()
+            ).maybeMakeMapValueNullable()
         )
 
     fun createMutableMapOfStringToType(type: TypeName) =
         ClassName("kotlin.collections", "MutableMap").parameterizedBy(
             String::class.asTypeName(),
-            type.copy(nullable = true)
+            type.maybeMakeMapValueNullable()
         )
 
     fun createMapOfStringToType(type: TypeName) =
         Map::class.asClassName().parameterizedBy(
             String::class.asTypeName(),
-            type.copy(nullable = true)
+            type.maybeMakeMapValueNullable()
         )
+
     fun createMapOfStringToNonNullType(type: TypeName) =
         Map::class.asClassName().parameterizedBy(
             String::class.asTypeName(),
@@ -45,4 +47,8 @@ object TypeFactory {
 
     fun createList(clazz: TypeName) =
         List::class.asClassName().parameterizedBy(clazz)
+
+    fun TypeName.maybeMakeMapValueNullable(): TypeName =
+        if (MutableSettings.modelOptions().contains(ModelCodeGenOptionType.NON_NULL_MAP_VALUES)) this
+        else this.copy(nullable = true)
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -40,6 +40,7 @@ class ModelGeneratorTest {
         "inLinedObject",
         "customExtensions",
         "mapExamples",
+        "mapExamplesNonNullValues",
         "mixingCamelSnakeLispCase",
         "oneOfPolymorphicModels",
         "optionalVsRequired",
@@ -81,6 +82,9 @@ class ModelGeneratorTest {
         }
         if (testCaseName == "discriminatedOneOf" || testCaseName == "oneOfMarkerInterface") {
             MutableSettings.addOption(ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_OF)
+        }
+        if (testCaseName == "mapExamplesNonNullValues") {
+            MutableSettings.addOption(ModelCodeGenOptionType.NON_NULL_MAP_VALUES)
         }
         val basePackage = "examples.${testCaseName.replace("/", ".")}"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!

--- a/src/test/resources/examples/mapExamplesNonNullValues/api.yaml
+++ b/src/test/resources/examples/mapExamplesNonNullValues/api.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+paths:
+info:
+  title:
+  version:
+components:
+  schemas:
+
+    Container:
+      type: object
+      required:
+        - string_map
+        - typed_object_map
+        - object_map
+      properties:
+        string_map:
+          $ref: '#/components/schemas/StringMap'
+        typed_object_map:
+          $ref: '#/components/schemas/TypedObjectMap'
+        object_map:
+          $ref: '#/components/schemas/ObjectMap'
+
+    StringMap:
+      type: object
+      additionalProperties:
+        type: string
+
+    TypedObjectMap:
+      type: object
+      additionalProperties:
+        type: object
+        properties:
+          code:
+            type: integer
+          text:
+            type: string
+
+    ObjectMap:
+      type: object
+      additionalProperties:
+        type: object
+

--- a/src/test/resources/examples/mapExamplesNonNullValues/models/Models.kt
+++ b/src/test/resources/examples/mapExamplesNonNullValues/models/Models.kt
@@ -1,0 +1,34 @@
+package examples.mapExamplesNonNullValues.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.Map
+
+public data class Container(
+    @param:JsonProperty("string_map")
+    @get:JsonProperty("string_map")
+    @get:NotNull
+    public val stringMap: Map<String, String>,
+    @param:JsonProperty("typed_object_map")
+    @get:JsonProperty("typed_object_map")
+    @get:NotNull
+    @get:Valid
+    public val typedObjectMap: Map<String, TypedObjectMapValue>,
+    @param:JsonProperty("object_map")
+    @get:JsonProperty("object_map")
+    @get:NotNull
+    public val objectMap: Map<String, Map<String, Any>>,
+)
+
+public data class TypedObjectMapValue(
+    @param:JsonProperty("code")
+    @get:JsonProperty("code")
+    public val code: Int? = null,
+    @param:JsonProperty("text")
+    @get:JsonProperty("text")
+    public val text: String? = null,
+)


### PR DESCRIPTION
Adopting the latest version of fabrikt, where the default nullability of map values has changed proved to be a PITA. Adding a configuration option to allow users to opt back in to previous behaviour via:
`--http-model-opts` `NON_NULL_MAP_VALUES`