### PR TITLE
Fix Jens issue around nested arrays missing explicit object type.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -11,6 +11,7 @@ import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import com.reprezen.kaizen.oasparser.model3.Path
 import com.reprezen.kaizen.oasparser.model3.Schema
 import java.net.URI
+import java.util.logging.Logger
 
 object KaizenParserExtensions {
 
@@ -112,7 +113,11 @@ object KaizenParserExtensions {
     fun Schema.isSimpleType(): Boolean =
         !isOneOfSuperInterface() && ((simpleTypes.contains(type) && !isEnumDefinition()) || isSimpleMapDefinition() || isSimpleOneOfAnyDefinition())
 
-    private fun Schema.isObjectType() = OasType.Object.type == type
+    private fun Schema.isObjectType() =
+        OasType.Object.type == type || if (properties?.isNotEmpty() == true) {
+            Logger.getGlobal().warning("Schema '$name' has 'type: null' but defines properties. Assuming: 'type: object'")
+        true
+    } else false
 
     private fun Schema.isArrayType() = OasType.Array.type == type
 

--- a/src/test/resources/examples/arrays/api.yaml
+++ b/src/test/resources/examples/arrays/api.yaml
@@ -10,6 +10,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ArrayOfSomething"
+        absent-object-type-in-array:
+          type: array
+          items:
+            properties:
+              some-array-prop:
+                type: string
 
     ArrayOfSomething:
       type: array

--- a/src/test/resources/examples/arrays/models/ContainsArrayOfArrays.kt
+++ b/src/test/resources/examples/arrays/models/ContainsArrayOfArrays.kt
@@ -9,4 +9,8 @@ public data class ContainsArrayOfArrays(
   @get:JsonProperty("array_of_arrays")
   @get:Valid
   public val arrayOfArrays: List<List<Something>>? = null,
+  @param:JsonProperty("absent-object-type-in-array")
+  @get:JsonProperty("absent-object-type-in-array")
+  @get:Valid
+  public val absentObjectTypeInArray: List<ContainsArrayOfArraysAbsentObjectTypeInArray>? = null,
 )

--- a/src/test/resources/examples/arrays/models/ContainsArrayOfArraysAbsentObjectTypeInArray.kt
+++ b/src/test/resources/examples/arrays/models/ContainsArrayOfArraysAbsentObjectTypeInArray.kt
@@ -1,0 +1,10 @@
+package examples.arrays.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class ContainsArrayOfArraysAbsentObjectTypeInArray(
+  @param:JsonProperty("some-array-prop")
+  @get:JsonProperty("some-array-prop")
+  public val someArrayProp: String? = null,
+)


### PR DESCRIPTION
Need to be lenient with inline object definitions like we are with top-level, and not require explicit `type: object` non-empty properties should be enough to assume object intent