### PR TITLE
Ktor server routes and controller interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,60 +188,60 @@ data class Responses(
 
 This section documents the available CLI parameters for controlling what gets generated. This documentation is generated using: `./gradlew printCodeGenUsage`
 
-| Parameter                     | Description                                                                                                                                                           |
-| ----------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   `--api-file`                | This must be a valid Open API v3 spec. All code generation will be based off this input.                                                                              |
-|   `--api-fragment`            | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes.                                                                     |
-| * `--base-package`            | The base package which all code will be generated under.                                                                                                              |
-|   `--external-ref-resolution` | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED                                                    |
-|                               | CHOOSE ONE OF:                                                                                                                                                        |
-|                               | `TARGETED` - Generate models only for directly referenced schemas in external API files.                                                                              |
-|                               | `AGGRESSIVE` - Referencing any schema in an external API file triggers generation of every external schema in that file.                                              |
-|   `--http-client-opts`        | Select the options for the http client code that you want to be generated.                                                                                            |
-|                               | CHOOSE ANY OF:                                                                                                                                                        |
-|                               | `RESILIENCE4J` - Generates a fault tolerance service for the client using the following library "io.github.resilience4j:resilience4j-all:+" (only for OkHttp clients) |
-|                               | `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated client functions (only for OpenFeign clients)                                             |
-|   `--http-client-target`      | Optionally select the target client that you want to be generated. Defaults to OK_HTTP                                                                                |
-|                               | CHOOSE ONE OF:                                                                                                                                                        |
-|                               | `OK_HTTP` - Generate OkHttp client.                                                                                                                                   |
-|                               | `OPEN_FEIGN` - Generate OpenFeign client.                                                                                                                             |
-|   `--http-controller-opts`    | Select the options for the controllers that you want to be generated.                                                                                                 |
-|                               | CHOOSE ANY OF:                                                                                                                                                        |
-|                               | `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions                                                                      |
-|                               | `AUTHENTICATION` - This option adds the authentication parameter to the generated controller functions                                                                |
-|   `--http-controller-target`  | Optionally select the target framework for the controllers that you want to be generated. Defaults to Spring Controllers                                              |
-|                               | CHOOSE ONE OF:                                                                                                                                                        |
-|                               | `SPRING` - Generate for Spring framework.                                                                                                                             |
-|                               | `MICRONAUT` - Generate for Micronaut framework.                                                                                                                       |
-|                               | `KTOR` - Generate for Ktor server.                                                                                                                                    |
-|   `--http-model-opts`         | Select the options for the http models that you want to be generated.                                                                                                 |
-|                               | CHOOSE ANY OF:                                                                                                                                                        |
-|                               | `X_EXTENSIBLE_ENUMS` - This option treats x-extensible-enums as enums                                                                                                 |
-|                               | `JAVA_SERIALIZATION` - This option adds Java Serializable interface to the generated models                                                                           |
-|                               | `QUARKUS_REFLECTION` - This option adds @RegisterForReflection to the generated models. Requires dependency "'io.quarkus:quarkus-core:+"                              |
-|                               | `MICRONAUT_INTROSPECTION` - This option adds @Introspected to the generated models. Requires dependency "'io.micronaut:micronaut-core:+"                              |
-|                               | `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+"                             |
-|                               | `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models.                                                                             |
-|                               | `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types                                                       |
-|                               | `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable                            |
-|   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir                                                                                                   |
-|   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources`                                                                            |
-|   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin`                                                                            |
-|   `--targets`                 | Targets are the parts of the application that you want to be generated.                                                                                               |
-|                               | CHOOSE ANY OF:                                                                                                                                                        |
-|                               | `HTTP_MODELS` - Jackson annotated data classes to represent the schema objects defined in the input.                                                                  |
-|                               | `CONTROLLERS` - Spring / Micronaut / Ktor HTTP controllers for each of the endpoints defined in the input.                                                            |
-|                               | `CLIENT` - Simple http rest client.                                                                                                                                   |
-|                               | `QUARKUS_REFLECTION_CONFIG` - This options generates the reflection-config.json file for quarkus integration projects                                                 |
-|   `--type-overrides`          | Specify non-default kotlin types for certain OAS types. For example, generate `Instant` instead of `OffsetDateTime`                                                   |
-|                               | CHOOSE ANY OF:                                                                                                                                                        |
-|                               | `DATETIME_AS_INSTANT` - Use `Instant` as the datetime type. Defaults to `OffsetDateTime`                                                                              |
-|                               | `DATETIME_AS_LOCALDATETIME` - Use `LocalDateTime` as the datetime type. Defaults to `OffsetDateTime`                                                                  |
-|   `--validation-library`      | Specify which validation library to use for annotations in generated model classes. Default: JAVAX_VALIDATION                                                         |
-|                               | CHOOSE ONE OF:                                                                                                                                                        |
-|                               | `JAVAX_VALIDATION` - Use `javax.validation` annotations in generated model classes (default)                                                                          |
-|                               | `JAKARTA_VALIDATION` - Use `jakarta.validation` annotations in generated model classes                                                                                |
-|                               | `NO_VALIDATION` - Use no validation annotations in generated model classes                                                                                            |
+| Parameter                     | Description |
+| ----------------------------- | ----------------------------- |
+|   `--api-file`                | This must be a valid Open API v3 spec. All code generation will be based off this input. |
+|   `--api-fragment`            | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. |
+| * `--base-package`            | The base package which all code will be generated under. |
+|   `--external-ref-resolution` | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED |
+|                               | CHOOSE ONE OF: |
+|                               |   `TARGETED` - Generate models only for directly referenced schemas in external API files. |
+|                               |   `AGGRESSIVE` - Referencing any schema in an external API file triggers generation of every external schema in that file. |
+|   `--http-client-opts`        | Select the options for the http client code that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `RESILIENCE4J` - Generates a fault tolerance service for the client using the following library "io.github.resilience4j:resilience4j-all:+" (only for OkHttp clients) |
+|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated client functions (only for OpenFeign clients) |
+|   `--http-client-target`      | Optionally select the target client that you want to be generated. Defaults to OK_HTTP |
+|                               | CHOOSE ONE OF: |
+|                               |   `OK_HTTP` - Generate OkHttp client. |
+|                               |   `OPEN_FEIGN` - Generate OpenFeign client. |
+|   `--http-controller-opts`    | Select the options for the controllers that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions |
+|                               |   `AUTHENTICATION` - This option adds the authentication parameter to the generated controller functions |
+|   `--http-controller-target`  | Optionally select the target framework for the controllers that you want to be generated. Defaults to Spring Controllers |
+|                               | CHOOSE ONE OF: |
+|                               |   `SPRING` - Generate for Spring framework. |
+|                               |   `MICRONAUT` - Generate for Micronaut framework. |
+|                               |   `KTOR` - Generate for Ktor server. |
+|   `--http-model-opts`         | Select the options for the http models that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `X_EXTENSIBLE_ENUMS` - This option treats x-extensible-enums as enums |
+|                               |   `JAVA_SERIALIZATION` - This option adds Java Serializable interface to the generated models |
+|                               |   `QUARKUS_REFLECTION` - This option adds @RegisterForReflection to the generated models. Requires dependency "'io.quarkus:quarkus-core:+" |
+|                               |   `MICRONAUT_INTROSPECTION` - This option adds @Introspected to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
+|                               |   `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
+|                               |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
+|                               |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
+|                               |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
+|   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir |
+|   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources` |
+|   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin` |
+|   `--targets`                 | Targets are the parts of the application that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `HTTP_MODELS` - Jackson annotated data classes to represent the schema objects defined in the input. |
+|                               |   `CONTROLLERS` - Spring / Micronaut / Ktor HTTP controllers for each of the endpoints defined in the input. |
+|                               |   `CLIENT` - Simple http rest client. |
+|                               |   `QUARKUS_REFLECTION_CONFIG` - This options generates the reflection-config.json file for quarkus integration projects |
+|   `--type-overrides`          | Specify non-default kotlin types for certain OAS types. For example, generate `Instant` instead of `OffsetDateTime` |
+|                               | CHOOSE ANY OF: |
+|                               |   `DATETIME_AS_INSTANT` - Use `Instant` as the datetime type. Defaults to `OffsetDateTime` |
+|                               |   `DATETIME_AS_LOCALDATETIME` - Use `LocalDateTime` as the datetime type. Defaults to `OffsetDateTime` |
+|   `--validation-library`      | Specify which validation library to use for annotations in generated model classes. Default: JAVAX_VALIDATION |
+|                               | CHOOSE ONE OF: |
+|                               |   `JAVAX_VALIDATION` - Use `javax.validation` annotations in generated model classes (default) |
+|                               |   `JAKARTA_VALIDATION` - Use `jakarta.validation` annotations in generated model classes |
+|                               |   `NO_VALIDATION` - Use no validation annotations in generated model classes |
 
 
 ### Command Line

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The library currently has support for generating:
 
 * **Jackson annotated data classes**
 * **Spring MVC annotated controller interfaces**
+* **Ktor server routes and controller interfaces**
 * **OkHttp Client** - with the option for a resilience4j fault-tolerance wrapper
 
 ### Example Generation
@@ -187,59 +188,60 @@ data class Responses(
 
 This section documents the available CLI parameters for controlling what gets generated. This documentation is generated using: `./gradlew printCodeGenUsage`
 
-| Parameter                     | Description |
-| ----------------------------- | ----------------------------- |
-|   `--api-file`                | This must be a valid Open API v3 spec. All code generation will be based off this input. |
-|   `--api-fragment`            | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. |
-| * `--base-package`            | The base package which all code will be generated under. |
-|   `--external-ref-resolution` | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED |
-|                               | CHOOSE ONE OF: |
-|                               |   `TARGETED` - Generate models only for directly referenced schemas in external API files. |
-|                               |   `AGGRESSIVE` - Referencing any schema in an external API file triggers generation of every external schema in that file. |
-|   `--http-client-opts`        | Select the options for the http client code that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `RESILIENCE4J` - Generates a fault tolerance service for the client using the following library "io.github.resilience4j:resilience4j-all:+" (only for OkHttp clients) |
-|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated client functions (only for OpenFeign clients) |
-|   `--http-client-target`      | Optionally select the target client that you want to be generated. Defaults to OK_HTTP |
-|                               | CHOOSE ONE OF: |
-|                               |   `OK_HTTP` - Generate OkHttp client. |
-|                               |   `OPEN_FEIGN` - Generate OpenFeign client. |
-|   `--http-controller-opts`    | Select the options for the controllers that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions |
-|                               |   `AUTHENTICATION` - This option adds the authentication parameter to the generated controller functions |
-|   `--http-controller-target`  | Optionally select the target framework for the controllers that you want to be generated. Defaults to Spring Controllers |
-|                               | CHOOSE ONE OF: |
-|                               |   `SPRING` - Generate for Spring framework. |
-|                               |   `MICRONAUT` - Generate for Micronaut framework. |
-|   `--http-model-opts`         | Select the options for the http models that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `X_EXTENSIBLE_ENUMS` - This option treats x-extensible-enums as enums |
-|                               |   `JAVA_SERIALIZATION` - This option adds Java Serializable interface to the generated models |
-|                               |   `QUARKUS_REFLECTION` - This option adds @RegisterForReflection to the generated models. Requires dependency "'io.quarkus:quarkus-core:+" |
-|                               |   `MICRONAUT_INTROSPECTION` - This option adds @Introspected to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
-|                               |   `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
-|                               |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
-|                               |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
-|                               |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
-|   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir |
-|   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources` |
-|   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin` |
-|   `--targets`                 | Targets are the parts of the application that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `HTTP_MODELS` - Jackson annotated data classes to represent the schema objects defined in the input. |
-|                               |   `CONTROLLERS` - Spring / Micronaut annotated HTTP controllers for each of the endpoints defined in the input. |
-|                               |   `CLIENT` - Simple http rest client. |
-|                               |   `QUARKUS_REFLECTION_CONFIG` - This options generates the reflection-config.json file for quarkus integration projects |
-|   `--type-overrides`          | Specify non-default kotlin types for certain OAS types. For example, generate `Instant` instead of `OffsetDateTime` |
-|                               | CHOOSE ANY OF: |
-|                               |   `DATETIME_AS_INSTANT` - Use `Instant` as the datetime type. Defaults to `OffsetDateTime` |
-|                               |   `DATETIME_AS_LOCALDATETIME` - Use `LocalDateTime` as the datetime type. Defaults to `OffsetDateTime` |
-|   `--validation-library`      | Specify which validation library to use for annotations in generated model classes. Default: JAVAX_VALIDATION |
-|                               | CHOOSE ONE OF: |
-|                               |   `JAVAX_VALIDATION` - Use `javax.validation` annotations in generated model classes (default) |
-|                               |   `JAKARTA_VALIDATION` - Use `jakarta.validation` annotations in generated model classes |
-|                               |   `NO_VALIDATION` - Use no validation annotations in generated model classes |
+| Parameter                     | Description                                                                                                                                                           |
+| ----------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   `--api-file`                | This must be a valid Open API v3 spec. All code generation will be based off this input.                                                                              |
+|   `--api-fragment`            | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes.                                                                     |
+| * `--base-package`            | The base package which all code will be generated under.                                                                                                              |
+|   `--external-ref-resolution` | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED                                                    |
+|                               | CHOOSE ONE OF:                                                                                                                                                        |
+|                               | `TARGETED` - Generate models only for directly referenced schemas in external API files.                                                                              |
+|                               | `AGGRESSIVE` - Referencing any schema in an external API file triggers generation of every external schema in that file.                                              |
+|   `--http-client-opts`        | Select the options for the http client code that you want to be generated.                                                                                            |
+|                               | CHOOSE ANY OF:                                                                                                                                                        |
+|                               | `RESILIENCE4J` - Generates a fault tolerance service for the client using the following library "io.github.resilience4j:resilience4j-all:+" (only for OkHttp clients) |
+|                               | `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated client functions (only for OpenFeign clients)                                             |
+|   `--http-client-target`      | Optionally select the target client that you want to be generated. Defaults to OK_HTTP                                                                                |
+|                               | CHOOSE ONE OF:                                                                                                                                                        |
+|                               | `OK_HTTP` - Generate OkHttp client.                                                                                                                                   |
+|                               | `OPEN_FEIGN` - Generate OpenFeign client.                                                                                                                             |
+|   `--http-controller-opts`    | Select the options for the controllers that you want to be generated.                                                                                                 |
+|                               | CHOOSE ANY OF:                                                                                                                                                        |
+|                               | `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions                                                                      |
+|                               | `AUTHENTICATION` - This option adds the authentication parameter to the generated controller functions                                                                |
+|   `--http-controller-target`  | Optionally select the target framework for the controllers that you want to be generated. Defaults to Spring Controllers                                              |
+|                               | CHOOSE ONE OF:                                                                                                                                                        |
+|                               | `SPRING` - Generate for Spring framework.                                                                                                                             |
+|                               | `MICRONAUT` - Generate for Micronaut framework.                                                                                                                       |
+|                               | `KTOR` - Generate for Ktor server.                                                                                                                                    |
+|   `--http-model-opts`         | Select the options for the http models that you want to be generated.                                                                                                 |
+|                               | CHOOSE ANY OF:                                                                                                                                                        |
+|                               | `X_EXTENSIBLE_ENUMS` - This option treats x-extensible-enums as enums                                                                                                 |
+|                               | `JAVA_SERIALIZATION` - This option adds Java Serializable interface to the generated models                                                                           |
+|                               | `QUARKUS_REFLECTION` - This option adds @RegisterForReflection to the generated models. Requires dependency "'io.quarkus:quarkus-core:+"                              |
+|                               | `MICRONAUT_INTROSPECTION` - This option adds @Introspected to the generated models. Requires dependency "'io.micronaut:micronaut-core:+"                              |
+|                               | `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+"                             |
+|                               | `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models.                                                                             |
+|                               | `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types                                                       |
+|                               | `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable                            |
+|   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir                                                                                                   |
+|   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources`                                                                            |
+|   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin`                                                                            |
+|   `--targets`                 | Targets are the parts of the application that you want to be generated.                                                                                               |
+|                               | CHOOSE ANY OF:                                                                                                                                                        |
+|                               | `HTTP_MODELS` - Jackson annotated data classes to represent the schema objects defined in the input.                                                                  |
+|                               | `CONTROLLERS` - Spring / Micronaut / Ktor HTTP controllers for each of the endpoints defined in the input.                                                            |
+|                               | `CLIENT` - Simple http rest client.                                                                                                                                   |
+|                               | `QUARKUS_REFLECTION_CONFIG` - This options generates the reflection-config.json file for quarkus integration projects                                                 |
+|   `--type-overrides`          | Specify non-default kotlin types for certain OAS types. For example, generate `Instant` instead of `OffsetDateTime`                                                   |
+|                               | CHOOSE ANY OF:                                                                                                                                                        |
+|                               | `DATETIME_AS_INSTANT` - Use `Instant` as the datetime type. Defaults to `OffsetDateTime`                                                                              |
+|                               | `DATETIME_AS_LOCALDATETIME` - Use `LocalDateTime` as the datetime type. Defaults to `OffsetDateTime`                                                                  |
+|   `--validation-library`      | Specify which validation library to use for annotations in generated model classes. Default: JAVAX_VALIDATION                                                         |
+|                               | CHOOSE ONE OF:                                                                                                                                                        |
+|                               | `JAVAX_VALIDATION` - Use `javax.validation` annotations in generated model classes (default)                                                                          |
+|                               | `JAKARTA_VALIDATION` - Use `jakarta.validation` annotations in generated model classes                                                                                |
+|                               | `NO_VALIDATION` - Use no validation annotations in generated model classes                                                                                            |
 
 
 ### Command Line

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     //testCompileOnly("io.micronaut.security:micronaut-security:3.8.7")
     testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
     testImplementation("org.openapitools:jackson-databind-nullable:0.2.6")
+    testImplementation("io.ktor:ktor-server-core:2.3.9")
+    testImplementation("io.ktor:ktor-server-auth:2.3.9")
 
     testImplementation(platform("com.pinterest.ktlint:ktlint-bom:0.49.0"))
     testImplementation("com.pinterest:ktlint")

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -10,7 +10,7 @@ enum class CodeGenerationType(val description: String) {
         "Jackson annotated data classes to represent the schema objects defined in the input."
     ),
     CONTROLLERS(
-        "Spring / Micronaut annotated HTTP controllers for each of the endpoints defined in the input."
+        "Spring / Micronaut / Ktor HTTP controllers for each of the endpoints defined in the input."
     ),
     CLIENT(
         "Simple http rest client."

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -59,7 +59,8 @@ enum class ControllerCodeGenOptionType(val description: String) {
 
 enum class ControllerCodeGenTargetType(val description: String) {
     SPRING("Generate for Spring framework."),
-    MICRONAUT("Generate for Micronaut framework.");
+    MICRONAUT("Generate for Micronaut framework."),
+    KTOR("Generate for Ktor server.");
 
     override fun toString() = "`${super.toString()}` - $description"
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -88,6 +88,7 @@ class CodeGenerator(
                 ControllerCodeGenTargetType.KTOR -> KtorControllerInterfaceGenerator(
                     packages,
                     sourceApi,
+                    MutableSettings.controllerOptions(),
                 )
             }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -43,7 +43,7 @@ class CodeGenerator(
     private fun generateModels(): Collection<GeneratedFile> = sourceSet(models().files)
 
     private fun generateControllerInterfaces(): Collection<GeneratedFile> =
-        sourceSet(controllers()).plus(sourceSet(models().files))
+        sourceSet(controllers().files).plus(sourceSet(models().files))
 
     private fun generateClient(): Collection<GeneratedFile> {
         val clientGenerator = when (MutableSettings.clientTarget()) {
@@ -68,7 +68,7 @@ class CodeGenerator(
     private fun resources(models: Models): List<ResourceFile> =
         listOfNotNull(QuarkusReflectionModelGenerator(models).generate())
 
-    private fun controllers(): List<FileSpec> {
+    private fun controllers(): KotlinTypes {
         val generator =
             when (MutableSettings.controllerTarget()) {
                 ControllerCodeGenTargetType.SPRING -> SpringControllerInterfaceGenerator(
@@ -91,14 +91,6 @@ class CodeGenerator(
                     MutableSettings.controllerOptions(),
                 )
             }
-
-        val controllerFiles: Collection<FileSpec> = generator.generate().files
-        val libFiles: Collection<FileSpec> = generator.generateLibrary().map {
-            FileSpec.builder(it.className)
-                .addType(it.spec)
-                .build()
-        }
-
-        return controllerFiles.plus(libFiles)
+        return generator.generate()
     }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -94,13 +94,9 @@ class CodeGenerator(
 
         val controllerFiles: Collection<FileSpec> = generator.generate().files
         val libFiles: Collection<FileSpec> = generator.generateLibrary().map {
-            val builder = FileSpec.builder(it.className)
+            FileSpec.builder(it.className)
                 .addType(it.spec)
-
-            // add imports for the library files
-            it.imports.forEach { import -> builder.addImport(import.packageName, import.name) }
-
-            builder.build()
+                .build()
         }
 
         return controllerFiles.plus(libFiles)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -8,6 +8,8 @@ import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
 import com.cjbooms.fabrikt.util.NormalisedString.toKotlinParameterName
+import com.cjbooms.fabrikt.util.capitalized
+import com.cjbooms.fabrikt.util.decapitalized
 import com.reprezen.kaizen.oasparser.model3.MediaType
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Parameter
@@ -21,8 +23,6 @@ import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
-import com.cjbooms.fabrikt.util.capitalized
-import com.cjbooms.fabrikt.util.decapitalized
 import java.util.function.Predicate
 
 object GeneratorUtils {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/AnnotationBasedControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/AnnotationBasedControllerInterfaceGenerator.kt
@@ -1,0 +1,59 @@
+package com.cjbooms.fabrikt.generators.controller
+
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.ValidationAnnotations
+import com.cjbooms.fabrikt.model.ControllerType
+import com.cjbooms.fabrikt.model.RequestParameter
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.basePath
+import com.cjbooms.fabrikt.util.toUpperCase
+import com.reprezen.kaizen.oasparser.model3.Operation
+import com.reprezen.kaizen.oasparser.model3.Path
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeSpec
+
+abstract class AnnotationBasedControllerInterfaceGenerator(
+    private val packages: Packages,
+    private val api: SourceApi,
+    private val validationAnnotations: ValidationAnnotations,
+) {
+    abstract fun buildFunction(path: Path, op: Operation, verb: String): FunSpec
+
+    abstract fun controllerBuilder(className: String, basePath: String): TypeSpec.Builder
+
+    fun buildController(resourceName: String, paths: Collection<Path>): ControllerType {
+        val typeBuilder: TypeSpec.Builder = controllerBuilder(
+            className = ControllerGeneratorUtils.controllerName(resourceName),
+            basePath = api.openApi3.basePath()
+        )
+
+        paths.flatMap { path ->
+            path.operations
+                .filter { it.key.toUpperCase() != "HEAD" }
+                .map { op ->
+                    buildFunction(
+                        path,
+                        op.value,
+                        op.key,
+                    )
+                }
+        }.forEach { typeBuilder.addFunction(it) }
+
+        return ControllerType(
+            typeBuilder.build(),
+            packages.base
+        )
+    }
+
+    fun ParameterSpec.Builder.addValidationAnnotations(parameter: RequestParameter): ParameterSpec.Builder {
+        if (parameter.minimum != null) this.maybeAddAnnotation(validationAnnotations.min(parameter.minimum.toInt()))
+        if (parameter.maximum != null) this.maybeAddAnnotation(validationAnnotations.max(parameter.maximum.toInt()))
+        if (parameter.typeInfo.isComplexType) this.maybeAddAnnotation(validationAnnotations.parameterValid())
+        return this
+    }
+
+    fun ParameterSpec.Builder.maybeAddAnnotation(annotation: AnnotationSpec?) =
+        if (annotation != null) this.addAnnotation(annotation) else this
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerInterfaceGenerator.kt
@@ -1,59 +1,9 @@
 package com.cjbooms.fabrikt.generators.controller
 
-import com.cjbooms.fabrikt.configurations.Packages
-import com.cjbooms.fabrikt.generators.ValidationAnnotations
-import com.cjbooms.fabrikt.model.ControllerType
+import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.KotlinTypes
-import com.cjbooms.fabrikt.model.RequestParameter
-import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.basePath
-import com.cjbooms.fabrikt.util.toUpperCase
-import com.reprezen.kaizen.oasparser.model3.Operation
-import com.reprezen.kaizen.oasparser.model3.Path
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.TypeSpec
 
-abstract class ControllerInterfaceGenerator(
-    private val packages: Packages,
-    private val api: SourceApi,
-    private val validationAnnotations: ValidationAnnotations,
-) {
-    abstract fun generate(): KotlinTypes
-    abstract fun buildFunction(path: Path, op: Operation, verb: String): FunSpec
-    abstract fun controllerBuilder(className: String, basePath: String): TypeSpec.Builder
-    fun buildController(resourceName: String, paths: Collection<Path>): ControllerType {
-        val typeBuilder: TypeSpec.Builder = controllerBuilder(
-            className = ControllerGeneratorUtils.controllerName(resourceName),
-            basePath = api.openApi3.basePath()
-        )
-
-        paths.flatMap { path ->
-            path.operations
-                .filter { it.key.toUpperCase() != "HEAD" }
-                .map { op ->
-                    buildFunction(
-                        path,
-                        op.value,
-                        op.key,
-                    )
-                }
-        }.forEach { typeBuilder.addFunction(it) }
-
-        return ControllerType(
-            typeBuilder.build(),
-            packages.base
-        )
-    }
-
-    fun ParameterSpec.Builder.addValidationAnnotations(parameter: RequestParameter): ParameterSpec.Builder {
-        if (parameter.minimum != null) this.maybeAddAnnotation(validationAnnotations.min(parameter.minimum.toInt()))
-        if (parameter.maximum != null) this.maybeAddAnnotation(validationAnnotations.max(parameter.maximum.toInt()))
-        if (parameter.typeInfo.isComplexType) this.maybeAddAnnotation(validationAnnotations.parameterValid())
-        return this
-    }
-
-    fun ParameterSpec.Builder.maybeAddAnnotation(annotation: AnnotationSpec?) =
-        if (annotation != null) this.addAnnotation(annotation) else this
+interface ControllerInterfaceGenerator {
+    fun generate(): KotlinTypes
+    fun generateLibrary(): Collection<ControllerLibraryType>
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerInterfaceGenerator.kt
@@ -1,9 +1,7 @@
 package com.cjbooms.fabrikt.generators.controller
 
-import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.KotlinTypes
 
 interface ControllerInterfaceGenerator {
     fun generate(): KotlinTypes
-    fun generateLibrary(): Collection<ControllerLibraryType>
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -8,7 +8,6 @@ import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.Securi
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
 import com.cjbooms.fabrikt.model.BodyParameter
-import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
@@ -34,8 +33,6 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asTypeName
-
-private const val CONTROLLER_RESULT_CLASS_NAME = "ControllerResult"
 
 /**
  * Generates controller interface and routing functions for Ktor.
@@ -316,8 +313,6 @@ class KtorControllerInterfaceGenerator(
 
         return kDoc.build()
     }
-
-    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     /**
      * Function for getting a typed query parameter

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -4,6 +4,7 @@ import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.SecuritySupport
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
@@ -19,6 +20,7 @@ import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSingleResource
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
+import com.cjbooms.fabrikt.util.capitalized
 import com.cjbooms.fabrikt.util.toUpperCase
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
@@ -59,6 +61,7 @@ class KtorControllerInterfaceGenerator(
                     "controller",
                     ClassName(packages.controllers, ControllerGeneratorUtils.controllerName(resourceName))
                 )
+                .addKdoc("Mounts all routes for the $resourceName resource\n\n")
 
             paths.forEach { path ->
                 path.value.operations
@@ -67,6 +70,7 @@ class KtorControllerInterfaceGenerator(
                         // add route handler
                         val routeCode = buildRouteCode(operation, verb, path)
                         routeFunBuilder.addCode(routeCode)
+                            routeFunBuilder.addKdoc("- ${verb.toUpperCase()} ${path.key} ${(operation.summary ?: operation.description).orEmpty()}\n")
 
                         // generate controller interface function
                         val controllerFun = buildControllerFun(operation, verb, path)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -1,0 +1,362 @@
+package com.cjbooms.fabrikt.generators.controller
+
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
+import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
+import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
+import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.ControllerLibraryType
+import com.cjbooms.fabrikt.model.ControllerType
+import com.cjbooms.fabrikt.model.HeaderParam
+import com.cjbooms.fabrikt.model.Import
+import com.cjbooms.fabrikt.model.IncomingParameter
+import com.cjbooms.fabrikt.model.KotlinTypes
+import com.cjbooms.fabrikt.model.PathParam
+import com.cjbooms.fabrikt.model.QueryParam
+import com.cjbooms.fabrikt.model.RequestParameter
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSingleResource
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.NormalisedString.camelCase
+import com.cjbooms.fabrikt.util.toUpperCase
+import com.reprezen.kaizen.oasparser.model3.Operation
+import com.reprezen.kaizen.oasparser.model3.Path
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.asTypeName
+
+private const val CONTROLLER_RESULT_CLASS_NAME = "ControllerResult"
+
+/**
+ * Generates controller interface and routing functions for Ktor.
+ *
+ * Ktor in its nature is very flexible and imposes very few constraints on how you structure your application. In order
+ * to be able to generate code we however have to add structure.
+ *
+ * This generator creates a routing function (as an extension function on Ktor's Route class) which you use to mount
+ * the route on your Ktor server. The route function handles basic parsing of parameters and delegates the actual
+ * handling of the request to a controller interface which you implement.
+ */
+class KtorControllerInterfaceGenerator(
+    private val packages: Packages,
+    private val api: SourceApi,
+) : ControllerInterfaceGenerator {
+    override fun generate(): KtorControllers {
+        val controllerInterfaces = api.openApi3.routeToPaths().map { (resourceName, paths) ->
+            val controllerBuilder = TypeSpec.interfaceBuilder(ControllerGeneratorUtils.controllerName(resourceName))
+
+            val routeFunBuilder = FunSpec.builder("${resourceName.camelCase()}Routes")
+                .receiver(ClassName("io.ktor.server.routing", "Route"))
+                .addParameter(
+                    "controller",
+                    ClassName(packages.controllers, ControllerGeneratorUtils.controllerName(resourceName))
+                )
+
+            paths.forEach { path ->
+                path.value.operations
+                    .filter { (verb, _) -> verb.toUpperCase() != "HEAD" }
+                    .forEach { (verb, operation) ->
+                        // add route handler
+                        val routeCode = buildRouteCode(operation, verb, path)
+                        routeFunBuilder.addCode(routeCode)
+
+                        // generate controller interface
+                        val methodName = getMethodName(operation, verb, path)
+                        val controllerFunBuilder = FunSpec.builder(methodName)
+                            .addModifiers(setOf(KModifier.ABSTRACT, KModifier.SUSPEND))
+                            .addParameter("call", ClassName("io.ktor.server.application", "ApplicationCall"))
+
+                        controllerFunBuilder.returns(
+                            ClassName(packages.controllers, CONTROLLER_RESULT_CLASS_NAME)
+                                .parameterizedBy(operation.happyPathResponse(packages.base))
+                        )
+
+                        val params = operation.toIncomingParameters(packages.base, path.value.parameters, emptyList())
+                        val (pathParams, queryParams, headerParams, bodyParams) = params.splitByType()
+
+                        headerParams.forEach { param ->
+                            // TODO: Consider handling header parameter types. Currently everything is a string.
+                            if (param.isRequired) {
+                                controllerFunBuilder.addParameter(ParameterSpec.builder(param.name, String::class).build())
+                            } else {
+                                controllerFunBuilder.addParameter(
+                                    ParameterSpec.builder(param.name, String::class.asTypeName().copy(nullable = true)).build()
+                                )
+                            }
+                        }
+
+                        (pathParams + queryParams).forEach { param ->
+                            if (param.isRequired) {
+                                controllerFunBuilder.addParameter(param.toParameterSpecBuilder().build())
+                            } else {
+                                controllerFunBuilder.addParameter(
+                                    ParameterSpec.builder(param.name, param.type.copy(nullable = true)).build()
+                                )
+                            }
+                        }
+
+                        bodyParams.forEach { param ->
+                            controllerFunBuilder.addParameter(param.toParameterSpecBuilder().build())
+                        }
+
+                        controllerFunBuilder.addKdoc(operation.toKdoc(params))
+
+                        controllerBuilder.addFunction(controllerFunBuilder.build())
+                    }
+            }
+
+            // add the companion object with the route functions
+            controllerBuilder.addType(
+                TypeSpec.companionObjectBuilder()
+                    .addFunction(routeFunBuilder.build())
+                    .build()
+            )
+
+            controllerBuilder
+        }
+
+        // imports for the generated code
+        val globalImports = listOf( // imports necessary for ktor
+                "io.ktor.server.application" to "call",
+                "io.ktor.server.application" to "ApplicationCall",
+                "io.ktor.server.auth" to "authenticate",
+                "io.ktor.server.plugins" to "BadRequestException",
+                "io.ktor.server.request" to "receive",
+                "io.ktor.server.response" to "respond",
+                "io.ktor.server.util" to "getOrFail",
+                "${packages.controllers}.RoutingUtils" to "getTyped", // utility for parsing query parameters
+                "${packages.controllers}.RoutingUtils" to "getOrFail", // utility for parsing header parameters
+            )
+            .plus(usedVerbs.map { "io.ktor.server.routing" to it })
+            .map { Import(it.first, it.second) }
+            .toSet()
+
+        val controllers = controllerInterfaces.map { ControllerType(it.build(), packages.base) }.toSet()
+
+        return KtorControllers(controllers, globalImports)
+    }
+
+    private fun buildRouteCode(operation: Operation, verb: String, path: Map.Entry<String, Path>): String {
+        val codeBlock = StringBuilder()
+
+        val addAuth = operation.securitySupport().allowsAuthenticated
+        if (addAuth) {
+            // Using the key from the first security requirement as the auth name
+            val authName: String = operation.securityRequirements.first().requirements.keys.first()
+
+            codeBlock.appendLine("authenticate(\"$authName\") {")
+        }
+
+        val params = operation.toIncomingParameters(packages.base, path.value.parameters, emptyList())
+        val (pathParams, queryParams, headerParams, bodyParams) = params.splitByType()
+
+        val happyPathResponse = operation.happyPathResponse(packages.base)
+
+        val methodName = getMethodName(operation, verb, path)
+
+        codeBlock.appendLine("${verb}(\"${path.key}\") {")
+
+        pathParams.forEach { param ->
+            codeBlock.appendLine("val ${param.name} = call.parameters.getOrFail<${param.type}>(\"${param.originalName}\")")
+        }
+
+        headerParams.forEach { param ->
+            if (param.isRequired) {
+                codeBlock.appendLine("val ${param.name} = call.request.headers.getOrFail(\"${param.originalName}\")")
+            } else {
+                codeBlock.appendLine("val ${param.name} = call.request.headers[\"${param.originalName}\"]")
+            }
+        }
+
+        queryParams.forEach { param ->
+            val typeName = param.type.copy(nullable = false) // not nullable because we handle that in the queryParameters.get* below
+            if (param.isRequired) {
+                codeBlock.appendLine("val ${param.name} = call.request.queryParameters.getOrFail<$typeName>(\"${param.originalName}\")")
+            } else {
+                codeBlock.appendLine("val ${param.name} = call.request.queryParameters.getTyped<$typeName>(\"${param.originalName}\")")
+            }
+        }
+
+        bodyParams.forEach { param ->
+            codeBlock.appendLine("val ${param.name} = call.receive<${param.type.simpleName()}>()")
+        }
+
+        val methodParameters =
+            listOf(headerParams, pathParams, queryParams, bodyParams).flatten()
+                .joinToString(", ") { it.name }
+                .let {
+                    if (it.isNotEmpty()) "call, $it"
+                    else "call"
+                }
+
+        codeBlock.appendLine("val result = controller.$methodName($methodParameters)")
+
+        if (happyPathResponse.simpleName() == Unit::class.simpleName) {
+            // When return type is Unit we only respond with the status code.
+            // Note however that in some cases the controller may choose to respond directly on the call
+            // in which case that takes precedence in Ktor's routing. For example: call.respondRedirect().
+            codeBlock.appendLine("call.respond(result.status)")
+        } else {
+            codeBlock.appendLine("call.respond(result.status, result.message)")
+        }
+
+        codeBlock.appendLine("}")
+
+        if (addAuth) {
+            codeBlock.appendLine("}")
+        }
+
+        return codeBlock.toString()
+    }
+
+    override fun generateLibrary(): Collection<ControllerLibraryType> = listOf(
+        buildRoutingUtils(),
+        buildControllerResult()
+    )
+
+    /**
+     * Builds a data class to be used as a return type for controller methods
+     */
+    private fun buildControllerResult(): ControllerLibraryType {
+        val genericT = TypeVariableName("T")
+
+        val spec = TypeSpec.classBuilder(CONTROLLER_RESULT_CLASS_NAME)
+            .addModifiers(KModifier.DATA)
+            .addTypeVariable(genericT)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("status", ClassName("io.ktor.http", "HttpStatusCode"))
+                    .addParameter("message", genericT) // naming aligned with Ktor's call.response(status, message)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("status", ClassName("io.ktor.http", "HttpStatusCode"))
+                    .initializer("status")
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("message", genericT)
+                    .initializer("message")
+                    .build()
+            )
+            .build()
+
+        return ControllerLibraryType(spec, packages.base)
+    }
+
+    /**
+     * Builds a utility object to be used for parsing query parameters
+     */
+    private fun buildRoutingUtils(): ControllerLibraryType {
+        val genericR = TypeVariableName("R", Any::class)
+
+        val returnType = genericR.copy(nullable = true, reified = true)
+
+        val spec = TypeSpec.objectBuilder("RoutingUtils")
+            .addFunction(
+                // Function for getting a typed query parameter
+                // Similar to Ktor's getOrFail but will not fail on missing parameter
+                FunSpec.builder("getTyped")
+                    .addModifiers(KModifier.INLINE)
+                    .receiver(ClassName("io.ktor.http", "Parameters"))
+                    .addParameter("name", String::class)
+                    .addTypeVariable(returnType)
+                    .returns(returnType)
+                    .addCode("""
+                        val values = getAll(name) ?: return null
+                        val typeInfo = typeInfo<R>()
+                        return try {
+                            @Suppress("UNCHECKED_CAST")
+                            DefaultConversionService.fromValues(values, typeInfo) as R
+                        } catch (cause: Exception) {
+                            throw ParameterConversionException(name, typeInfo.type.simpleName ?: typeInfo.type.toString(), cause)
+                        }
+                    """.trimIndent())
+                    .addKdoc("""
+                        Gets parameter value associated with this name or null if the name is not present.
+                        Converting to type R using DefaultConversionService.
+                        
+                        Throws:
+                          ParameterConversionException - when conversion from String to R fails
+                    """.trimIndent())
+                    .build()
+            )
+            .addFunction(
+                // Function for getting typed header parameter
+                FunSpec.builder("getOrFail")
+                    .receiver(ClassName("io.ktor.http", "Headers"))
+                    .returns(String::class)
+                    .addParameter("name", String::class)
+                    .addCode("""
+                        return this[name] ?: throw BadRequestException("Header " + name + " is required")
+                    """.trimIndent())
+                    .addKdoc("""
+                        Gets first value from the list of values associated with a name.
+                        
+                        Throws:
+                          BadRequestException - when the name is not present
+                    """.trimIndent())
+                    .build()
+            )
+            .build()
+
+        return ControllerLibraryType(spec, packages.base, imports = setOf(
+            Import("io.ktor.util.reflect", "typeInfo"),
+            Import("io.ktor.server.plugins", "BadRequestException"),
+            Import("io.ktor.util.converters", "DefaultConversionService"),
+            Import("io.ktor.server.plugins", "ParameterConversionException"),
+        ))
+    }
+
+    private fun getMethodName(
+        operation: Operation, verb: String, path: Map.Entry<String, Path>
+    ) = ControllerGeneratorUtils.methodName(
+        operation, verb, path.value.pathString.isSingleResource()
+    )
+
+    private val usedVerbs: List<String> =
+        api.openApi3.routeToPaths()
+            .flatMap { resourceToPaths -> resourceToPaths.value.flatMap { it.value.operations.keys } }
+            .distinct()
+
+    data class KtorControllers(
+        val controllers: Set<ControllerType>,
+        val globalImports: Set<Import>,
+    ) : KotlinTypes(controllers) {
+        override val files: Collection<FileSpec> = super.files.map { fileSpec ->
+            fileSpec.toBuilder().apply {
+                // Could be improved by only importing what is necessary in the specific file
+                globalImports.forEach { addImport(it.packageName, it.name) }
+            }.build()
+        }
+    }
+}
+
+private fun List<IncomingParameter>.splitByType(): IncomingParametersByType {
+    val requestParams = this.filterIsInstance<RequestParameter>()
+
+    return IncomingParametersByType(
+        pathParams = requestParams.filter { it.parameterLocation is PathParam },
+        queryParams = requestParams.filter { it.parameterLocation is QueryParam },
+        headerParams = requestParams.filter { it.parameterLocation is HeaderParam },
+        bodyParams = this.filterIsInstance<BodyParameter>()
+    )
+}
+
+private data class IncomingParametersByType(
+    val pathParams: List<RequestParameter>,
+    val queryParams: List<RequestParameter>,
+    val headerParams: List<RequestParameter>,
+    val bodyParams: List<BodyParameter>,
+)
+
+private fun TypeName.simpleName(): String = this.toString().split(".").last()

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -13,7 +13,6 @@ import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports
 import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports.SECURITY_RULE_IS_ANONYMOUS
 import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports.SECURITY_RULE_IS_AUTHENTICATED
 import com.cjbooms.fabrikt.model.BodyParameter
-import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypes
@@ -53,8 +52,6 @@ class MicronautControllerInterfaceGenerator(
             }.toSet(),
             addAuthenticationParameter,
         )
-
-    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     override fun controllerBuilder(
         className: String,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -13,6 +13,7 @@ import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports
 import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports.SECURITY_RULE_IS_ANONYMOUS
 import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports.SECURITY_RULE_IS_AUTHENTICATED
 import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypes
@@ -37,7 +38,7 @@ class MicronautControllerInterfaceGenerator(
     private val api: SourceApi,
     private val validationAnnotations: ValidationAnnotations,
     private val options: Set<ControllerCodeGenOptionType> = emptySet(),
-) : ControllerInterfaceGenerator(packages, api, validationAnnotations) {
+) : ControllerInterfaceGenerator, AnnotationBasedControllerInterfaceGenerator(packages, api, validationAnnotations) {
 
     private val useSuspendModifier: Boolean
         get() = options.any { it == ControllerCodeGenOptionType.SUSPEND_MODIFIER }
@@ -52,6 +53,8 @@ class MicronautControllerInterfaceGenerator(
             }.toSet(),
             addAuthenticationParameter,
         )
+
+    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     override fun controllerBuilder(
         className: String,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -11,6 +11,7 @@ import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securi
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringAnnotations
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports
 import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
@@ -36,7 +37,7 @@ class SpringControllerInterfaceGenerator(
     private val api: SourceApi,
     private val validationAnnotations: ValidationAnnotations,
     private val options: Set<ControllerCodeGenOptionType> = emptySet(),
-) : ControllerInterfaceGenerator(packages, api, validationAnnotations) {
+) : ControllerInterfaceGenerator, AnnotationBasedControllerInterfaceGenerator(packages, api, validationAnnotations) {
 
     private val addAuthenticationParameter: Boolean
         get() = options.any { it == ControllerCodeGenOptionType.AUTHENTICATION }
@@ -47,6 +48,8 @@ class SpringControllerInterfaceGenerator(
                 buildController(resourceName, paths.values)
             }.toSet(),
         )
+
+    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     override fun controllerBuilder(
         className: String,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -11,7 +11,6 @@ import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securi
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringAnnotations
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports
 import com.cjbooms.fabrikt.model.BodyParameter
-import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
@@ -48,8 +47,6 @@ class SpringControllerInterfaceGenerator(
                 buildController(resourceName, paths.values)
             }.toSet(),
         )
-
-    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     override fun controllerBuilder(
         className: String,

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -41,9 +41,6 @@ class ControllerType(spec: TypeSpec, basePackage: String) : GeneratedType(spec, 
     }
 }
 
-class ControllerLibraryType(spec: TypeSpec, basePackage: String) :
-    GeneratedType(spec, controllersPackage(basePackage))
-
 data class Models(val models: Collection<ModelType>) : KotlinTypes(models) {
     override val files: Collection<FileSpec> = models.toFileSpec()
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -41,6 +41,11 @@ class ControllerType(spec: TypeSpec, basePackage: String) : GeneratedType(spec, 
     }
 }
 
+class ControllerLibraryType(spec: TypeSpec, basePackage: String, val imports: Collection<Import> = emptySet()) :
+    GeneratedType(spec, controllersPackage(basePackage))
+
+data class Import(val packageName: String, val name: String)
+
 data class Models(val models: Collection<ModelType>) : KotlinTypes(models) {
     override val files: Collection<FileSpec> = models.toFileSpec()
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -41,10 +41,8 @@ class ControllerType(spec: TypeSpec, basePackage: String) : GeneratedType(spec, 
     }
 }
 
-class ControllerLibraryType(spec: TypeSpec, basePackage: String, val imports: Collection<Import> = emptySet()) :
+class ControllerLibraryType(spec: TypeSpec, basePackage: String) :
     GeneratedType(spec, controllersPackage(basePackage))
-
-data class Import(val packageName: String, val name: String)
 
 data class Models(val models: Collection<ModelType>) : KotlinTypes(models) {
     override val files: Collection<FileSpec> = models.toFileSpec()

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -58,7 +58,7 @@ class KtorControllerInterfaceGeneratorTest {
 
     @ParameterizedTest
     @MethodSource("testCases")
-    fun `correct models are generated for different OpenApi Specifications`(testCaseName: String) {
+    fun `correct controllers are generated for different OpenApi Specifications`(testCaseName: String) {
         val basePackage = "examples.$testCaseName"
         val api = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
         val expectedControllers = readTextResource("/examples/$testCaseName/controllers/ktor/Controllers.kt")
@@ -196,12 +196,16 @@ class KtorControllerInterfaceGeneratorTest {
     @Test
     fun `ensure generates ByteArray body parameter and response for string with format binary`() {
         val api = SourceApi(readTextResource("/examples/binary/api.yaml"))
-        val controllers = KtorControllerInterfaceGenerator(
+        val generator = KtorControllerInterfaceGenerator(
             Packages(basePackage),
             api
-        ).generate().toSingleFile(emptySet())
+        )
+        val controllers = generator.generate()
+        val lib = generator.generateLibrary()
+
+        val fileStr = controllers.toSingleFile(lib)
         val expectedControllers = readTextResource("/examples/binary/controllers/ktor/Controllers.kt")
 
-        assertThat(controllers.trim()).isEqualTo(expectedControllers.trim())
+        assertThat(fileStr.trim()).isEqualTo(expectedControllers.trim())
     }
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -1,0 +1,182 @@
+package com.cjbooms.fabrikt.generators
+
+import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.cli.ControllerCodeGenTargetType
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.controller.KtorControllerInterfaceGenerator
+import com.cjbooms.fabrikt.model.ControllerLibraryType
+import com.cjbooms.fabrikt.model.Destinations.controllersPackage
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.Linter
+import com.cjbooms.fabrikt.util.ModelNameRegistry
+import com.cjbooms.fabrikt.util.ResourceHelper.readTextResource
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorControllerInterfaceGeneratorTest {
+    private val basePackage = "ie.zalando"
+    private lateinit var generated: Collection<FileSpec>
+
+    @Suppress("unused")
+    private fun testCases(): Stream<String> = Stream.of(
+        "githubApi",
+        "singleAllOf",
+        "pathLevelParameters",
+        "parameterNameClash",
+    )
+
+    private fun setupGithubApiTestEnv() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+        generated = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate().files
+    }
+
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(
+            genTypes = setOf(CodeGenerationType.CONTROLLERS),
+            controllerTarget = ControllerCodeGenTargetType.KTOR,
+        )
+        ModelNameRegistry.clear()
+    }
+
+    // @Test
+    // fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("singleAllOf")
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    fun `correct models are generated for different OpenApi Specifications`(testCaseName: String) {
+        val basePackage = "examples.$testCaseName"
+        val api = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
+        val expectedControllers = readTextResource("/examples/$testCaseName/controllers/ktor/Controllers.kt")
+
+        val ktorControllers = KtorControllerInterfaceGenerator(
+            Packages(basePackage),
+            api
+        )
+
+        val library = ktorControllers.generateLibrary()
+        val controllers = ktorControllers.generate().toSingleFile(library)
+
+        assertThat(controllers).isEqualTo(expectedControllers)
+    }
+
+    @Test
+    fun `should contain correct number of controller classes`() {
+        setupGithubApiTestEnv()
+        assertThat(generated.size).isEqualTo(6)
+    }
+
+    @Test
+    fun `the correct controllers are generated`() {
+        setupGithubApiTestEnv()
+        assertThat(generated.map { it.name })
+            .containsOnly(
+                "InternalEventsController",
+                "ContributorsController",
+                "OrganisationsController",
+                "OrganisationsContributorsController",
+                "RepositoriesController",
+                "RepositoriesPullRequestsController",
+            )
+    }
+
+    @Test
+    fun `ensure package is correct`() {
+        setupGithubApiTestEnv()
+        assertThat(generated.map { it.packageName }.distinct())
+            .containsOnly(controllersPackage(basePackage))
+    }
+
+    @Test
+    fun `ensure that subresource specific controllers are created`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+        val controllers = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate()
+
+        assertThat(controllers.files).size().isEqualTo(6)
+        assertThat(controllers.files.map { it.name }).containsAll(
+            listOf(
+                "ContributorsController",
+                "OrganisationsController",
+                "OrganisationsContributorsController",
+                "RepositoriesController",
+                "RepositoriesPullRequestsController",
+            ),
+        )
+
+        val linkedFunctionNames = controllers.files
+            .filter { it.name == "OrganisationsContributorsController" }
+            .flatMap { it.members }
+            .flatMap { (it as TypeSpec).funSpecs.map { t -> t.name } }
+        val ownedFunctionNames = controllers.files
+            .filter { it.name == "RepositoriesPullRequestsController" }
+            .flatMap { it.members }
+            .flatMap { (it as TypeSpec).funSpecs.map { t -> t.name } }
+        assertThat(linkedFunctionNames).containsExactlyInAnyOrder(
+            "get",
+            "getById",
+            "putById",
+            "deleteById",
+        )
+        assertThat(ownedFunctionNames).containsExactlyInAnyOrder(
+            "get",
+            "getById",
+            "post",
+            "putById",
+        )
+    }
+
+    @Test
+    fun `ensure controller methods has the suspend modifier`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+        val controllers = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate()
+
+        assertThat(controllers.files).size().isEqualTo(6)
+        assertThat(
+            controllers.files
+                .flatMap { file -> file.members }
+                .flatMap { (it as TypeSpec).funSpecs.map(FunSpec::modifiers) }
+                .all { it.contains(KModifier.SUSPEND) },
+        ).isTrue()
+    }
+
+    private fun KtorControllerInterfaceGenerator.KtorControllers.toSingleFile(extraSpecs: Collection<ControllerLibraryType>): String {
+        val destPackage = if (controllers.isNotEmpty()) controllers.first().destinationPackage else ""
+        val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
+
+        globalImports.forEach {
+            singleFileBuilder.addImport(it.packageName, it.name)
+        }
+
+        controllers.forEach {
+            singleFileBuilder.addType(it.spec)
+        }
+
+        extraSpecs.forEach {
+            singleFileBuilder.addType(it.spec)
+            it.imports.forEach { import -> singleFileBuilder.addImport(import.packageName, import.name) }
+        }
+
+        val singleFileString = singleFileBuilder.build().toString()
+
+        return Linter.lintString(singleFileString)
+    }
+
+    @Test
+    fun `ensure generates ByteArray body parameter and response for string with format binary`() {
+        val api = SourceApi(readTextResource("/examples/binary/api.yaml"))
+        val controllers = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate().toSingleFile(emptySet())
+        val expectedControllers = readTextResource("/examples/binary/controllers/ktor/Controllers.kt")
+
+        assertThat(controllers.trim()).isEqualTo(expectedControllers.trim())
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -5,7 +5,6 @@ import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.cli.ControllerCodeGenTargetType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.controller.KtorControllerInterfaceGenerator
-import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.Destinations.controllersPackage
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.Linter
@@ -68,8 +67,7 @@ class KtorControllerInterfaceGeneratorTest {
             api
         )
 
-        val library = ktorControllers.generateLibrary()
-        val controllers = ktorControllers.generate().toSingleFile(library)
+        val controllers = ktorControllers.generate().toSingleFile()
 
         assertThat(controllers).isEqualTo(expectedControllers)
     }
@@ -80,13 +78,11 @@ class KtorControllerInterfaceGeneratorTest {
         val api = SourceApi(readTextResource("/examples/authentication/api.yaml"))
         val expectedControllers = readTextResource("/examples/authentication/controllers/ktor/Controllers.kt")
 
-        val generator = KtorControllerInterfaceGenerator(
+        val controllers = KtorControllerInterfaceGenerator(
             Packages(basePackage),
             api,
             setOf(ControllerCodeGenOptionType.AUTHENTICATION),
-        )
-        val library = generator.generateLibrary()
-        val controllers = generator.generate().toSingleFile(library)
+        ).generate().toSingleFile()
 
         assertThat(controllers).isEqualTo(expectedControllers)
     }
@@ -176,15 +172,11 @@ class KtorControllerInterfaceGeneratorTest {
         ).isTrue()
     }
 
-    private fun KtorControllerInterfaceGenerator.KtorControllers.toSingleFile(extraSpecs: Collection<ControllerLibraryType>): String {
+    private fun KtorControllerInterfaceGenerator.KtorControllers.toSingleFile(): String {
         val destPackage = if (controllers.isNotEmpty()) controllers.first().destinationPackage else ""
         val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
 
         controllers.forEach {
-            singleFileBuilder.addType(it.spec)
-        }
-
-        extraSpecs.forEach {
             singleFileBuilder.addType(it.spec)
         }
 
@@ -201,9 +193,8 @@ class KtorControllerInterfaceGeneratorTest {
             api
         )
         val controllers = generator.generate()
-        val lib = generator.generateLibrary()
 
-        val fileStr = controllers.toSingleFile(lib)
+        val fileStr = controllers.toSingleFile()
         val expectedControllers = readTextResource("/examples/binary/controllers/ktor/Controllers.kt")
 
         assertThat(fileStr.trim()).isEqualTo(expectedControllers.trim())

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -180,17 +180,12 @@ class KtorControllerInterfaceGeneratorTest {
         val destPackage = if (controllers.isNotEmpty()) controllers.first().destinationPackage else ""
         val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
 
-        globalImports.forEach {
-            singleFileBuilder.addImport(it.packageName, it.name)
-        }
-
         controllers.forEach {
             singleFileBuilder.addType(it.spec)
         }
 
         extraSpecs.forEach {
             singleFileBuilder.addType(it.spec)
-            it.imports.forEach { import -> singleFileBuilder.addImport(import.packageName, import.name) }
         }
 
         val singleFileString = singleFileBuilder.build().toString()

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.generators
 
 import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.cli.ControllerCodeGenTargetType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.controller.KtorControllerInterfaceGenerator
@@ -37,7 +38,10 @@ class KtorControllerInterfaceGeneratorTest {
 
     private fun setupGithubApiTestEnv() {
         val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
-        generated = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate().files
+        generated = KtorControllerInterfaceGenerator(
+            Packages(basePackage),
+            api
+        ).generate().files
     }
 
     @BeforeEach
@@ -66,6 +70,23 @@ class KtorControllerInterfaceGeneratorTest {
 
         val library = ktorControllers.generateLibrary()
         val controllers = ktorControllers.generate().toSingleFile(library)
+
+        assertThat(controllers).isEqualTo(expectedControllers)
+    }
+
+    @Test
+    fun `correct controllers are generated for ControllerCodeGenOptionType_AUTHENTICATION`() {
+        val basePackage = "examples.authentication"
+        val api = SourceApi(readTextResource("/examples/authentication/api.yaml"))
+        val expectedControllers = readTextResource("/examples/authentication/controllers/ktor/Controllers.kt")
+
+        val generator = KtorControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            setOf(ControllerCodeGenOptionType.AUTHENTICATION),
+        )
+        val library = generator.generateLibrary()
+        val controllers = generator.generate().toSingleFile(library)
 
         assertThat(controllers).isEqualTo(expectedControllers)
     }
@@ -100,7 +121,10 @@ class KtorControllerInterfaceGeneratorTest {
     @Test
     fun `ensure that subresource specific controllers are created`() {
         val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
-        val controllers = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate()
+        val controllers = KtorControllerInterfaceGenerator(
+            Packages(basePackage),
+            api
+        ).generate()
 
         assertThat(controllers.files).size().isEqualTo(6)
         assertThat(controllers.files.map { it.name }).containsAll(
@@ -138,7 +162,10 @@ class KtorControllerInterfaceGeneratorTest {
     @Test
     fun `ensure controller methods has the suspend modifier`() {
         val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
-        val controllers = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate()
+        val controllers = KtorControllerInterfaceGenerator(
+            Packages(basePackage),
+            api
+        ).generate()
 
         assertThat(controllers.files).size().isEqualTo(6)
         assertThat(
@@ -174,7 +201,10 @@ class KtorControllerInterfaceGeneratorTest {
     @Test
     fun `ensure generates ByteArray body parameter and response for string with format binary`() {
         val api = SourceApi(readTextResource("/examples/binary/api.yaml"))
-        val controllers = KtorControllerInterfaceGenerator(Packages(basePackage), api).generate().toSingleFile(emptySet())
+        val controllers = KtorControllerInterfaceGenerator(
+            Packages(basePackage),
+            api
+        ).generate().toSingleFile(emptySet())
         val expectedControllers = readTextResource("/examples/binary/controllers/ktor/Controllers.kt")
 
         assertThat(controllers.trim()).isEqualTo(expectedControllers.trim())

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -1,6 +1,5 @@
 package examples.authentication.controllers
 
-import examples.authentication.controllers.RoutingUtils.getOrFail
 import io.ktor.http.Headers
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
@@ -37,6 +36,38 @@ public interface RequiredController {
                 }
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -56,6 +87,38 @@ public interface ProhibitedController {
                 call.respond(result.status)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -77,6 +140,38 @@ public interface OptionalController {
                 }
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -96,6 +191,38 @@ public interface NoneController {
                 call.respond(result.status)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -117,41 +244,39 @@ public interface DefaultController {
                 }
             }
         }
-    }
-}
 
-public object RoutingUtils {
-    /**
-     * Gets parameter value associated with this name or null if the name is not present.
-     * Converting to type R using DefaultConversionService.
-     *
-     * Throws:
-     *   ParameterConversionException - when conversion from String to R fails
-     */
-    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
-        val values = getAll(name) ?: return null
-        val typeInfo = typeInfo<R>()
-        return try {
-            @Suppress("UNCHECKED_CAST")
-            DefaultConversionService.fromValues(values, typeInfo) as R
-        } catch (cause: Exception) {
-            throw ParameterConversionException(
-                name,
-                typeInfo.type.simpleName
-                    ?: typeInfo.type.toString(),
-                cause,
-            )
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
         }
-    }
 
-    /**
-     * Gets first value from the list of values associated with a name.
-     *
-     * Throws:
-     *   BadRequestException - when the name is not present
-     */
-    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
-        BadRequestException("Header " + name + " is required")
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
+    }
 }
 
 public data class ControllerResult<T>(

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -8,7 +8,6 @@ import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.`get`
 import io.ktor.server.util.getOrFail
@@ -16,7 +15,6 @@ import io.ktor.util.converters.DefaultConversionService
 import io.ktor.util.reflect.typeInfo
 import kotlin.Any
 import kotlin.String
-import kotlin.Unit
 
 public interface RequiredController {
     /**
@@ -24,15 +22,14 @@ public interface RequiredController {
      *
      * @param testString
      */
-    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+    public suspend fun testPath(call: ApplicationCall, testString: String)
 
     public companion object {
         public fun Route.requiredRoutes(controller: RequiredController) {
             authenticate("BasicAuth", optional = false) {
                 `get`("/required") {
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    val result = controller.testPath(call, testString)
-                    call.respond(result.status)
+                    controller.testPath(call, testString)
                 }
             }
         }
@@ -77,14 +74,13 @@ public interface ProhibitedController {
      *
      * @param testString
      */
-    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+    public suspend fun testPath(call: ApplicationCall, testString: String)
 
     public companion object {
         public fun Route.prohibitedRoutes(controller: ProhibitedController) {
             `get`("/prohibited") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                val result = controller.testPath(call, testString)
-                call.respond(result.status)
+                controller.testPath(call, testString)
             }
         }
 
@@ -128,15 +124,14 @@ public interface OptionalController {
      *
      * @param testString
      */
-    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+    public suspend fun testPath(call: ApplicationCall, testString: String)
 
     public companion object {
         public fun Route.optionalRoutes(controller: OptionalController) {
             authenticate("BasicAuth", optional = true) {
                 `get`("/optional") {
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    val result = controller.testPath(call, testString)
-                    call.respond(result.status)
+                    controller.testPath(call, testString)
                 }
             }
         }
@@ -181,14 +176,13 @@ public interface NoneController {
      *
      * @param testString
      */
-    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+    public suspend fun testPath(call: ApplicationCall, testString: String)
 
     public companion object {
         public fun Route.noneRoutes(controller: NoneController) {
             `get`("/none") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                val result = controller.testPath(call, testString)
-                call.respond(result.status)
+                controller.testPath(call, testString)
             }
         }
 
@@ -232,15 +226,14 @@ public interface DefaultController {
      *
      * @param testString
      */
-    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+    public suspend fun testPath(call: ApplicationCall, testString: String)
 
     public companion object {
         public fun Route.defaultRoutes(controller: DefaultController) {
             authenticate("basicAuth", optional = false) {
                 `get`("/default") {
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    val result = controller.testPath(call, testString)
-                    call.respond(result.status)
+                    controller.testPath(call, testString)
                 }
             }
         }

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -1,7 +1,6 @@
 package examples.authentication.controllers
 
 import io.ktor.http.Headers
-import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
@@ -21,14 +20,16 @@ import kotlin.String
 
 public interface RequiredController {
     /**
-     *
+     * Route is expected to respond with status 200.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param testString
+     * @param call The Ktor application call
      */
     public suspend fun testPath(
-        call: ApplicationCall,
         testString: String,
         principal: Principal,
+        call: ApplicationCall,
     )
 
     public companion object {
@@ -38,7 +39,7 @@ public interface RequiredController {
                     val principal = call.principal<Principal>() ?: throw
                         IllegalStateException("Principal not found")
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    controller.testPath(call, testString, principal)
+                    controller.testPath(testString, principal, call)
                 }
             }
         }
@@ -79,17 +80,19 @@ public interface RequiredController {
 
 public interface ProhibitedController {
     /**
-     *
+     * Route is expected to respond with status 200.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param testString
+     * @param call The Ktor application call
      */
-    public suspend fun testPath(call: ApplicationCall, testString: String)
+    public suspend fun testPath(testString: String, call: ApplicationCall)
 
     public companion object {
         public fun Route.prohibitedRoutes(controller: ProhibitedController) {
             `get`("/prohibited") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                controller.testPath(call, testString)
+                controller.testPath(testString, call)
             }
         }
 
@@ -129,14 +132,16 @@ public interface ProhibitedController {
 
 public interface OptionalController {
     /**
-     *
+     * Route is expected to respond with status 200.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param testString
+     * @param call The Ktor application call
      */
     public suspend fun testPath(
-        call: ApplicationCall,
         testString: String,
         principal: Principal?,
+        call: ApplicationCall,
     )
 
     public companion object {
@@ -145,7 +150,7 @@ public interface OptionalController {
                 `get`("/optional") {
                     val principal = call.principal<Principal>()
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    controller.testPath(call, testString, principal)
+                    controller.testPath(testString, principal, call)
                 }
             }
         }
@@ -186,17 +191,19 @@ public interface OptionalController {
 
 public interface NoneController {
     /**
-     *
+     * Route is expected to respond with status 200.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param testString
+     * @param call The Ktor application call
      */
-    public suspend fun testPath(call: ApplicationCall, testString: String)
+    public suspend fun testPath(testString: String, call: ApplicationCall)
 
     public companion object {
         public fun Route.noneRoutes(controller: NoneController) {
             `get`("/none") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                controller.testPath(call, testString)
+                controller.testPath(testString, call)
             }
         }
 
@@ -236,14 +243,16 @@ public interface NoneController {
 
 public interface DefaultController {
     /**
-     *
+     * Route is expected to respond with status 200.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param testString
+     * @param call The Ktor application call
      */
     public suspend fun testPath(
-        call: ApplicationCall,
         testString: String,
         principal: Principal,
+        call: ApplicationCall,
     )
 
     public companion object {
@@ -253,7 +262,7 @@ public interface DefaultController {
                     val principal = call.principal<Principal>() ?: throw
                         IllegalStateException("Principal not found")
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    controller.testPath(call, testString, principal)
+                    controller.testPath(testString, principal, call)
                 }
             }
         }
@@ -291,8 +300,3 @@ public interface DefaultController {
             BadRequestException("Header " + name + " is required")
     }
 }
-
-public data class ControllerResult<T>(
-    public val status: HttpStatusCode,
-    public val message: T,
-)

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -1,0 +1,160 @@
+package examples.authentication.controllers
+
+import examples.authentication.controllers.RoutingUtils.getOrFail
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.`get`
+import io.ktor.server.util.getOrFail
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
+import kotlin.String
+import kotlin.Unit
+
+public interface RequiredController {
+    /**
+     *
+     *
+     * @param testString
+     */
+    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.requiredRoutes(controller: RequiredController) {
+            authenticate("BasicAuth") {
+                get("/required") {
+                    val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
+                    val result = controller.testPath(call, testString)
+                    call.respond(result.status)
+                }
+            }
+        }
+    }
+}
+
+public interface ProhibitedController {
+    /**
+     *
+     *
+     * @param testString
+     */
+    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.prohibitedRoutes(controller: ProhibitedController) {
+            get("/prohibited") {
+                val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
+                val result = controller.testPath(call, testString)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public interface OptionalController {
+    /**
+     *
+     *
+     * @param testString
+     */
+    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.optionalRoutes(controller: OptionalController) {
+            authenticate("BasicAuth", optional = true) {
+                get("/optional") {
+                    val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
+                    val result = controller.testPath(call, testString)
+                    call.respond(result.status)
+                }
+            }
+        }
+    }
+}
+
+public interface NoneController {
+    /**
+     *
+     *
+     * @param testString
+     */
+    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.noneRoutes(controller: NoneController) {
+            get("/none") {
+                val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
+                val result = controller.testPath(call, testString)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public interface DefaultController {
+    /**
+     *
+     *
+     * @param testString
+     */
+    public suspend fun testPath(call: ApplicationCall, testString: String): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.defaultRoutes(controller: DefaultController) {
+            authenticate("basicAuth") {
+                get("/default") {
+                    val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
+                    val result = controller.testPath(call, testString)
+                    call.respond(result.status)
+                }
+            }
+        }
+    }
+}
+
+public object RoutingUtils {
+    /**
+     * Gets parameter value associated with this name or null if the name is not present.
+     * Converting to type R using DefaultConversionService.
+     *
+     * Throws:
+     *   ParameterConversionException - when conversion from String to R fails
+     */
+    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+        val values = getAll(name) ?: return null
+        val typeInfo = typeInfo<R>()
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            DefaultConversionService.fromValues(values, typeInfo) as R
+        } catch (cause: Exception) {
+            throw ParameterConversionException(
+                name,
+                typeInfo.type.simpleName
+                    ?: typeInfo.type.toString(),
+                cause,
+            )
+        }
+    }
+
+    /**
+     * Gets first value from the list of values associated with a name.
+     *
+     * Throws:
+     *   BadRequestException - when the name is not present
+     */
+    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
+        BadRequestException("Header " + name + " is required")
+}
+
+public data class ControllerResult<T>(
+    public val status: HttpStatusCode,
+    public val message: T,
+)

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -33,6 +33,11 @@ public interface RequiredController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Required resource
+         *
+         * - GET /required
+         */
         public fun Route.requiredRoutes(controller: RequiredController) {
             authenticate("BasicAuth", optional = false) {
                 `get`("/required") {
@@ -89,6 +94,11 @@ public interface ProhibitedController {
     public suspend fun testPath(testString: String, call: ApplicationCall)
 
     public companion object {
+        /**
+         * Mounts all routes for the Prohibited resource
+         *
+         * - GET /prohibited
+         */
         public fun Route.prohibitedRoutes(controller: ProhibitedController) {
             `get`("/prohibited") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
@@ -145,6 +155,11 @@ public interface OptionalController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Optional resource
+         *
+         * - GET /optional
+         */
         public fun Route.optionalRoutes(controller: OptionalController) {
             authenticate("BasicAuth", optional = true) {
                 `get`("/optional") {
@@ -200,6 +215,11 @@ public interface NoneController {
     public suspend fun testPath(testString: String, call: ApplicationCall)
 
     public companion object {
+        /**
+         * Mounts all routes for the None resource
+         *
+         * - GET /none
+         */
         public fun Route.noneRoutes(controller: NoneController) {
             `get`("/none") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
@@ -256,6 +276,11 @@ public interface DefaultController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Default resource
+         *
+         * - GET /default
+         */
         public fun Route.defaultRoutes(controller: DefaultController) {
             authenticate("basicAuth", optional = false) {
                 `get`("/default") {

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -28,8 +28,8 @@ public interface RequiredController {
 
     public companion object {
         public fun Route.requiredRoutes(controller: RequiredController) {
-            authenticate("BasicAuth") {
-                get("/required") {
+            authenticate("BasicAuth", optional = false) {
+                `get`("/required") {
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
                     val result = controller.testPath(call, testString)
                     call.respond(result.status)
@@ -81,7 +81,7 @@ public interface ProhibitedController {
 
     public companion object {
         public fun Route.prohibitedRoutes(controller: ProhibitedController) {
-            get("/prohibited") {
+            `get`("/prohibited") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
                 val result = controller.testPath(call, testString)
                 call.respond(result.status)
@@ -133,7 +133,7 @@ public interface OptionalController {
     public companion object {
         public fun Route.optionalRoutes(controller: OptionalController) {
             authenticate("BasicAuth", optional = true) {
-                get("/optional") {
+                `get`("/optional") {
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
                     val result = controller.testPath(call, testString)
                     call.respond(result.status)
@@ -185,7 +185,7 @@ public interface NoneController {
 
     public companion object {
         public fun Route.noneRoutes(controller: NoneController) {
-            get("/none") {
+            `get`("/none") {
                 val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
                 val result = controller.testPath(call, testString)
                 call.respond(result.status)
@@ -236,8 +236,8 @@ public interface DefaultController {
 
     public companion object {
         public fun Route.defaultRoutes(controller: DefaultController) {
-            authenticate("basicAuth") {
-                get("/default") {
+            authenticate("basicAuth", optional = false) {
+                `get`("/default") {
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
                     val result = controller.testPath(call, testString)
                     call.respond(result.status)

--- a/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
@@ -26,6 +26,11 @@ public interface BinaryDataController {
     public suspend fun postBinaryData(applicationOctetStream: ByteArray, call: ApplicationCall)
 
     public companion object {
+        /**
+         * Mounts all routes for the BinaryData resource
+         *
+         * - POST /binary-data
+         */
         public fun Route.binaryDataRoutes(controller: BinaryDataController) {
             post("/binary-data") {
                 val applicationOctetStream = call.receive<ByteArray>()

--- a/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
@@ -1,12 +1,20 @@
 package ie.zalando.controllers
 
+import io.ktor.http.Headers
+import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ParameterConversionException
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
 import kotlin.ByteArray
+import kotlin.String
 
 public interface BinaryDataController {
     /**
@@ -24,5 +32,37 @@ public interface BinaryDataController {
                 call.respond(result.status, result.message)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }

--- a/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
@@ -1,0 +1,28 @@
+package ie.zalando.controllers
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import kotlin.ByteArray
+
+public interface BinaryDataController {
+    /**
+     *
+     *
+     * @param applicationOctetStream
+     */
+    public suspend fun postBinaryData(call: ApplicationCall, applicationOctetStream: ByteArray): ControllerResult<ByteArray>
+
+    public companion object {
+        public fun Route.binaryDataRoutes(controller: BinaryDataController) {
+            post("/binary-data") {
+                val applicationOctetStream = call.receive<ByteArray>()
+                val result = controller.postBinaryData(call, applicationOctetStream)
+                call.respond(result.status, result.message)
+            }
+        }
+    }
+}

--- a/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
@@ -7,7 +7,6 @@ import io.ktor.server.application.call
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
 import io.ktor.server.request.receive
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import io.ktor.util.converters.DefaultConversionService
@@ -18,18 +17,19 @@ import kotlin.String
 
 public interface BinaryDataController {
     /**
-     *
+     * Route is expected to respond with [kotlin.ByteArray].
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param applicationOctetStream
+     * @param call The Ktor application call
      */
-    public suspend fun postBinaryData(call: ApplicationCall, applicationOctetStream: ByteArray): ControllerResult<ByteArray>
+    public suspend fun postBinaryData(applicationOctetStream: ByteArray, call: ApplicationCall)
 
     public companion object {
         public fun Route.binaryDataRoutes(controller: BinaryDataController) {
             post("/binary-data") {
                 val applicationOctetStream = call.receive<ByteArray>()
-                val result = controller.postBinaryData(call, applicationOctetStream)
-                call.respond(result.status, result.message)
+                controller.postBinaryData(applicationOctetStream, call)
             }
         }
 

--- a/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
@@ -18,7 +18,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
-import io.ktor.server.auth.authenticate
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
 import io.ktor.server.request.receive
@@ -48,12 +47,10 @@ public interface InternalEventsController {
 
     public companion object {
         public fun Route.internalEventsRoutes(controller: InternalEventsController) {
-            authenticate("oauth2") {
-                post("/internal/events") {
-                    val bulkEntityDetails = call.receive<BulkEntityDetails>()
-                    val result = controller.post(call, bulkEntityDetails)
-                    call.respond(result.status, result.message)
-                }
+            post("/internal/events") {
+                val bulkEntityDetails = call.receive<BulkEntityDetails>()
+                val result = controller.post(call, bulkEntityDetails)
+                call.respond(result.status, result.message)
             }
         }
     }

--- a/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
@@ -40,6 +40,11 @@ public interface InternalEventsController {
     public suspend fun post(bulkEntityDetails: BulkEntityDetails, call: ApplicationCall)
 
     public companion object {
+        /**
+         * Mounts all routes for the InternalEvents resource
+         *
+         * - POST /internal/events Generate change events for a list of entities
+         */
         public fun Route.internalEventsRoutes(controller: InternalEventsController) {
             post("/internal/events") {
                 val bulkEntityDetails = call.receive<BulkEntityDetails>()
@@ -188,6 +193,14 @@ public interface ContributorsController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Contributors resource
+         *
+         * - GET /contributors Page through all the Contributor resources matching the query filters
+         * - POST /contributors Create a new Contributor
+         * - GET /contributors/{id} Get a Contributor by ID
+         * - PUT /contributors/{id} Update an existing Contributor
+         */
         public fun Route.contributorsRoutes(controller: ContributorsController) {
             `get`("/contributors") {
                 val xFlowId = call.request.headers["X-Flow-Id"]
@@ -362,6 +375,14 @@ public interface OrganisationsController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Organisations resource
+         *
+         * - GET /organisations Page through all the Organisation resources matching the query filters
+         * - POST /organisations Create a new Organisation
+         * - GET /organisations/{id} Get a Organisation by ID
+         * - PUT /organisations/{id} Update an existing Organisation
+         */
         public fun Route.organisationsRoutes(controller: OrganisationsController) {
             `get`("/organisations") {
                 val xFlowId = call.request.headers["X-Flow-Id"]
@@ -532,6 +553,18 @@ public interface OrganisationsContributorsController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the OrganisationsContributors resource
+         *
+         * - GET /organisations/{parent-id}/contributors Page through all the Contributor resources for
+         * this parent Organisation matching the query filters
+         * - GET /organisations/{parent-id}/contributors/{id} Get a Contributor for this Organisation by
+         * ID
+         * - PUT /organisations/{parent-id}/contributors/{id} Add an existing Contributor to this
+         * Organisation
+         * - DELETE /organisations/{parent-id}/contributors/{id} Remove Contributor from this
+         * Organisation. Does not delete the underlying Contributor.
+         */
         public fun Route.organisationsContributorsRoutes(controller: OrganisationsContributorsController) {
             `get`("/organisations/{parent-id}/contributors") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
@@ -710,6 +743,14 @@ public interface RepositoriesController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Repositories resource
+         *
+         * - GET /repositories Page through all the Repository resources matching the query filters
+         * - POST /repositories Create a new Repository
+         * - GET /repositories/{id} Get a Repository by ID
+         * - PUT /repositories/{id} Update an existing Repository
+         */
         public fun Route.repositoriesRoutes(controller: RepositoriesController) {
             `get`("/repositories") {
                 val xFlowId = call.request.headers["X-Flow-Id"]
@@ -894,6 +935,18 @@ public interface RepositoriesPullRequestsController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the RepositoriesPullRequests resource
+         *
+         * - GET /repositories/{parent-id}/pull-requests Page through all the PullRequest resources for
+         * this parent Repository matching the query filters
+         * - POST /repositories/{parent-id}/pull-requests Create a new PullRequest for this parent
+         * Repository
+         * - GET /repositories/{parent-id}/pull-requests/{id} Get a PullRequest for this Repository by
+         * ID
+         * - PUT /repositories/{parent-id}/pull-requests/{id} Update the PullRequest owned by this
+         * Repository
+         */
         public fun Route.repositoriesPullRequestsRoutes(controller: RepositoriesPullRequestsController) {
             `get`("/repositories/{parent-id}/pull-requests") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")

--- a/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
@@ -189,7 +189,7 @@ public interface ContributorsController {
 
     public companion object {
         public fun Route.contributorsRoutes(controller: ContributorsController) {
-            get("/contributors") {
+            `get`("/contributors") {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
                 val includeInactive =
@@ -205,7 +205,7 @@ public interface ContributorsController {
                 val result = controller.createContributor(call, xFlowId, idempotencyKey, contributor)
                 call.respond(result.status)
             }
-            get("/contributors/{id}") {
+            `get`("/contributors/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val ifNoneMatch = call.request.headers["If-None-Match"]
@@ -362,7 +362,7 @@ public interface OrganisationsController {
 
     public companion object {
         public fun Route.organisationsRoutes(controller: OrganisationsController) {
-            get("/organisations") {
+            `get`("/organisations") {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
                 val includeInactive =
@@ -378,7 +378,7 @@ public interface OrganisationsController {
                 val result = controller.post(call, xFlowId, idempotencyKey, organisation)
                 call.respond(result.status)
             }
-            get("/organisations/{id}") {
+            `get`("/organisations/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val ifNoneMatch = call.request.headers["If-None-Match"]
@@ -529,7 +529,7 @@ public interface OrganisationsContributorsController {
 
     public companion object {
         public fun Route.organisationsContributorsRoutes(controller: OrganisationsContributorsController) {
-            get("/organisations/{parent-id}/contributors") {
+            `get`("/organisations/{parent-id}/contributors") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
@@ -539,7 +539,7 @@ public interface OrganisationsContributorsController {
                 val result = controller.get(call, xFlowId, parentId, limit, includeInactive, cursor)
                 call.respond(result.status, result.message)
             }
-            get("/organisations/{parent-id}/contributors/{id}") {
+            `get`("/organisations/{parent-id}/contributors/{id}") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
@@ -708,7 +708,7 @@ public interface RepositoriesController {
 
     public companion object {
         public fun Route.repositoriesRoutes(controller: RepositoriesController) {
-            get("/repositories") {
+            `get`("/repositories") {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
                 val slug =
@@ -728,7 +728,7 @@ public interface RepositoriesController {
                 val result = controller.post(call, xFlowId, idempotencyKey, repository)
                 call.respond(result.status)
             }
-            get("/repositories/{id}") {
+            `get`("/repositories/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val ifNoneMatch = call.request.headers["If-None-Match"]
@@ -890,7 +890,7 @@ public interface RepositoriesPullRequestsController {
 
     public companion object {
         public fun Route.repositoriesPullRequestsRoutes(controller: RepositoriesPullRequestsController) {
-            get("/repositories/{parent-id}/pull-requests") {
+            `get`("/repositories/{parent-id}/pull-requests") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
@@ -908,7 +908,7 @@ public interface RepositoriesPullRequestsController {
                 val result = controller.post(call, xFlowId, idempotencyKey, parentId, pullRequest)
                 call.respond(result.status)
             }
-            get("/repositories/{parent-id}/pull-requests/{id}") {
+            `get`("/repositories/{parent-id}/pull-requests/{id}") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]

--- a/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
@@ -1,7 +1,5 @@
 package examples.githubApi.controllers
 
-import examples.githubApi.controllers.RoutingUtils.getOrFail
-import examples.githubApi.controllers.RoutingUtils.getTyped
 import examples.githubApi.models.BulkEntityDetails
 import examples.githubApi.models.Contributor
 import examples.githubApi.models.ContributorQueryResult
@@ -53,6 +51,38 @@ public interface InternalEventsController {
                 call.respond(result.status, result.message)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -194,6 +224,38 @@ public interface ContributorsController {
                 call.respond(result.status)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -335,6 +397,38 @@ public interface OrganisationsController {
                 call.respond(result.status)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -470,6 +564,38 @@ public interface OrganisationsContributorsController {
                 call.respond(result.status)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -621,6 +747,38 @@ public interface RepositoriesController {
                 call.respond(result.status)
             }
         }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
     }
 }
 
@@ -777,41 +935,39 @@ public interface RepositoriesPullRequestsController {
                 call.respond(result.status)
             }
         }
-    }
-}
 
-public object RoutingUtils {
-    /**
-     * Gets parameter value associated with this name or null if the name is not present.
-     * Converting to type R using DefaultConversionService.
-     *
-     * Throws:
-     *   ParameterConversionException - when conversion from String to R fails
-     */
-    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
-        val values = getAll(name) ?: return null
-        val typeInfo = typeInfo<R>()
-        return try {
-            @Suppress("UNCHECKED_CAST")
-            DefaultConversionService.fromValues(values, typeInfo) as R
-        } catch (cause: Exception) {
-            throw ParameterConversionException(
-                name,
-                typeInfo.type.simpleName
-                    ?: typeInfo.type.toString(),
-                cause,
-            )
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
         }
-    }
 
-    /**
-     * Gets first value from the list of values associated with a name.
-     *
-     * Throws:
-     *   BadRequestException - when the name is not present
-     */
-    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
-        BadRequestException("Header " + name + " is required")
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
+    }
 }
 
 public data class ControllerResult<T>(

--- a/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
@@ -32,7 +32,6 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
-import kotlin.Unit
 import kotlin.collections.List
 
 public interface InternalEventsController {
@@ -131,7 +130,7 @@ public interface ContributorsController {
         xFlowId: String?,
         idempotencyKey: String?,
         contributor: Contributor,
-    ): ControllerResult<Unit>
+    )
 
     /**
      * Get a Contributor by ID
@@ -185,7 +184,7 @@ public interface ContributorsController {
         idempotencyKey: String?,
         id: String,
         contributor: Contributor,
-    ): ControllerResult<Unit>
+    )
 
     public companion object {
         public fun Route.contributorsRoutes(controller: ContributorsController) {
@@ -202,8 +201,7 @@ public interface ContributorsController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val contributor = call.receive<Contributor>()
-                val result = controller.createContributor(call, xFlowId, idempotencyKey, contributor)
-                call.respond(result.status)
+                controller.createContributor(call, xFlowId, idempotencyKey, contributor)
             }
             `get`("/contributors/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
@@ -220,8 +218,7 @@ public interface ContributorsController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val contributor = call.receive<Contributor>()
-                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, contributor)
-                call.respond(result.status)
+                controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, contributor)
             }
         }
 
@@ -304,7 +301,7 @@ public interface OrganisationsController {
         xFlowId: String?,
         idempotencyKey: String?,
         organisation: Organisation,
-    ): ControllerResult<Unit>
+    )
 
     /**
      * Get a Organisation by ID
@@ -358,7 +355,7 @@ public interface OrganisationsController {
         idempotencyKey: String?,
         id: String,
         organisation: Organisation,
-    ): ControllerResult<Unit>
+    )
 
     public companion object {
         public fun Route.organisationsRoutes(controller: OrganisationsController) {
@@ -375,8 +372,7 @@ public interface OrganisationsController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val organisation = call.receive<Organisation>()
-                val result = controller.post(call, xFlowId, idempotencyKey, organisation)
-                call.respond(result.status)
+                controller.post(call, xFlowId, idempotencyKey, organisation)
             }
             `get`("/organisations/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
@@ -393,8 +389,7 @@ public interface OrganisationsController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val organisation = call.receive<Organisation>()
-                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, organisation)
-                call.respond(result.status)
+                controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, organisation)
             }
         }
 
@@ -509,7 +504,7 @@ public interface OrganisationsContributorsController {
         idempotencyKey: String?,
         parentId: String,
         id: String,
-    ): ControllerResult<Unit>
+    )
 
     /**
      * Remove Contributor from this Organisation. Does not delete the underlying Contributor.
@@ -525,7 +520,7 @@ public interface OrganisationsContributorsController {
         xFlowId: String?,
         parentId: String,
         id: String,
-    ): ControllerResult<Unit>
+    )
 
     public companion object {
         public fun Route.organisationsContributorsRoutes(controller: OrganisationsContributorsController) {
@@ -553,15 +548,13 @@ public interface OrganisationsContributorsController {
                 val ifMatch = call.request.headers.getOrFail("If-Match")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
-                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, parentId, id)
-                call.respond(result.status)
+                controller.putById(call, ifMatch, xFlowId, idempotencyKey, parentId, id)
             }
             delete("/organisations/{parent-id}/contributors/{id}") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
-                val result = controller.deleteById(call, xFlowId, parentId, id)
-                call.respond(result.status)
+                controller.deleteById(call, xFlowId, parentId, id)
             }
         }
 
@@ -650,7 +643,7 @@ public interface RepositoriesController {
         xFlowId: String?,
         idempotencyKey: String?,
         repository: Repository,
-    ): ControllerResult<Unit>
+    )
 
     /**
      * Get a Repository by ID
@@ -704,7 +697,7 @@ public interface RepositoriesController {
         idempotencyKey: String?,
         id: String,
         repository: Repository,
-    ): ControllerResult<Unit>
+    )
 
     public companion object {
         public fun Route.repositoriesRoutes(controller: RepositoriesController) {
@@ -725,8 +718,7 @@ public interface RepositoriesController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val repository = call.receive<Repository>()
-                val result = controller.post(call, xFlowId, idempotencyKey, repository)
-                call.respond(result.status)
+                controller.post(call, xFlowId, idempotencyKey, repository)
             }
             `get`("/repositories/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
@@ -743,8 +735,7 @@ public interface RepositoriesController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val repository = call.receive<Repository>()
-                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, repository)
-                call.respond(result.status)
+                controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, repository)
             }
         }
 
@@ -832,7 +823,7 @@ public interface RepositoriesPullRequestsController {
         idempotencyKey: String?,
         parentId: String,
         pullRequest: PullRequest,
-    ): ControllerResult<Unit>
+    )
 
     /**
      * Get a PullRequest for this Repository by ID
@@ -886,7 +877,7 @@ public interface RepositoriesPullRequestsController {
         parentId: String,
         id: String,
         pullRequest: PullRequest,
-    ): ControllerResult<Unit>
+    )
 
     public companion object {
         public fun Route.repositoriesPullRequestsRoutes(controller: RepositoriesPullRequestsController) {
@@ -905,8 +896,7 @@ public interface RepositoriesPullRequestsController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val pullRequest = call.receive<PullRequest>()
-                val result = controller.post(call, xFlowId, idempotencyKey, parentId, pullRequest)
-                call.respond(result.status)
+                controller.post(call, xFlowId, idempotencyKey, parentId, pullRequest)
             }
             `get`("/repositories/{parent-id}/pull-requests/{id}") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
@@ -923,16 +913,7 @@ public interface RepositoriesPullRequestsController {
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val idempotencyKey = call.request.headers["Idempotency-Key"]
                 val pullRequest = call.receive<PullRequest>()
-                val result = controller.putById(
-                    call,
-                    ifMatch,
-                    xFlowId,
-                    idempotencyKey,
-                    parentId,
-                    id,
-                    pullRequest,
-                )
-                call.respond(result.status)
+                controller.putById(call, ifMatch, xFlowId, idempotencyKey, parentId, id, pullRequest)
             }
         }
 

--- a/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
@@ -1,0 +1,823 @@
+package examples.githubApi.controllers
+
+import examples.githubApi.controllers.RoutingUtils.getOrFail
+import examples.githubApi.controllers.RoutingUtils.getTyped
+import examples.githubApi.models.BulkEntityDetails
+import examples.githubApi.models.Contributor
+import examples.githubApi.models.ContributorQueryResult
+import examples.githubApi.models.EventResults
+import examples.githubApi.models.Organisation
+import examples.githubApi.models.OrganisationQueryResult
+import examples.githubApi.models.PullRequest
+import examples.githubApi.models.PullRequestQueryResult
+import examples.githubApi.models.Repository
+import examples.githubApi.models.RepositoryQueryResult
+import examples.githubApi.models.StatusQueryParam
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.`get`
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.util.getOrFail
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.Unit
+import kotlin.collections.List
+
+public interface InternalEventsController {
+    /**
+     * Generate change events for a list of entities
+     *
+     * @param bulkEntityDetails
+     */
+    public suspend fun post(call: ApplicationCall, bulkEntityDetails: BulkEntityDetails): ControllerResult<EventResults>
+
+    public companion object {
+        public fun Route.internalEventsRoutes(controller: InternalEventsController) {
+            authenticate("oauth2") {
+                post("/internal/events") {
+                    val bulkEntityDetails = call.receive<BulkEntityDetails>()
+                    val result = controller.post(call, bulkEntityDetails)
+                    call.respond(result.status, result.message)
+                }
+            }
+        }
+    }
+}
+
+public interface ContributorsController {
+    /**
+     * Page through all the Contributor resources matching the query filters
+     *
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param includeInactive A query parameter to request both active and inactive entities
+     * @param cursor An encoded value which represents a point in the data from where pagination will
+     * commence. The pagination direction (either forward or backward) will also be encoded within the
+     * cursor value. The cursor value will always be generated server side
+     *
+     */
+    public suspend fun searchContributors(
+        call: ApplicationCall,
+        xFlowId: String?,
+        limit: Int?,
+        includeInactive: Boolean?,
+        cursor: String?,
+    ): ControllerResult<ContributorQueryResult>
+
+    /**
+     * Create a new Contributor
+     *
+     * @param contributor
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun createContributor(
+        call: ApplicationCall,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        contributor: Contributor,
+    ): ControllerResult<Unit>
+
+    /**
+     * Get a Contributor by ID
+     *
+     * @param id The unique id for the resource
+     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
+     * Will return a 404 if the status property does not match the query parameter."
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
+     * only operate on the resource if it does not match any of the provided entity-tags. If the provided
+     * entity-tag is `*`, it is required that the resource does not exist at all.
+     *
+     */
+    public suspend fun getContributor(
+        call: ApplicationCall,
+        xFlowId: String?,
+        ifNoneMatch: String?,
+        id: String,
+        status: StatusQueryParam?,
+    ): ControllerResult<Contributor>
+
+    /**
+     * Update an existing Contributor
+     *
+     * @param contributor
+     * @param id The unique id for the resource
+     * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
+     * operate on the resource that matches at least one of the provided entity-tags. This allows clients
+     * express a precondition that prevent the method from being applied if there have been any changes
+     * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun putById(
+        call: ApplicationCall,
+        ifMatch: String,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        id: String,
+        contributor: Contributor,
+    ): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.contributorsRoutes(controller: ContributorsController) {
+            get("/contributors") {
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
+                val includeInactive =
+                    call.request.queryParameters.getTyped<kotlin.Boolean>("include_inactive")
+                val cursor = call.request.queryParameters.getTyped<kotlin.String>("cursor")
+                val result = controller.searchContributors(call, xFlowId, limit, includeInactive, cursor)
+                call.respond(result.status, result.message)
+            }
+            post("/contributors") {
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val contributor = call.receive<Contributor>()
+                val result = controller.createContributor(call, xFlowId, idempotencyKey, contributor)
+                call.respond(result.status)
+            }
+            get("/contributors/{id}") {
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val ifNoneMatch = call.request.headers["If-None-Match"]
+                val status =
+                    call.request.queryParameters.getTyped<examples.githubApi.models.StatusQueryParam>("status")
+                val result = controller.getContributor(call, xFlowId, ifNoneMatch, id, status)
+                call.respond(result.status, result.message)
+            }
+            put("/contributors/{id}") {
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val ifMatch = call.request.headers.getOrFail("If-Match")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val contributor = call.receive<Contributor>()
+                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, contributor)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public interface OrganisationsController {
+    /**
+     * Page through all the Organisation resources matching the query filters
+     *
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param includeInactive A query parameter to request both active and inactive entities
+     * @param cursor An encoded value which represents a point in the data from where pagination will
+     * commence. The pagination direction (either forward or backward) will also be encoded within the
+     * cursor value. The cursor value will always be generated server side
+     *
+     */
+    public suspend fun `get`(
+        call: ApplicationCall,
+        xFlowId: String?,
+        limit: Int?,
+        includeInactive: Boolean?,
+        cursor: String?,
+    ): ControllerResult<OrganisationQueryResult>
+
+    /**
+     * Create a new Organisation
+     *
+     * @param organisation
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun post(
+        call: ApplicationCall,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        organisation: Organisation,
+    ): ControllerResult<Unit>
+
+    /**
+     * Get a Organisation by ID
+     *
+     * @param id The unique id for the resource
+     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
+     * Will return a 404 if the status property does not match the query parameter."
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
+     * only operate on the resource if it does not match any of the provided entity-tags. If the provided
+     * entity-tag is `*`, it is required that the resource does not exist at all.
+     *
+     */
+    public suspend fun getById(
+        call: ApplicationCall,
+        xFlowId: String?,
+        ifNoneMatch: String?,
+        id: String,
+        status: StatusQueryParam?,
+    ): ControllerResult<Organisation>
+
+    /**
+     * Update an existing Organisation
+     *
+     * @param organisation
+     * @param id The unique id for the resource
+     * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
+     * operate on the resource that matches at least one of the provided entity-tags. This allows clients
+     * express a precondition that prevent the method from being applied if there have been any changes
+     * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun putById(
+        call: ApplicationCall,
+        ifMatch: String,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        id: String,
+        organisation: Organisation,
+    ): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.organisationsRoutes(controller: OrganisationsController) {
+            get("/organisations") {
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
+                val includeInactive =
+                    call.request.queryParameters.getTyped<kotlin.Boolean>("include_inactive")
+                val cursor = call.request.queryParameters.getTyped<kotlin.String>("cursor")
+                val result = controller.get(call, xFlowId, limit, includeInactive, cursor)
+                call.respond(result.status, result.message)
+            }
+            post("/organisations") {
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val organisation = call.receive<Organisation>()
+                val result = controller.post(call, xFlowId, idempotencyKey, organisation)
+                call.respond(result.status)
+            }
+            get("/organisations/{id}") {
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val ifNoneMatch = call.request.headers["If-None-Match"]
+                val status =
+                    call.request.queryParameters.getTyped<examples.githubApi.models.StatusQueryParam>("status")
+                val result = controller.getById(call, xFlowId, ifNoneMatch, id, status)
+                call.respond(result.status, result.message)
+            }
+            put("/organisations/{id}") {
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val ifMatch = call.request.headers.getOrFail("If-Match")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val organisation = call.receive<Organisation>()
+                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, organisation)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public interface OrganisationsContributorsController {
+    /**
+     * Page through all the Contributor resources for this parent Organisation matching the query
+     * filters
+     *
+     * @param parentId The unique id for the parent resource
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param includeInactive A query parameter to request both active and inactive entities
+     * @param cursor An encoded value which represents a point in the data from where pagination will
+     * commence. The pagination direction (either forward or backward) will also be encoded within the
+     * cursor value. The cursor value will always be generated server side
+     *
+     */
+    public suspend fun `get`(
+        call: ApplicationCall,
+        xFlowId: String?,
+        parentId: String,
+        limit: Int?,
+        includeInactive: Boolean?,
+        cursor: String?,
+    ): ControllerResult<ContributorQueryResult>
+
+    /**
+     * Get a Contributor for this Organisation by ID
+     *
+     * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
+     * only operate on the resource if it does not match any of the provided entity-tags. If the provided
+     * entity-tag is `*`, it is required that the resource does not exist at all.
+     *
+     */
+    public suspend fun getById(
+        call: ApplicationCall,
+        xFlowId: String?,
+        ifNoneMatch: String?,
+        parentId: String,
+        id: String,
+    ): ControllerResult<Contributor>
+
+    /**
+     * Add an existing Contributor to this Organisation
+     *
+     * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
+     * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
+     * operate on the resource that matches at least one of the provided entity-tags. This allows clients
+     * express a precondition that prevent the method from being applied if there have been any changes
+     * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun putById(
+        call: ApplicationCall,
+        ifMatch: String,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        parentId: String,
+        id: String,
+    ): ControllerResult<Unit>
+
+    /**
+     * Remove Contributor from this Organisation. Does not delete the underlying Contributor.
+     *
+     * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     */
+    public suspend fun deleteById(
+        call: ApplicationCall,
+        xFlowId: String?,
+        parentId: String,
+        id: String,
+    ): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.organisationsContributorsRoutes(controller: OrganisationsContributorsController) {
+            get("/organisations/{parent-id}/contributors") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
+                val includeInactive =
+                    call.request.queryParameters.getTyped<kotlin.Boolean>("include_inactive")
+                val cursor = call.request.queryParameters.getTyped<kotlin.String>("cursor")
+                val result = controller.get(call, xFlowId, parentId, limit, includeInactive, cursor)
+                call.respond(result.status, result.message)
+            }
+            get("/organisations/{parent-id}/contributors/{id}") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val ifNoneMatch = call.request.headers["If-None-Match"]
+                val result = controller.getById(call, xFlowId, ifNoneMatch, parentId, id)
+                call.respond(result.status, result.message)
+            }
+            put("/organisations/{parent-id}/contributors/{id}") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val ifMatch = call.request.headers.getOrFail("If-Match")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, parentId, id)
+                call.respond(result.status)
+            }
+            delete("/organisations/{parent-id}/contributors/{id}") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val result = controller.deleteById(call, xFlowId, parentId, id)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public interface RepositoriesController {
+    /**
+     * Page through all the Repository resources matching the query filters
+     *
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param slug Filters resources by the [slug] property. Accepts comma-delimited values
+     *
+     * @param name Filters resources by the [name] property. Accepts comma-delimited values
+     *
+     * @param includeInactive A query parameter to request both active and inactive entities
+     * @param cursor An encoded value which represents a point in the data from where pagination will
+     * commence. The pagination direction (either forward or backward) will also be encoded within the
+     * cursor value. The cursor value will always be generated server side
+     *
+     */
+    public suspend fun `get`(
+        call: ApplicationCall,
+        xFlowId: String?,
+        limit: Int?,
+        slug: List<String>?,
+        name: List<String>?,
+        includeInactive: Boolean?,
+        cursor: String?,
+    ): ControllerResult<RepositoryQueryResult>
+
+    /**
+     * Create a new Repository
+     *
+     * @param repository
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun post(
+        call: ApplicationCall,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        repository: Repository,
+    ): ControllerResult<Unit>
+
+    /**
+     * Get a Repository by ID
+     *
+     * @param id The unique id for the resource
+     * @param status Changes the behavior of GET | HEAD based on the value of the status property.
+     * Will return a 404 if the status property does not match the query parameter."
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
+     * only operate on the resource if it does not match any of the provided entity-tags. If the provided
+     * entity-tag is `*`, it is required that the resource does not exist at all.
+     *
+     */
+    public suspend fun getById(
+        call: ApplicationCall,
+        xFlowId: String?,
+        ifNoneMatch: String?,
+        id: String,
+        status: StatusQueryParam?,
+    ): ControllerResult<Repository>
+
+    /**
+     * Update an existing Repository
+     *
+     * @param repository
+     * @param id The unique id for the resource
+     * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
+     * operate on the resource that matches at least one of the provided entity-tags. This allows clients
+     * express a precondition that prevent the method from being applied if there have been any changes
+     * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun putById(
+        call: ApplicationCall,
+        ifMatch: String,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        id: String,
+        repository: Repository,
+    ): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.repositoriesRoutes(controller: RepositoriesController) {
+            get("/repositories") {
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
+                val slug =
+                    call.request.queryParameters.getTyped<kotlin.collections.List<kotlin.String>>("slug")
+                val name =
+                    call.request.queryParameters.getTyped<kotlin.collections.List<kotlin.String>>("name")
+                val includeInactive =
+                    call.request.queryParameters.getTyped<kotlin.Boolean>("include_inactive")
+                val cursor = call.request.queryParameters.getTyped<kotlin.String>("cursor")
+                val result = controller.get(call, xFlowId, limit, slug, name, includeInactive, cursor)
+                call.respond(result.status, result.message)
+            }
+            post("/repositories") {
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val repository = call.receive<Repository>()
+                val result = controller.post(call, xFlowId, idempotencyKey, repository)
+                call.respond(result.status)
+            }
+            get("/repositories/{id}") {
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val ifNoneMatch = call.request.headers["If-None-Match"]
+                val status =
+                    call.request.queryParameters.getTyped<examples.githubApi.models.StatusQueryParam>("status")
+                val result = controller.getById(call, xFlowId, ifNoneMatch, id, status)
+                call.respond(result.status, result.message)
+            }
+            put("/repositories/{id}") {
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val ifMatch = call.request.headers.getOrFail("If-Match")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val repository = call.receive<Repository>()
+                val result = controller.putById(call, ifMatch, xFlowId, idempotencyKey, id, repository)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public interface RepositoriesPullRequestsController {
+    /**
+     * Page through all the PullRequest resources for this parent Repository matching the query
+     * filters
+     *
+     * @param parentId The unique id for the parent resource
+     * @param limit Upper bound for number of results to be returned from query api. A default limit
+     * will be applied if this is not present
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param includeInactive A query parameter to request both active and inactive entities
+     * @param cursor An encoded value which represents a point in the data from where pagination will
+     * commence. The pagination direction (either forward or backward) will also be encoded within the
+     * cursor value. The cursor value will always be generated server side
+     *
+     */
+    public suspend fun `get`(
+        call: ApplicationCall,
+        xFlowId: String?,
+        parentId: String,
+        limit: Int?,
+        includeInactive: Boolean?,
+        cursor: String?,
+    ): ControllerResult<PullRequestQueryResult>
+
+    /**
+     * Create a new PullRequest for this parent Repository
+     *
+     * @param pullRequest
+     * @param parentId The unique id for the parent resource
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun post(
+        call: ApplicationCall,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        parentId: String,
+        pullRequest: PullRequest,
+    ): ControllerResult<Unit>
+
+    /**
+     * Get a PullRequest for this Repository by ID
+     *
+     * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param ifNoneMatch The RFC7232 If-None-Match header field in a request requires the server to
+     * only operate on the resource if it does not match any of the provided entity-tags. If the provided
+     * entity-tag is `*`, it is required that the resource does not exist at all.
+     *
+     */
+    public suspend fun getById(
+        call: ApplicationCall,
+        xFlowId: String?,
+        ifNoneMatch: String?,
+        parentId: String,
+        id: String,
+    ): ControllerResult<PullRequest>
+
+    /**
+     * Update the PullRequest owned by this Repository
+     *
+     * @param pullRequest
+     * @param parentId The unique id for the parent resource
+     * @param id The unique id for the resource
+     * @param ifMatch The RFC7232 If-Match header field in a request requires the server to only
+     * operate on the resource that matches at least one of the provided entity-tags. This allows clients
+     * express a precondition that prevent the method from being applied if there have been any changes
+     * to the resource.
+     *
+     * @param xFlowId A custom header that will be passed onto any further requests and can be used
+     * for diagnosing.
+     *
+     * @param idempotencyKey This unique identifier can be used to allow for clients to safely retry
+     * requests without accidentally performing the same operation twice. This is useful in cases such as
+     * network failures. This Id should remain the same for a given operation, so that the server can use
+     * it to recognise subsequent retries of the same request. Clients should be careful in using this
+     * key as subsequent requests with the same key return the same result. How the key is generated is
+     * up to the client, but it is suggested to use UUID (v4), or any other random string with enough
+     * entropy to avoid collisions.
+     *
+     */
+    public suspend fun putById(
+        call: ApplicationCall,
+        ifMatch: String,
+        xFlowId: String?,
+        idempotencyKey: String?,
+        parentId: String,
+        id: String,
+        pullRequest: PullRequest,
+    ): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.repositoriesPullRequestsRoutes(controller: RepositoriesPullRequestsController) {
+            get("/repositories/{parent-id}/pull-requests") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val limit = call.request.queryParameters.getTyped<kotlin.Int>("limit")
+                val includeInactive =
+                    call.request.queryParameters.getTyped<kotlin.Boolean>("include_inactive")
+                val cursor = call.request.queryParameters.getTyped<kotlin.String>("cursor")
+                val result = controller.get(call, xFlowId, parentId, limit, includeInactive, cursor)
+                call.respond(result.status, result.message)
+            }
+            post("/repositories/{parent-id}/pull-requests") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val pullRequest = call.receive<PullRequest>()
+                val result = controller.post(call, xFlowId, idempotencyKey, parentId, pullRequest)
+                call.respond(result.status)
+            }
+            get("/repositories/{parent-id}/pull-requests/{id}") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val ifNoneMatch = call.request.headers["If-None-Match"]
+                val result = controller.getById(call, xFlowId, ifNoneMatch, parentId, id)
+                call.respond(result.status, result.message)
+            }
+            put("/repositories/{parent-id}/pull-requests/{id}") {
+                val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
+                val id = call.parameters.getOrFail<kotlin.String>("id")
+                val ifMatch = call.request.headers.getOrFail("If-Match")
+                val xFlowId = call.request.headers["X-Flow-Id"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
+                val pullRequest = call.receive<PullRequest>()
+                val result = controller.putById(
+                    call,
+                    ifMatch,
+                    xFlowId,
+                    idempotencyKey,
+                    parentId,
+                    id,
+                    pullRequest,
+                )
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public object RoutingUtils {
+    /**
+     * Gets parameter value associated with this name or null if the name is not present.
+     * Converting to type R using DefaultConversionService.
+     *
+     * Throws:
+     *   ParameterConversionException - when conversion from String to R fails
+     */
+    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+        val values = getAll(name) ?: return null
+        val typeInfo = typeInfo<R>()
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            DefaultConversionService.fromValues(values, typeInfo) as R
+        } catch (cause: Exception) {
+            throw ParameterConversionException(
+                name,
+                typeInfo.type.simpleName
+                    ?: typeInfo.type.toString(),
+                cause,
+            )
+        }
+    }
+
+    /**
+     * Gets first value from the list of values associated with a name.
+     *
+     * Throws:
+     *   BadRequestException - when the name is not present
+     */
+    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
+        BadRequestException("Header " + name + " is required")
+}
+
+public data class ControllerResult<T>(
+    public val status: HttpStatusCode,
+    public val message: T,
+)

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -1,6 +1,5 @@
 package examples.parameterNameClash.controllers
 
-import examples.parameterNameClash.controllers.RoutingUtils.getOrFail
 import examples.parameterNameClash.models.SomeObject
 import io.ktor.http.Headers
 import io.ktor.http.HttpStatusCode
@@ -61,41 +60,39 @@ public interface ExampleController {
                 call.respond(result.status)
             }
         }
-    }
-}
 
-public object RoutingUtils {
-    /**
-     * Gets parameter value associated with this name or null if the name is not present.
-     * Converting to type R using DefaultConversionService.
-     *
-     * Throws:
-     *   ParameterConversionException - when conversion from String to R fails
-     */
-    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
-        val values = getAll(name) ?: return null
-        val typeInfo = typeInfo<R>()
-        return try {
-            @Suppress("UNCHECKED_CAST")
-            DefaultConversionService.fromValues(values, typeInfo) as R
-        } catch (cause: Exception) {
-            throw ParameterConversionException(
-                name,
-                typeInfo.type.simpleName
-                    ?: typeInfo.type.toString(),
-                cause,
-            )
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
         }
-    }
 
-    /**
-     * Gets first value from the list of values associated with a name.
-     *
-     * Throws:
-     *   BadRequestException - when the name is not present
-     */
-    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
-        BadRequestException("Header " + name + " is required")
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
+    }
 }
 
 public data class ControllerResult<T>(

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -9,7 +9,6 @@ import io.ktor.server.application.call
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
 import io.ktor.server.request.receive
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.`get`
 import io.ktor.server.routing.post
@@ -18,7 +17,6 @@ import io.ktor.util.converters.DefaultConversionService
 import io.ktor.util.reflect.typeInfo
 import kotlin.Any
 import kotlin.String
-import kotlin.Unit
 
 public interface ExampleController {
     /**
@@ -31,7 +29,7 @@ public interface ExampleController {
         call: ApplicationCall,
         pathB: String,
         queryB: String,
-    ): ControllerResult<Unit>
+    )
 
     /**
      *
@@ -43,21 +41,19 @@ public interface ExampleController {
         call: ApplicationCall,
         querySomeObject: String,
         bodySomeObject: SomeObject,
-    ): ControllerResult<Unit>
+    )
 
     public companion object {
         public fun Route.exampleRoutes(controller: ExampleController) {
             `get`("/example/{b}") {
                 val pathB = call.parameters.getOrFail<kotlin.String>("b")
                 val queryB = call.request.queryParameters.getOrFail<kotlin.String>("b")
-                val result = controller.getById(call, pathB, queryB)
-                call.respond(result.status)
+                controller.getById(call, pathB, queryB)
             }
             post("/example") {
                 val querySomeObject = call.request.queryParameters.getOrFail<kotlin.String>("someObject")
                 val bodySomeObject = call.receive<SomeObject>()
-                val result = controller.post(call, querySomeObject, bodySomeObject)
-                call.respond(result.status)
+                controller.post(call, querySomeObject, bodySomeObject)
             }
         }
 

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -1,0 +1,104 @@
+package examples.parameterNameClash.controllers
+
+import examples.parameterNameClash.controllers.RoutingUtils.getOrFail
+import examples.parameterNameClash.models.SomeObject
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.`get`
+import io.ktor.server.routing.post
+import io.ktor.server.util.getOrFail
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
+import kotlin.String
+import kotlin.Unit
+
+public interface ExampleController {
+    /**
+     *
+     *
+     * @param pathB
+     * @param queryB
+     */
+    public suspend fun getById(
+        call: ApplicationCall,
+        pathB: String,
+        queryB: String,
+    ): ControllerResult<Unit>
+
+    /**
+     *
+     *
+     * @param bodySomeObject example
+     * @param querySomeObject
+     */
+    public suspend fun post(
+        call: ApplicationCall,
+        querySomeObject: String,
+        bodySomeObject: SomeObject,
+    ): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.exampleRoutes(controller: ExampleController) {
+            get("/example/{b}") {
+                val pathB = call.parameters.getOrFail<kotlin.String>("b")
+                val queryB = call.request.queryParameters.getOrFail<kotlin.String>("b")
+                val result = controller.getById(call, pathB, queryB)
+                call.respond(result.status)
+            }
+            post("/example") {
+                val querySomeObject = call.request.queryParameters.getOrFail<kotlin.String>("someObject")
+                val bodySomeObject = call.receive<SomeObject>()
+                val result = controller.post(call, querySomeObject, bodySomeObject)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public object RoutingUtils {
+    /**
+     * Gets parameter value associated with this name or null if the name is not present.
+     * Converting to type R using DefaultConversionService.
+     *
+     * Throws:
+     *   ParameterConversionException - when conversion from String to R fails
+     */
+    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+        val values = getAll(name) ?: return null
+        val typeInfo = typeInfo<R>()
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            DefaultConversionService.fromValues(values, typeInfo) as R
+        } catch (cause: Exception) {
+            throw ParameterConversionException(
+                name,
+                typeInfo.type.simpleName
+                    ?: typeInfo.type.toString(),
+                cause,
+            )
+        }
+    }
+
+    /**
+     * Gets first value from the list of values associated with a name.
+     *
+     * Throws:
+     *   BadRequestException - when the name is not present
+     */
+    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
+        BadRequestException("Header " + name + " is required")
+}
+
+public data class ControllerResult<T>(
+    public val status: HttpStatusCode,
+    public val message: T,
+)

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -47,7 +47,7 @@ public interface ExampleController {
 
     public companion object {
         public fun Route.exampleRoutes(controller: ExampleController) {
-            get("/example/{b}") {
+            `get`("/example/{b}") {
                 val pathB = call.parameters.getOrFail<kotlin.String>("b")
                 val queryB = call.request.queryParameters.getOrFail<kotlin.String>("b")
                 val result = controller.getById(call, pathB, queryB)

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -47,6 +47,12 @@ public interface ExampleController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Example resource
+         *
+         * - GET /example/{b}
+         * - POST /example
+         */
         public fun Route.exampleRoutes(controller: ExampleController) {
             `get`("/example/{b}") {
                 val pathB = call.parameters.getOrFail<kotlin.String>("b")

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -2,7 +2,6 @@ package examples.parameterNameClash.controllers
 
 import examples.parameterNameClash.models.SomeObject
 import io.ktor.http.Headers
-import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
@@ -20,27 +19,31 @@ import kotlin.String
 
 public interface ExampleController {
     /**
-     *
+     * Route is expected to respond with status 204.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param pathB
      * @param queryB
+     * @param call The Ktor application call
      */
     public suspend fun getById(
-        call: ApplicationCall,
         pathB: String,
         queryB: String,
+        call: ApplicationCall,
     )
 
     /**
-     *
+     * Route is expected to respond with status 204.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param bodySomeObject example
      * @param querySomeObject
+     * @param call The Ktor application call
      */
     public suspend fun post(
-        call: ApplicationCall,
         querySomeObject: String,
         bodySomeObject: SomeObject,
+        call: ApplicationCall,
     )
 
     public companion object {
@@ -48,12 +51,12 @@ public interface ExampleController {
             `get`("/example/{b}") {
                 val pathB = call.parameters.getOrFail<kotlin.String>("b")
                 val queryB = call.request.queryParameters.getOrFail<kotlin.String>("b")
-                controller.getById(call, pathB, queryB)
+                controller.getById(pathB, queryB, call)
             }
             post("/example") {
                 val querySomeObject = call.request.queryParameters.getOrFail<kotlin.String>("someObject")
                 val bodySomeObject = call.receive<SomeObject>()
-                controller.post(call, querySomeObject, bodySomeObject)
+                controller.post(querySomeObject, bodySomeObject, call)
             }
         }
 
@@ -90,8 +93,3 @@ public interface ExampleController {
             BadRequestException("Header " + name + " is required")
     }
 }
-
-public data class ControllerResult<T>(
-    public val status: HttpStatusCode,
-    public val message: T,
-)

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -7,7 +7,6 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.`get`
 import io.ktor.server.util.getOrFail
@@ -15,7 +14,6 @@ import io.ktor.util.converters.DefaultConversionService
 import io.ktor.util.reflect.typeInfo
 import kotlin.Any
 import kotlin.String
-import kotlin.Unit
 
 public interface ExampleController {
     /**
@@ -28,15 +26,14 @@ public interface ExampleController {
         call: ApplicationCall,
         a: String,
         b: String,
-    ): ControllerResult<Unit>
+    )
 
     public companion object {
         public fun Route.exampleRoutes(controller: ExampleController) {
             `get`("/example") {
                 val a = call.request.queryParameters.getOrFail<kotlin.String>("a")
                 val b = call.request.queryParameters.getOrFail<kotlin.String>("b")
-                val result = controller.get(call, a, b)
-                call.respond(result.status)
+                controller.get(call, a, b)
             }
         }
 

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -1,0 +1,83 @@
+package examples.pathLevelParameters.controllers
+
+import examples.pathLevelParameters.controllers.RoutingUtils.getOrFail
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.`get`
+import io.ktor.server.util.getOrFail
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
+import kotlin.String
+import kotlin.Unit
+
+public interface ExampleController {
+    /**
+     *
+     *
+     * @param a
+     * @param b
+     */
+    public suspend fun `get`(
+        call: ApplicationCall,
+        a: String,
+        b: String,
+    ): ControllerResult<Unit>
+
+    public companion object {
+        public fun Route.exampleRoutes(controller: ExampleController) {
+            get("/example") {
+                val a = call.request.queryParameters.getOrFail<kotlin.String>("a")
+                val b = call.request.queryParameters.getOrFail<kotlin.String>("b")
+                val result = controller.get(call, a, b)
+                call.respond(result.status)
+            }
+        }
+    }
+}
+
+public object RoutingUtils {
+    /**
+     * Gets parameter value associated with this name or null if the name is not present.
+     * Converting to type R using DefaultConversionService.
+     *
+     * Throws:
+     *   ParameterConversionException - when conversion from String to R fails
+     */
+    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+        val values = getAll(name) ?: return null
+        val typeInfo = typeInfo<R>()
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            DefaultConversionService.fromValues(values, typeInfo) as R
+        } catch (cause: Exception) {
+            throw ParameterConversionException(
+                name,
+                typeInfo.type.simpleName
+                    ?: typeInfo.type.toString(),
+                cause,
+            )
+        }
+    }
+
+    /**
+     * Gets first value from the list of values associated with a name.
+     *
+     * Throws:
+     *   BadRequestException - when the name is not present
+     */
+    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
+        BadRequestException("Header " + name + " is required")
+}
+
+public data class ControllerResult<T>(
+    public val status: HttpStatusCode,
+    public val message: T,
+)

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -1,6 +1,5 @@
 package examples.pathLevelParameters.controllers
 
-import examples.pathLevelParameters.controllers.RoutingUtils.getOrFail
 import io.ktor.http.Headers
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
@@ -40,41 +39,39 @@ public interface ExampleController {
                 call.respond(result.status)
             }
         }
-    }
-}
 
-public object RoutingUtils {
-    /**
-     * Gets parameter value associated with this name or null if the name is not present.
-     * Converting to type R using DefaultConversionService.
-     *
-     * Throws:
-     *   ParameterConversionException - when conversion from String to R fails
-     */
-    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
-        val values = getAll(name) ?: return null
-        val typeInfo = typeInfo<R>()
-        return try {
-            @Suppress("UNCHECKED_CAST")
-            DefaultConversionService.fromValues(values, typeInfo) as R
-        } catch (cause: Exception) {
-            throw ParameterConversionException(
-                name,
-                typeInfo.type.simpleName
-                    ?: typeInfo.type.toString(),
-                cause,
-            )
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
         }
-    }
 
-    /**
-     * Gets first value from the list of values associated with a name.
-     *
-     * Throws:
-     *   BadRequestException - when the name is not present
-     */
-    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
-        BadRequestException("Header " + name + " is required")
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
+    }
 }
 
 public data class ControllerResult<T>(

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -1,7 +1,6 @@
 package examples.pathLevelParameters.controllers
 
 import io.ktor.http.Headers
-import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
@@ -17,15 +16,17 @@ import kotlin.String
 
 public interface ExampleController {
     /**
-     *
+     * Route is expected to respond with status 204.
+     * Use [io.ktor.server.response.respond] to send the response.
      *
      * @param a
      * @param b
+     * @param call The Ktor application call
      */
     public suspend fun `get`(
-        call: ApplicationCall,
         a: String,
         b: String,
+        call: ApplicationCall,
     )
 
     public companion object {
@@ -33,7 +34,7 @@ public interface ExampleController {
             `get`("/example") {
                 val a = call.request.queryParameters.getOrFail<kotlin.String>("a")
                 val b = call.request.queryParameters.getOrFail<kotlin.String>("b")
-                controller.get(call, a, b)
+                controller.get(a, b, call)
             }
         }
 
@@ -70,8 +71,3 @@ public interface ExampleController {
             BadRequestException("Header " + name + " is required")
     }
 }
-
-public data class ControllerResult<T>(
-    public val status: HttpStatusCode,
-    public val message: T,
-)

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -32,7 +32,7 @@ public interface ExampleController {
 
     public companion object {
         public fun Route.exampleRoutes(controller: ExampleController) {
-            get("/example") {
+            `get`("/example") {
                 val a = call.request.queryParameters.getOrFail<kotlin.String>("a")
                 val b = call.request.queryParameters.getOrFail<kotlin.String>("b")
                 val result = controller.get(call, a, b)

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -30,6 +30,11 @@ public interface ExampleController {
     )
 
     public companion object {
+        /**
+         * Mounts all routes for the Example resource
+         *
+         * - GET /example
+         */
         public fun Route.exampleRoutes(controller: ExampleController) {
             `get`("/example") {
                 val a = call.request.queryParameters.getOrFail<kotlin.String>("a")

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -29,41 +29,39 @@ public interface TestController {
                 call.respond(result.status, result.message)
             }
         }
-    }
-}
 
-public object RoutingUtils {
-    /**
-     * Gets parameter value associated with this name or null if the name is not present.
-     * Converting to type R using DefaultConversionService.
-     *
-     * Throws:
-     *   ParameterConversionException - when conversion from String to R fails
-     */
-    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
-        val values = getAll(name) ?: return null
-        val typeInfo = typeInfo<R>()
-        return try {
-            @Suppress("UNCHECKED_CAST")
-            DefaultConversionService.fromValues(values, typeInfo) as R
-        } catch (cause: Exception) {
-            throw ParameterConversionException(
-                name,
-                typeInfo.type.simpleName
-                    ?: typeInfo.type.toString(),
-                cause,
-            )
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
         }
-    }
 
-    /**
-     * Gets first value from the list of values associated with a name.
-     *
-     * Throws:
-     *   BadRequestException - when the name is not present
-     */
-    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
-        BadRequestException("Header " + name + " is required")
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
+    }
 }
 
 public data class ControllerResult<T>(

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -1,0 +1,72 @@
+package examples.singleAllOf.controllers
+
+import examples.singleAllOf.models.Result
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.`get`
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
+import kotlin.String
+
+public interface TestController {
+    /**
+     *
+     */
+    public suspend fun test(call: ApplicationCall): ControllerResult<Result>
+
+    public companion object {
+        public fun Route.testRoutes(controller: TestController) {
+            get("/test") {
+                val result = controller.test(call)
+                call.respond(result.status, result.message)
+            }
+        }
+    }
+}
+
+public object RoutingUtils {
+    /**
+     * Gets parameter value associated with this name or null if the name is not present.
+     * Converting to type R using DefaultConversionService.
+     *
+     * Throws:
+     *   ParameterConversionException - when conversion from String to R fails
+     */
+    public inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+        val values = getAll(name) ?: return null
+        val typeInfo = typeInfo<R>()
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            DefaultConversionService.fromValues(values, typeInfo) as R
+        } catch (cause: Exception) {
+            throw ParameterConversionException(
+                name,
+                typeInfo.type.simpleName
+                    ?: typeInfo.type.toString(),
+                cause,
+            )
+        }
+    }
+
+    /**
+     * Gets first value from the list of values associated with a name.
+     *
+     * Throws:
+     *   BadRequestException - when the name is not present
+     */
+    public fun Headers.getOrFail(name: String): String = this[name] ?: throw
+        BadRequestException("Header " + name + " is required")
+}
+
+public data class ControllerResult<T>(
+    public val status: HttpStatusCode,
+    public val message: T,
+)

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -24,7 +24,7 @@ public interface TestController {
 
     public companion object {
         public fun Route.testRoutes(controller: TestController) {
-            get("/test") {
+            `get`("/test") {
                 val result = controller.test(call)
                 call.respond(result.status, result.message)
             }

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -1,14 +1,10 @@
 package examples.singleAllOf.controllers
 
-import examples.singleAllOf.models.Result
 import io.ktor.http.Headers
-import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.`get`
 import io.ktor.util.converters.DefaultConversionService
@@ -18,15 +14,17 @@ import kotlin.String
 
 public interface TestController {
     /**
+     * Route is expected to respond with [examples.singleAllOf.models.Result].
+     * Use [io.ktor.server.response.respond] to send the response.
      *
+     * @param call The Ktor application call
      */
-    public suspend fun test(call: ApplicationCall): ControllerResult<Result>
+    public suspend fun test(call: ApplicationCall)
 
     public companion object {
         public fun Route.testRoutes(controller: TestController) {
             `get`("/test") {
-                val result = controller.test(call)
-                call.respond(result.status, result.message)
+                controller.test(call)
             }
         }
 
@@ -63,8 +61,3 @@ public interface TestController {
             BadRequestException("Header " + name + " is required")
     }
 }
-
-public data class ControllerResult<T>(
-    public val status: HttpStatusCode,
-    public val message: T,
-)

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -22,6 +22,11 @@ public interface TestController {
     public suspend fun test(call: ApplicationCall)
 
     public companion object {
+        /**
+         * Mounts all routes for the Test resource
+         *
+         * - GET /test
+         */
         public fun Route.testRoutes(controller: TestController) {
             `get`("/test") {
                 controller.test(call)


### PR DESCRIPTION
### Design choices

Inspired by #214, Ktor server code is generated as a controller interface with methods for the routes along with a companion object which is used for mounting the routes on the Ktor server (see example further down).

Ktor is by design very flexible, and thus in order for us to be able to generate code we need to make certain design decisions. The approach with routing function + an interface should work well for most cases. The users are still free to configure Ktor however they like, including where they mount the routes and how the implement the controller interface.

Ktor's ApplicationCall is passed to the controller methods to allow them to perform additional logic on the incoming/outgoing request. One might desire to create an extension function for resolving the current user or respond directly with a redirect which requires having access to `call`.

Controller methods responsible for responding to the request (`call.respond()`). If no respond is sent, Ktor will respond with 404 per default.

**Example**

```kotlin
public interface InternalEventsController {

    public suspend fun post(bulkEntityDetails: BulkEntityDetails, call: ApplicationCall)

    public companion object {
        public fun Route.internalEventsRoutes(controller: InternalEventsController) {
            authenticate("oauth2") {
                post("/internal/events") {
                    val bulkEntityDetails = call.receive<BulkEntityDetails>()
                    controller.post(bulkEntityDetails, call)
                }
            }
        }
    }
}
```

**Usage example**

```kotlin
fun main() {
    embeddedServer(Netty, port = 8080) {
        routing {
            internalEventsRoutes(object : InternalEventsController {
                override suspend fun post(
                    bulkEntityDetails: BulkEntityDetails,
                    call: ApplicationCall
                ) {
                    call.respond(HttpStatusCode.OK, EventResults(emptyList()))
                }
            })
        }
    }.start(wait = true)
}
```

Here the controller interface is implemented as an object, but one could also implement is as a regular class which would make things like dependency injection and modularisation easier.

### Changes
1. Add Ktor route & controller interface generation.
2. Split controller interface generator abstract class in two; one for annotation based libraries (Spring, Micronaut) and one common for all.

### Known limitations
1. Headers are always handled as strings. Should be OK for now, but an improvement would be to also handle those in a typed way (including conversion from string).