### PR TITLE
Ktor typed respond functions

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -43,7 +43,7 @@ class CodeGenerator(
     private fun generateModels(): Collection<GeneratedFile> = sourceSet(models().files)
 
     private fun generateControllerInterfaces(): Collection<GeneratedFile> =
-        sourceSet(controllers().files).plus(sourceSet(models().files))
+        sourceSet(controllers()).plus(sourceSet(models().files))
 
     private fun generateClient(): Collection<GeneratedFile> {
         val clientGenerator = when (MutableSettings.clientTarget()) {
@@ -68,7 +68,7 @@ class CodeGenerator(
     private fun resources(models: Models): List<ResourceFile> =
         listOfNotNull(QuarkusReflectionModelGenerator(models).generate())
 
-    private fun controllers(): KotlinTypes {
+    private fun controllers(): List<FileSpec> {
         val generator =
             when (MutableSettings.controllerTarget()) {
                 ControllerCodeGenTargetType.SPRING -> SpringControllerInterfaceGenerator(
@@ -91,6 +91,14 @@ class CodeGenerator(
                     MutableSettings.controllerOptions(),
                 )
             }
-        return generator.generate()
+
+        val controllerFiles: Collection<FileSpec> = generator.generate().files
+        val libFiles: Collection<FileSpec> = generator.generateLibrary().map {
+            FileSpec.builder(it.className)
+                .addType(it.spec)
+                .build()
+        }
+
+        return controllerFiles.plus(libFiles)
     }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerInterfaceGenerator.kt
@@ -1,7 +1,9 @@
 package com.cjbooms.fabrikt.generators.controller
 
+import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.KotlinTypes
 
 interface ControllerInterfaceGenerator {
     fun generate(): KotlinTypes
+    fun generateLibrary(): Collection<ControllerLibraryType>
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -9,6 +9,7 @@ import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.Securi
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
 import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
@@ -35,6 +36,8 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asTypeName
+
+private const val CONTROLLER_RESULT_CLASS_NAME = "ControllerResult"
 
 /**
  * Generates controller interface and routing functions for Ktor.
@@ -317,6 +320,8 @@ class KtorControllerInterfaceGenerator(
 
         return kDoc.build()
     }
+
+    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     /**
      * Function for getting a typed query parameter

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -4,7 +4,6 @@ import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
-import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.SecuritySupport
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
@@ -21,10 +20,10 @@ import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSingleResource
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
-import com.cjbooms.fabrikt.util.capitalized
 import com.cjbooms.fabrikt.util.toUpperCase
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -32,12 +31,14 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asTypeName
 
-private const val CONTROLLER_RESULT_CLASS_NAME = "ControllerResult"
+private const val TYPED_APPLICATION_CALL_CLASS_NAME = "TypedApplicationCall"
 
 /**
  * Generates controller interface and routing functions for Ktor.
@@ -149,7 +150,15 @@ class KtorControllerInterfaceGenerator(
 
         builder.addKdoc(buildControllerFunKdoc(operation, params))
 
-        builder.addParameter("call", ClassName("io.ktor.server.application", "ApplicationCall"))
+        if (operation.happyPathResponse(packages.base).isUnit()) {
+            builder.addParameter("call", ClassName("io.ktor.server.application", "ApplicationCall"))
+        } else {
+            builder.addParameter(
+                "call",
+                ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME)
+                    .parameterizedBy(operation.happyPathResponse(packages.base))
+            )
+        }
 
         return builder.build()
     }
@@ -267,10 +276,24 @@ class KtorControllerInterfaceGenerator(
             listOf(headerParams, pathParams, queryParams, bodyParams).asSequence().flatten().map { it.name }
                 .plus(if (addAuth) "principal" else null)
                 .filterNotNull()
-                .plus("call")
                 .joinToString(", ")
 
-        builder.addStatement("controller.$methodName($methodParameters)")
+        if (operation.happyPathResponse(packages.base).isUnit()) {
+            builder.addStatement(
+                "controller.%L(%L%M)",
+                methodName,
+                methodParameters.let { if (it.isNotEmpty()) "$it, " else "" },
+                MemberName("io.ktor.server.application", "call"),
+            )
+        } else {
+            builder.addStatement(
+                "controller.%L(%L%T.from(%M))", // construct TypedApplicationCall
+                methodName,
+                methodParameters.let { if (it.isNotEmpty()) "$it, " else "" },
+                ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME),
+                MemberName("io.ktor.server.application", "call"),
+            )
+        }
 
         builder
             .unindent()
@@ -299,29 +322,131 @@ class KtorControllerInterfaceGenerator(
         val happyPathResponse = operation.happyPathResponse(packages.base)
         if (happyPathResponse.isUnit()) {
             kDoc.add("Route is expected to respond with status ${operation.responses.keys.first()}.\n")
-        } else if (operation.responses.isNotEmpty()) {
+            kDoc.add("Use [%M] to send the response.\n\n", MemberName("io.ktor.server.response", "respond", isExtension = true))
+        } else {
             kDoc.add(
-                "Route is expected to respond with [%L].\n",
+                "Route is expected to respond with [%L].\nUse [%M] to send the response.\n\n",
                 happyPathResponse.toString(),
+                MemberName(ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME), "respondTyped")
             )
         }
-
-        // document how to send response
-        kDoc.add(
-            "Use [%M] to send the response.\n\n",
-            MemberName("io.ktor.server.response", "respond", isExtension = true)
-        )
 
         // document parameters
         parameters.forEach {
             kDoc.add("@param %L %L\n", it.name.toKCodeName(), it.description?.trimIndent().orEmpty()).build()
         }
-        kDoc.add("@param call The Ktor application call\n")
+        if (happyPathResponse.isUnit()) {
+            kDoc.add("@param call The Ktor application call\n")
+        } else {
+            kDoc.add("@param call Decorated ApplicationCall with additional typed respond methods\n",)
+        }
 
         return kDoc.build()
     }
 
-    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
+    override fun generateLibrary(): Collection<ControllerLibraryType> = setOf(
+        buildTypedApplicationCall(),
+    )
+
+    /**
+     * Builds a typed ApplicationCall that provides type safe variants of the respond functions.
+     *
+     * Implemented as a decorator for Ktor's ApplicationCall and can be used as a drop-in replacement.
+     */
+    private fun buildTypedApplicationCall(): ControllerLibraryType {
+        val returnType = TypeVariableName("R", Any::class)
+
+        val messageType = TypeVariableName("T", returnType)
+            .copy(reified = true)
+
+        val spec = TypeSpec.classBuilder(TYPED_APPLICATION_CALL_CLASS_NAME)
+            .addTypeVariable(returnType)
+            .addSuperinterface(ClassName("io.ktor.server.application", "ApplicationCall"), delegate = CodeBlock.of("applicationCall"))
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("applicationCall", ClassName("io.ktor.server.application", "ApplicationCall"))
+                    .addModifiers(KModifier.PRIVATE)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("applicationCall", ClassName("io.ktor.server.application", "ApplicationCall"))
+                    .addModifiers(KModifier.PRIVATE)
+                    .initializer("applicationCall")
+                    .build()
+            )
+            .addKdoc(
+                CodeBlock.builder()
+                    .add("Decorator for Ktor's ApplicationCall that provides type safe variants of the [%M] functions.\n\n",
+                        MemberName("io.ktor.server.response", "respond", isExtension = true),
+                    )
+                    .add(
+                        "It can be used as a drop-in replacement for [%M].\n\n",
+                        MemberName("io.ktor.server.application", "ApplicationCall"),
+                    )
+                    .add("@param R The type of the response body\n\n")
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("respondTyped")
+                    .addModifiers(KModifier.INLINE, KModifier.SUSPEND)
+                    .addTypeVariable(messageType)
+                    .addAnnotation(
+                        AnnotationSpec.builder(Suppress::class)
+                            .addMember("%S", "unused")
+                            .build()
+                    )
+                    .addParameter("message", messageType)
+                    .addCode(
+                        CodeBlock.builder()
+                            .addStatement(
+                                "%M(message)",
+                                MemberName("io.ktor.server.response", "respond", isExtension = true),
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("respondTyped")
+                    .addModifiers(KModifier.INLINE, KModifier.SUSPEND)
+                    .addTypeVariable(messageType)
+                    .addAnnotation(
+                        AnnotationSpec.builder(Suppress::class)
+                            .addMember("%S", "unused")
+                            .build()
+                    )
+                    .addParameter("status", ClassName("io.ktor.http", "HttpStatusCode"))
+                    .addParameter("message", messageType)
+                    .addCode(
+                        CodeBlock.builder()
+                            .addStatement(
+                                "%M(status, message)",
+                                MemberName("io.ktor.server.response", "respond", isExtension = true),
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .addType(
+                TypeSpec.companionObjectBuilder()
+                    .addFunction(
+                        FunSpec.builder("from")
+                            .addTypeVariable(returnType)
+                            .addParameter("applicationCall", ClassName("io.ktor.server.application", "ApplicationCall"))
+                            .returns(ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME).parameterizedBy(returnType))
+                            .addCode(
+                                CodeBlock.builder()
+                                    .addStatement("return %T(applicationCall)", ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME).parameterizedBy(returnType))
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+
+        return ControllerLibraryType(spec, packages.base)
+    }
 
     /**
      * Function for getting a typed query parameter

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -287,7 +287,7 @@ class KtorControllerInterfaceGenerator(
             )
         } else {
             builder.addStatement(
-                "controller.%L(%L%T.from(%M))", // construct TypedApplicationCall
+                "controller.%L(%L%T(%M))", // construct TypedApplicationCall
                 methodName,
                 methodParameters.let { if (it.isNotEmpty()) "$it, " else "" },
                 ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME),
@@ -365,7 +365,6 @@ class KtorControllerInterfaceGenerator(
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("applicationCall", ClassName("io.ktor.server.application", "ApplicationCall"))
-                    .addModifiers(KModifier.PRIVATE)
                     .build()
             )
             .addProperty(
@@ -422,22 +421,6 @@ class KtorControllerInterfaceGenerator(
                             .addStatement(
                                 "%M(status, message)",
                                 MemberName("io.ktor.server.response", "respond", isExtension = true),
-                            )
-                            .build()
-                    )
-                    .build()
-            )
-            .addType(
-                TypeSpec.companionObjectBuilder()
-                    .addFunction(
-                        FunSpec.builder("from")
-                            .addTypeVariable(returnType)
-                            .addParameter("applicationCall", ClassName("io.ktor.server.application", "ApplicationCall"))
-                            .returns(ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME).parameterizedBy(returnType))
-                            .addCode(
-                                CodeBlock.builder()
-                                    .addStatement("return %T(applicationCall)", ClassName(packages.controllers, TYPED_APPLICATION_CALL_CLASS_NAME).parameterizedBy(returnType))
-                                    .build()
                             )
                             .build()
                     )

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -13,6 +13,7 @@ import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports
 import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports.SECURITY_RULE_IS_ANONYMOUS
 import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports.SECURITY_RULE_IS_AUTHENTICATED
 import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypes
@@ -52,6 +53,8 @@ class MicronautControllerInterfaceGenerator(
             }.toSet(),
             addAuthenticationParameter,
         )
+
+    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     override fun controllerBuilder(
         className: String,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -11,6 +11,7 @@ import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securi
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringAnnotations
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports
 import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
@@ -47,6 +48,8 @@ class SpringControllerInterfaceGenerator(
                 buildController(resourceName, paths.values)
             }.toSet(),
         )
+
+    override fun generateLibrary(): Collection<ControllerLibraryType> = emptySet()
 
     override fun controllerBuilder(
         className: String,

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -40,6 +40,9 @@ class ControllerType(spec: TypeSpec, basePackage: String) : GeneratedType(spec, 
     }
 }
 
+class ControllerLibraryType(spec: TypeSpec, basePackage: String) :
+    GeneratedType(spec, controllersPackage(basePackage))
+
 data class Models(val models: Collection<ModelType>) : KotlinTypes(models) {
     override val files: Collection<FileSpec> = models.toFileSpec()
 }

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -1,6 +1,7 @@
 package examples.authentication.controllers
 
 import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
@@ -9,6 +10,7 @@ import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.principal
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.`get`
 import io.ktor.server.util.getOrFail
@@ -17,11 +19,12 @@ import io.ktor.util.reflect.typeInfo
 import kotlin.Any
 import kotlin.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
 
 public interface RequiredController {
     /**
      * Route is expected to respond with status 200.
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [respond] to send the response.
      *
      * @param testString
      * @param call The Ktor application call
@@ -86,7 +89,7 @@ public interface RequiredController {
 public interface ProhibitedController {
     /**
      * Route is expected to respond with status 200.
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [respond] to send the response.
      *
      * @param testString
      * @param call The Ktor application call
@@ -143,7 +146,7 @@ public interface ProhibitedController {
 public interface OptionalController {
     /**
      * Route is expected to respond with status 200.
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [respond] to send the response.
      *
      * @param testString
      * @param call The Ktor application call
@@ -207,7 +210,7 @@ public interface OptionalController {
 public interface NoneController {
     /**
      * Route is expected to respond with status 200.
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [respond] to send the response.
      *
      * @param testString
      * @param call The Ktor application call
@@ -264,7 +267,7 @@ public interface NoneController {
 public interface DefaultController {
     /**
      * Route is expected to respond with status 200.
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [respond] to send the response.
      *
      * @param testString
      * @param call The Ktor application call
@@ -323,5 +326,31 @@ public interface DefaultController {
          */
         private fun Headers.getOrFail(name: String): String = this[name] ?: throw
             BadRequestException("Header " + name + " is required")
+    }
+}
+
+/**
+ * Decorator for Ktor's ApplicationCall that provides type safe variants of the [respond] functions.
+ *
+ * It can be used as a drop-in replacement for [io.ktor.server.application.ApplicationCall].
+ *
+ * @param R The type of the response body
+ */
+public class TypedApplicationCall<R : Any> private constructor(
+    private val applicationCall: ApplicationCall,
+) : ApplicationCall by applicationCall {
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(message: T) {
+        respond(message)
+    }
+
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
+        respond(status, message)
+    }
+
+    public companion object {
+        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
+            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -336,7 +336,7 @@ public interface DefaultController {
  *
  * @param R The type of the response body
  */
-public class TypedApplicationCall<R : Any> private constructor(
+public class TypedApplicationCall<R : Any>(
     private val applicationCall: ApplicationCall,
 ) : ApplicationCall by applicationCall {
     @Suppress("unused")
@@ -347,10 +347,5 @@ public class TypedApplicationCall<R : Any> private constructor(
     @Suppress("unused")
     public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
         respond(status, message)
-    }
-
-    public companion object {
-        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
-            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/binary/controllers/ktor/Controllers.kt
@@ -40,7 +40,7 @@ public interface BinaryDataController {
         public fun Route.binaryDataRoutes(controller: BinaryDataController) {
             post("/binary-data") {
                 val applicationOctetStream = call.receive<ByteArray>()
-                controller.postBinaryData(applicationOctetStream, TypedApplicationCall.from(call))
+                controller.postBinaryData(applicationOctetStream, TypedApplicationCall(call))
             }
         }
 
@@ -85,7 +85,7 @@ public interface BinaryDataController {
  *
  * @param R The type of the response body
  */
-public class TypedApplicationCall<R : Any> private constructor(
+public class TypedApplicationCall<R : Any>(
     private val applicationCall: ApplicationCall,
 ) : ApplicationCall by applicationCall {
     @Suppress("unused")
@@ -96,10 +96,5 @@ public class TypedApplicationCall<R : Any> private constructor(
     @Suppress("unused")
     public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
         respond(status, message)
-    }
-
-    public companion object {
-        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
-            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt
@@ -59,7 +59,7 @@ public interface InternalEventsController {
         public fun Route.internalEventsRoutes(controller: InternalEventsController) {
             post("/internal/events") {
                 val bulkEntityDetails = call.receive<BulkEntityDetails>()
-                controller.post(bulkEntityDetails, TypedApplicationCall.from(call))
+                controller.post(bulkEntityDetails, TypedApplicationCall(call))
             }
         }
 
@@ -224,7 +224,7 @@ public interface ContributorsController {
                     limit,
                     includeInactive,
                     cursor,
-                    TypedApplicationCall.from(call),
+                    TypedApplicationCall(call),
                 )
             }
             post("/contributors") {
@@ -239,7 +239,7 @@ public interface ContributorsController {
                 val ifNoneMatch = call.request.headers["If-None-Match"]
                 val status =
                     call.request.queryParameters.getTyped<examples.githubApi.models.StatusQueryParam>("status")
-                controller.getContributor(xFlowId, ifNoneMatch, id, status, TypedApplicationCall.from(call))
+                controller.getContributor(xFlowId, ifNoneMatch, id, status, TypedApplicationCall(call))
             }
             put("/contributors/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
@@ -407,7 +407,7 @@ public interface OrganisationsController {
                 val includeInactive =
                     call.request.queryParameters.getTyped<kotlin.Boolean>("include_inactive")
                 val cursor = call.request.queryParameters.getTyped<kotlin.String>("cursor")
-                controller.get(xFlowId, limit, includeInactive, cursor, TypedApplicationCall.from(call))
+                controller.get(xFlowId, limit, includeInactive, cursor, TypedApplicationCall(call))
             }
             post("/organisations") {
                 val xFlowId = call.request.headers["X-Flow-Id"]
@@ -421,7 +421,7 @@ public interface OrganisationsController {
                 val ifNoneMatch = call.request.headers["If-None-Match"]
                 val status =
                     call.request.queryParameters.getTyped<examples.githubApi.models.StatusQueryParam>("status")
-                controller.getById(xFlowId, ifNoneMatch, id, status, TypedApplicationCall.from(call))
+                controller.getById(xFlowId, ifNoneMatch, id, status, TypedApplicationCall(call))
             }
             put("/organisations/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
@@ -596,7 +596,7 @@ public interface OrganisationsContributorsController {
                     limit,
                     includeInactive,
                     cursor,
-                    TypedApplicationCall.from(call),
+                    TypedApplicationCall(call),
                 )
             }
             `get`("/organisations/{parent-id}/contributors/{id}") {
@@ -604,7 +604,7 @@ public interface OrganisationsContributorsController {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val ifNoneMatch = call.request.headers["If-None-Match"]
-                controller.getById(xFlowId, ifNoneMatch, parentId, id, TypedApplicationCall.from(call))
+                controller.getById(xFlowId, ifNoneMatch, parentId, id, TypedApplicationCall(call))
             }
             put("/organisations/{parent-id}/contributors/{id}") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
@@ -793,7 +793,7 @@ public interface RepositoriesController {
                     name,
                     includeInactive,
                     cursor,
-                    TypedApplicationCall.from(call),
+                    TypedApplicationCall(call),
                 )
             }
             post("/repositories") {
@@ -808,7 +808,7 @@ public interface RepositoriesController {
                 val ifNoneMatch = call.request.headers["If-None-Match"]
                 val status =
                     call.request.queryParameters.getTyped<examples.githubApi.models.StatusQueryParam>("status")
-                controller.getById(xFlowId, ifNoneMatch, id, status, TypedApplicationCall.from(call))
+                controller.getById(xFlowId, ifNoneMatch, id, status, TypedApplicationCall(call))
             }
             put("/repositories/{id}") {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
@@ -993,7 +993,7 @@ public interface RepositoriesPullRequestsController {
                     limit,
                     includeInactive,
                     cursor,
-                    TypedApplicationCall.from(call),
+                    TypedApplicationCall(call),
                 )
             }
             post("/repositories/{parent-id}/pull-requests") {
@@ -1008,7 +1008,7 @@ public interface RepositoriesPullRequestsController {
                 val id = call.parameters.getOrFail<kotlin.String>("id")
                 val xFlowId = call.request.headers["X-Flow-Id"]
                 val ifNoneMatch = call.request.headers["If-None-Match"]
-                controller.getById(xFlowId, ifNoneMatch, parentId, id, TypedApplicationCall.from(call))
+                controller.getById(xFlowId, ifNoneMatch, parentId, id, TypedApplicationCall(call))
             }
             put("/repositories/{parent-id}/pull-requests/{id}") {
                 val parentId = call.parameters.getOrFail<kotlin.String>("parent-id")
@@ -1062,7 +1062,7 @@ public interface RepositoriesPullRequestsController {
  *
  * @param R The type of the response body
  */
-public class TypedApplicationCall<R : Any> private constructor(
+public class TypedApplicationCall<R : Any>(
     private val applicationCall: ApplicationCall,
 ) : ApplicationCall by applicationCall {
     @Suppress("unused")
@@ -1073,10 +1073,5 @@ public class TypedApplicationCall<R : Any> private constructor(
     @Suppress("unused")
     public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
         respond(status, message)
-    }
-
-    public companion object {
-        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
-            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -2,12 +2,14 @@ package examples.parameterNameClash.controllers
 
 import examples.parameterNameClash.models.SomeObject
 import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
 import io.ktor.server.request.receive
+import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.`get`
 import io.ktor.server.routing.post
@@ -16,11 +18,12 @@ import io.ktor.util.converters.DefaultConversionService
 import io.ktor.util.reflect.typeInfo
 import kotlin.Any
 import kotlin.String
+import kotlin.Suppress
 
 public interface ExampleController {
     /**
      * Route is expected to respond with status 204.
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [respond] to send the response.
      *
      * @param pathB
      * @param queryB
@@ -34,7 +37,7 @@ public interface ExampleController {
 
     /**
      * Route is expected to respond with status 204.
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [respond] to send the response.
      *
      * @param bodySomeObject example
      * @param querySomeObject
@@ -97,5 +100,31 @@ public interface ExampleController {
          */
         private fun Headers.getOrFail(name: String): String = this[name] ?: throw
             BadRequestException("Header " + name + " is required")
+    }
+}
+
+/**
+ * Decorator for Ktor's ApplicationCall that provides type safe variants of the [respond] functions.
+ *
+ * It can be used as a drop-in replacement for [io.ktor.server.application.ApplicationCall].
+ *
+ * @param R The type of the response body
+ */
+public class TypedApplicationCall<R : Any> private constructor(
+    private val applicationCall: ApplicationCall,
+) : ApplicationCall by applicationCall {
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(message: T) {
+        respond(message)
+    }
+
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
+        respond(status, message)
+    }
+
+    public companion object {
+        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
+            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/parameterNameClash/controllers/ktor/Controllers.kt
@@ -110,7 +110,7 @@ public interface ExampleController {
  *
  * @param R The type of the response body
  */
-public class TypedApplicationCall<R : Any> private constructor(
+public class TypedApplicationCall<R : Any>(
     private val applicationCall: ApplicationCall,
 ) : ApplicationCall by applicationCall {
     @Suppress("unused")
@@ -121,10 +121,5 @@ public class TypedApplicationCall<R : Any> private constructor(
     @Suppress("unused")
     public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
         respond(status, message)
-    }
-
-    public companion object {
-        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
-            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -87,7 +87,7 @@ public interface ExampleController {
  *
  * @param R The type of the response body
  */
-public class TypedApplicationCall<R : Any> private constructor(
+public class TypedApplicationCall<R : Any>(
     private val applicationCall: ApplicationCall,
 ) : ApplicationCall by applicationCall {
     @Suppress("unused")
@@ -98,10 +98,5 @@ public class TypedApplicationCall<R : Any> private constructor(
     @Suppress("unused")
     public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
         respond(status, message)
-    }
-
-    public companion object {
-        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
-            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -34,7 +34,7 @@ public interface TestController {
          */
         public fun Route.testRoutes(controller: TestController) {
             `get`("/test") {
-                controller.test(TypedApplicationCall.from(call))
+                controller.test(TypedApplicationCall(call))
             }
         }
 
@@ -79,7 +79,7 @@ public interface TestController {
  *
  * @param R The type of the response body
  */
-public class TypedApplicationCall<R : Any> private constructor(
+public class TypedApplicationCall<R : Any>(
     private val applicationCall: ApplicationCall,
 ) : ApplicationCall by applicationCall {
     @Suppress("unused")
@@ -90,10 +90,5 @@ public class TypedApplicationCall<R : Any> private constructor(
     @Suppress("unused")
     public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
         respond(status, message)
-    }
-
-    public companion object {
-        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
-            TypedApplicationCall<R>(applicationCall)
     }
 }

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -1,25 +1,30 @@
 package examples.singleAllOf.controllers
 
+import examples.singleAllOf.models.Result
 import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.`get`
 import io.ktor.util.converters.DefaultConversionService
 import io.ktor.util.reflect.typeInfo
 import kotlin.Any
 import kotlin.String
+import kotlin.Suppress
 
 public interface TestController {
     /**
      * Route is expected to respond with [examples.singleAllOf.models.Result].
-     * Use [io.ktor.server.response.respond] to send the response.
+     * Use [examples.singleAllOf.controllers.TypedApplicationCall.respondTyped] to send the response.
      *
-     * @param call The Ktor application call
+     * @param call Decorated ApplicationCall with additional typed respond methods
      */
-    public suspend fun test(call: ApplicationCall)
+    public suspend fun test(call: TypedApplicationCall<Result>)
 
     public companion object {
         /**
@@ -29,7 +34,7 @@ public interface TestController {
          */
         public fun Route.testRoutes(controller: TestController) {
             `get`("/test") {
-                controller.test(call)
+                controller.test(TypedApplicationCall.from(call))
             }
         }
 
@@ -64,5 +69,31 @@ public interface TestController {
          */
         private fun Headers.getOrFail(name: String): String = this[name] ?: throw
             BadRequestException("Header " + name + " is required")
+    }
+}
+
+/**
+ * Decorator for Ktor's ApplicationCall that provides type safe variants of the [respond] functions.
+ *
+ * It can be used as a drop-in replacement for [io.ktor.server.application.ApplicationCall].
+ *
+ * @param R The type of the response body
+ */
+public class TypedApplicationCall<R : Any> private constructor(
+    private val applicationCall: ApplicationCall,
+) : ApplicationCall by applicationCall {
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(message: T) {
+        respond(message)
+    }
+
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
+        respond(status, message)
+    }
+
+    public companion object {
+        public fun <R : Any> from(applicationCall: ApplicationCall): TypedApplicationCall<R> =
+            TypedApplicationCall<R>(applicationCall)
     }
 }


### PR DESCRIPTION
In #280 it was discussed how to provide the user with a type safe way to respond to the request.

It was [decided](https://github.com/cjbooms/fabrikt/pull/280#discussion_r1579041527) to fully delegate the responsibility of responding to the controller implementation, which provides the user with direct access to `call` and maintains full flexibility.

In order to be able to offer a type safe way to respond, this PR introduces two new functions on `call`:
- `call.repondTyped(status: HttpStatusCode, message: T)`
- `call.repondTyped(message: T)`

The functions are provided through a decorator on ApplicationCall (which is luckily an interface) and can be used as a drop-in replacement for ApplicationCall.

The `TypedApplicationCall` class is included as a utility class through a `generateLibrary` functionality inspired by the [client generators](https://github.com/cjbooms/fabrikt/blob/master/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGenerator.kt#L9).

Routes that do not respond with content is provided with the regular ApplicationCall as there is no need for type safety there.

Offering this type safety makes the experience much more enjoyable and removes the mental load of remembering to check which type should be returned 🧘 

https://github.com/cjbooms/fabrikt/assets/11440456/1b2b2d19-2222-48b7-82f7-bf2c45fc1059

**Examples:**

Generated class: [TypedApplicationCall](https://github.com/ulrikandersen/fabrikt/blob/3274ee9b4b83c7954a1df765f37b18c4e978ad4c/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt#L339)

Route with response content: [POST /internal/events](https://github.com/ulrikandersen/fabrikt/blob/3274ee9b4b83c7954a1df765f37b18c4e978ad4c/src/test/resources/examples/githubApi/controllers/ktor/Controllers.kt#L48)

Route without response content: [GET /required](https://github.com/ulrikandersen/fabrikt/blob/3274ee9b4b83c7954a1df765f37b18c4e978ad4c/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt#L32)