### PR TITLE
Restructures and refreshes the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 * [Examples](#examples)
 * [Usage Instructions](#usage-instructions)
   * [Command Line](#command-line)
-  * [Gradle](#gradle)
+  * [Gradle w/ custom task](#gradle-w-custom-task)
+  * [Gradle w/ plugin](#gradle-w-plugin)
   * [Maven](#maven)
 * [Configuration Options](#configuration-options)
 * [Building Locally](#building-locally)
@@ -90,7 +91,7 @@ java -jar fabrikt.jar \
     --http-client-opts resilience4j
 ```
 
-### Gradle
+### Gradle w/ custom task
 
 Here is an example of a Gradle task with code generated to the `build/generated` directory, and execution linked to the compile task. 
 
@@ -132,6 +133,28 @@ tasks {
 dependencies {
      fabrikt("com.cjbooms:fabrikt:+") // This should be pinned  
      ...
+}
+```
+
+### Gradle w/ plugin
+
+The [Fabrikt Gradle plugin](https://github.com/acanda/fabrikt-gradle-plugin) serves as a convenient wrapper for Fabrikt, 
+allowing seamless integration of code generation into a Gradle build.
+
+**Note:** Since the plugin is maintained separately from the Fabrikt library, please refer to the
+[Configuration](https://github.com/acanda/fabrikt-gradle-plugin?tab=readme-ov-file#configuration) section of the 
+plugin's README for the most up-to-date information on how to use it.
+
+```kotlin
+plugins {
+    id("ch.acanda.gradle.fabrikt") version "1.1.0" // find latest version: https://github.com/acanda/fabrikt-gradle-plugin/releases
+}
+
+fabrikt {
+    generate("dog") {
+        apiFile = file("src/main/openapi/dog.yaml")
+        basePackage = "com.example.api"
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# Fabrikt `/ˈfa-brikt/` - Kotlin code from OpenApi3 specifications
+# Fabrikt `/ˈfa-brikt/` - Kotlin code from OpenAPI 3
 
-This library was built to take advantage of the complex modeling features available in OpenApi3. It generates Kotlin data classes with advanced support for features such as: 
+---
+
+* [Introduction](#introduction)
+* [Features](#features)
+* [Examples](#examples)
+* [Usage Instructions](#usage-instructions)
+  * [Command Line](#command-line)
+  * [Gradle](#gradle)
+  * [Maven](#maven)
+* [Configuration Options](#configuration-options)
+* [Building Locally](#building-locally)
+* [Publishing](#publishing)
+* [Specific Features](#specific-features)
+
+---
+
+## Introduction
+
+This library was built to take advantage of the complex modeling features available in OpenAPI 3. It generates Kotlin data classes with advanced support for features such as: 
  - Null Safety
  - Inlined schema definitions
  - Enumerations 
@@ -10,13 +28,16 @@ This library was built to take advantage of the complex modeling features availa
  - GraalVM Native Reflection Registration
  - Json Merge Patch (via `JsonNullable`) (add `x-json-merge-patch: true` to schemas)
  - Override Jackson Include NonNull (via `JsonInclude`) (add `x-jackson-include-non-null: true` to schemas)
- - Generate CompletionStage wrapped controllers (add `x-async-support: true` to path)
+ 
+as well as HTTP clients and controllers for a number of popular frameworks (see [Features](#features)).
 
 More than just bootstrapping, this library can be permanently integrated into a gradle or maven build and will ensure contract and code always match, even as APIs evolve in complexity. 
 
-The team that built this tool initially contributed to the Kotlin code generation ability in [OpenApiTools](https://github.com/OpenAPITools/openapi-generator), but reached the limits of what could be achieved with template-based generation. This library leverages the rich OpenApi3 model provided by [KaiZen-OpenApi-Parser](https://github.com/RepreZen/KaiZen-OpenApi-Parser) and uses [Kotlin Poet](https://square.github.io/kotlinpoet/) to programmatically construct Kotlin classes for maximum flexibility. 
+The team that built this tool initially contributed to the Kotlin code generation ability in [OpenApiTools](https://github.com/OpenAPITools/openapi-generator), but reached the limits of what could be achieved with template-based generation. This library leverages the rich OpenAPI 3 model provided by [KaiZen-OpenApi-Parser](https://github.com/RepreZen/KaiZen-OpenApi-Parser) and uses [Kotlin Poet](https://square.github.io/kotlinpoet/) to programmatically construct Kotlin classes for maximum flexibility. 
 
-It was built at [Zalando Tech](https://opensource.zalando.com/) and is battle-tested in production there. It is particulary well suited to API's built according to Zalando's [REST API guidelines](https://opensource.zalando.com/restful-api-guidelines/). It is [available on Maven Central](https://search.maven.org/artifact/com.cjbooms/fabrikt) at the following coordinates:
+It was built at [Zalando Tech](https://opensource.zalando.com/) and is battle-tested in production there. It is particularly well-suited to API's built according to Zalando's [REST API guidelines](https://opensource.zalando.com/restful-api-guidelines/).
+
+The library is [available on Maven Central](https://search.maven.org/artifact/com.cjbooms/fabrikt) at the following coordinates:
 
 ```xml
 <dependency>
@@ -29,21 +50,177 @@ It was built at [Zalando Tech](https://opensource.zalando.com/) and is battle-te
 
 The library currently has support for generating:
 
-* **Jackson annotated data classes**
-* **Spring MVC annotated controller interfaces**
-* **Ktor server routes and controller interfaces ([examples](end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor))**
-* **OkHttp Client** - with the option for a resilience4j fault-tolerance wrapper
+* Models
+  * **Jackson** annotated **data classes**
+* Clients
+  * **OkHttp Client** - with the option for a resilience4j fault-tolerance wrapper
+  * **OpenFeign** annotated client interfaces
+* Controllers
+  * **Spring MVC** annotated controller interfaces
+  * **Micronaut** HTTP annotated controller interfaces
+  * **Ktor server** routes and controller interfaces
 
-### Example Generation
+## Examples
 
-Consult test directory for OAS code generation examples, it forms a living documentation full of [code examples](src/test/resources/examples) generated from different OpenApi3 permutations. 
+Consult test directory for OpenAPI code generation examples. 
 
-#### Polymorphism via allOf
+It forms a living documentation full of [code examples](src/test/resources/examples) generated from different OpenAPI 3 permutations.
+
+Furthermore, the [end-to-end tests](/end2end-tests) demonstrate how to integrate the library using Gradle.
+
+## Usage Instructions
+
+The library can be used in a variety of ways, including as a command line tool, a Gradle task, or a Maven plugin.
+
+Please refer to [Configuration Options](#configuration-options) section for a list of available parameters.
+
+### Command Line
+
+Fabrikt is packaged as an executable jar, allowing it to be integrated into any build tool. 
+
+The CLI can be invoked as follows:
+
+```
+java -jar fabrikt.jar \
+    --output-directory '/tmp' \
+    --base-package 'com.example' \
+    --api-file '/path-to-api/open-api.yaml' \
+    --targets 'client' \
+    --targets 'http_models' \
+    --http-client-opts resilience4j
+```
+
+### Gradle
+
+Here is an example of a Gradle task with code generated to the `build/generated` directory, and execution linked to the compile task. 
+
+```kotlin
+val fabrikt: Configuration by configurations.creating
+
+val generationDir = "$buildDir/generated"
+val apiFile = "$buildDir/path-to-api/open-api.yaml"
+
+sourceSets {
+    main { java.srcDirs("$generationDir/src/main/kotlin") }
+    test { java.srcDirs("$generationDir/src/test/kotlin") }
+    ...
+}
+
+tasks {   
+    ...
+    val generateCode by creating(JavaExec::class) {
+        inputs.files(apiFile)
+        outputs.dir(generationDir)
+        outputs.cacheIf { true }
+        classpath(fabrikt)
+        mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
+        args = listOf(
+            "--output-directory", generationDir,
+            "--base-package", "com.example",
+            "--api-file", apiFile,
+            "--targets", "http_models",
+            "--targets", "client",
+            "--http-client-opts", "resilience4j"
+        )
+    }
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+        dependsOn(generateCode)
+    }
+}
+
+dependencies {
+     fabrikt("com.cjbooms:fabrikt:+") // This should be pinned  
+     ...
+}
+```
+
+### Maven
+
+The [exec-maven-plugin](http://www.mojohaus.org/exec-maven-plugin/examples/example-exec-using-plugin-dependencies.html) is capable of downloading the Fabrikt library from Maven Central and executing its main method with defined arguments.
+
+## Configuration Options
+
+This section documents the available CLI parameters for controlling what gets generated. This documentation is generated using: `./gradlew printCodeGenUsage`
+
+| Parameter                     | Description |
+| ----------------------------- | ----------------------------- |
+|   `--api-file`                | This must be a valid Open API v3 spec. All code generation will be based off this input. |
+|   `--api-fragment`            | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. |
+| * `--base-package`            | The base package which all code will be generated under. |
+|   `--external-ref-resolution` | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED |
+|                               | CHOOSE ONE OF: |
+|                               |   `TARGETED` - Generate models only for directly referenced schemas in external API files. |
+|                               |   `AGGRESSIVE` - Referencing any schema in an external API file triggers generation of every external schema in that file. |
+|   `--http-client-opts`        | Select the options for the http client code that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `RESILIENCE4J` - Generates a fault tolerance service for the client using the following library "io.github.resilience4j:resilience4j-all:+" (only for OkHttp clients) |
+|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated client functions (only for OpenFeign clients) |
+|                               |   `SPRING_RESPONSE_ENTITY_WRAPPER` - This option adds the Spring-ResponseEntity generic around the response to be able to get response headers and status (only for OpenFeign clients). |
+|   `--http-client-target`      | Optionally select the target client that you want to be generated. Defaults to OK_HTTP |
+|                               | CHOOSE ONE OF: |
+|                               |   `OK_HTTP` - Generate OkHttp client. |
+|                               |   `OPEN_FEIGN` - Generate OpenFeign client. |
+|   `--http-controller-opts`    | Select the options for the controllers that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions |
+|                               |   `AUTHENTICATION` - This option adds the authentication parameter to the generated controller functions |
+|                               |   `COMPLETION_STAGE` - This option makes generated controller functions have Type CompletionStage<T> (works only with Spring Controller generator) |
+|   `--http-controller-target`  | Optionally select the target framework for the controllers that you want to be generated. Defaults to Spring Controllers |
+|                               | CHOOSE ONE OF: |
+|                               |   `SPRING` - Generate for Spring framework. |
+|                               |   `MICRONAUT` - Generate for Micronaut framework. |
+|                               |   `KTOR` - Generate for Ktor server. |
+|   `--http-model-opts`         | Select the options for the http models that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `X_EXTENSIBLE_ENUMS` - This option treats x-extensible-enums as enums |
+|                               |   `JAVA_SERIALIZATION` - This option adds Java Serializable interface to the generated models |
+|                               |   `QUARKUS_REFLECTION` - This option adds @RegisterForReflection to the generated models. Requires dependency "'io.quarkus:quarkus-core:+" |
+|                               |   `MICRONAUT_INTROSPECTION` - This option adds @Introspected to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
+|                               |   `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
+|                               |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
+|                               |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
+|                               |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
+|   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir |
+|   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources` |
+|   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin` |
+|   `--targets`                 | Targets are the parts of the application that you want to be generated. |
+|                               | CHOOSE ANY OF: |
+|                               |   `HTTP_MODELS` - Jackson annotated data classes to represent the schema objects defined in the input. |
+|                               |   `CONTROLLERS` - Spring / Micronaut / Ktor HTTP controllers for each of the endpoints defined in the input. |
+|                               |   `CLIENT` - Simple http rest client. |
+|                               |   `QUARKUS_REFLECTION_CONFIG` - This options generates the reflection-config.json file for quarkus integration projects |
+|   `--type-overrides`          | Specify non-default kotlin types for certain OAS types. For example, generate `Instant` instead of `OffsetDateTime` |
+|                               | CHOOSE ANY OF: |
+|                               |   `DATETIME_AS_INSTANT` - Use `Instant` as the datetime type. Defaults to `OffsetDateTime` |
+|                               |   `DATETIME_AS_LOCALDATETIME` - Use `LocalDateTime` as the datetime type. Defaults to `OffsetDateTime` |
+|                               |   `BYTEARRAY_AS_INPUTSTREAM` - Use `InputStream` as ByteArray type. Defaults to `ByteArray` |
+|   `--validation-library`      | Specify which validation library to use for annotations in generated model classes. Default: JAVAX_VALIDATION |
+|                               | CHOOSE ONE OF: |
+|                               |   `JAVAX_VALIDATION` - Use `javax.validation` annotations in generated model classes (default) |
+|                               |   `JAKARTA_VALIDATION` - Use `jakarta.validation` annotations in generated model classes |
+|                               |   `NO_VALIDATION` - Use no validation annotations in generated model classes |
+
+## Building Locally
+
+Fabrikt is built with Gradle and requires an initialised git repository. The easiest way to build it is to clone the repo locally before executing the build command:
+```
+git clone git@github.com:cjbooms/fabrikt.git
+cd fabrikt/
+./gradlew clean build
+```
+
+## Publishing
+This library is published to [Sonatype's OSS](https://s01.oss.sonatype.org/#welcome) staging repository using Github actions when a release is drafted. It can be manually promoted from there to the release repository which is indexed by Maven Central.
+
+## Specific Features
+
+### Polymorphism via `allOf`
 
 The following example shows how `allOf` can be used to generate polymorphic Kotlin data classes. It does the following:
- - A `ChildDefinition` schema defines both the discriminator mapping details and the schema for the discriminator property. In this case the discriminator property is an enumeration
- - In each child schema, `allOf` is used to merge the `ChildDefinition` with the child's custom schema. This guarantees that each child schema inherits the correct discriminator property. 
- - In the `Responses` schema a `oneOf` lists only child schemas. This will be detected by Fabrikt and it will generate the list of parent types: `List<ChildDefinition>`
+- A `ChildDefinition` schema defines both the discriminator mapping details and the schema for the discriminator property. In this case the discriminator property is an enumeration
+- In each child schema, `allOf` is used to merge the `ChildDefinition` with the child's custom schema. This guarantees that each child schema inherits the correct discriminator property.
+- In the `Responses` schema a `oneOf` lists only child schemas. This will be detected by Fabrikt and it will generate the list of parent types: `List<ChildDefinition>`
 
 _NOTE: A new feature has been added that allows Polymorphism to be achieved using only a [discriminated oneOf](src/test/resources/examples/discriminatedOneOf). This feature makes use of Kotlin `sealed interface` and must be explicitly enabled via `--http-model-opts, SEALED_INTERFACES_FOR_ONE_OF`_
 
@@ -183,141 +360,3 @@ data class Responses(
     val entries: List<ChildDefinition>? = null
 )
 ```
-
-
-## Usage Instructions
-
-This section documents the available CLI parameters for controlling what gets generated. This documentation is generated using: `./gradlew printCodeGenUsage`
-
-| Parameter                     | Description |
-| ----------------------------- | ----------------------------- |
-|   `--api-file`                | This must be a valid Open API v3 spec. All code generation will be based off this input. |
-|   `--api-fragment`            | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. |
-| * `--base-package`            | The base package which all code will be generated under. |
-|   `--external-ref-resolution` | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED |
-|                               | CHOOSE ONE OF: |
-|                               |   `TARGETED` - Generate models only for directly referenced schemas in external API files. |
-|                               |   `AGGRESSIVE` - Referencing any schema in an external API file triggers generation of every external schema in that file. |
-|   `--http-client-opts`        | Select the options for the http client code that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `RESILIENCE4J` - Generates a fault tolerance service for the client using the following library "io.github.resilience4j:resilience4j-all:+" (only for OkHttp clients) |
-|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated client functions (only for OpenFeign clients) |
-|                               |   `SPRING_RESPONSE_ENTITY_WRAPPER` - This option adds the Spring-ResponseEntity generic around the response to be able to get response headers and status (only for OpenFeign clients). |
-|   `--http-client-target`      | Optionally select the target client that you want to be generated. Defaults to OK_HTTP |
-|                               | CHOOSE ONE OF: |
-|                               |   `OK_HTTP` - Generate OkHttp client. |
-|                               |   `OPEN_FEIGN` - Generate OpenFeign client. |
-|   `--http-controller-opts`    | Select the options for the controllers that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions |
-|                               |   `AUTHENTICATION` - This option adds the authentication parameter to the generated controller functions |
-|                               |   `COMPLETION_STAGE` - This option makes generated controller functions have Type CompletionStage<T> (works only with Spring Controller generator) |
-|   `--http-controller-target`  | Optionally select the target framework for the controllers that you want to be generated. Defaults to Spring Controllers |
-|                               | CHOOSE ONE OF: |
-|                               |   `SPRING` - Generate for Spring framework. |
-|                               |   `MICRONAUT` - Generate for Micronaut framework. |
-|                               |   `KTOR` - Generate for Ktor server. |
-|   `--http-model-opts`         | Select the options for the http models that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `X_EXTENSIBLE_ENUMS` - This option treats x-extensible-enums as enums |
-|                               |   `JAVA_SERIALIZATION` - This option adds Java Serializable interface to the generated models |
-|                               |   `QUARKUS_REFLECTION` - This option adds @RegisterForReflection to the generated models. Requires dependency "'io.quarkus:quarkus-core:+" |
-|                               |   `MICRONAUT_INTROSPECTION` - This option adds @Introspected to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
-|                               |   `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
-|                               |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
-|                               |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
-|                               |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
-|   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir |
-|   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources` |
-|   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin` |
-|   `--targets`                 | Targets are the parts of the application that you want to be generated. |
-|                               | CHOOSE ANY OF: |
-|                               |   `HTTP_MODELS` - Jackson annotated data classes to represent the schema objects defined in the input. |
-|                               |   `CONTROLLERS` - Spring / Micronaut / Ktor HTTP controllers for each of the endpoints defined in the input. |
-|                               |   `CLIENT` - Simple http rest client. |
-|                               |   `QUARKUS_REFLECTION_CONFIG` - This options generates the reflection-config.json file for quarkus integration projects |
-|   `--type-overrides`          | Specify non-default kotlin types for certain OAS types. For example, generate `Instant` instead of `OffsetDateTime` |
-|                               | CHOOSE ANY OF: |
-|                               |   `DATETIME_AS_INSTANT` - Use `Instant` as the datetime type. Defaults to `OffsetDateTime` |
-|                               |   `DATETIME_AS_LOCALDATETIME` - Use `LocalDateTime` as the datetime type. Defaults to `OffsetDateTime` |
-|                               |   `BYTEARRAY_AS_INPUTSTREAM` - Use `InputStream` as ByteArray type. Defaults to `ByteArray` |
-|   `--validation-library`      | Specify which validation library to use for annotations in generated model classes. Default: JAVAX_VALIDATION |
-|                               | CHOOSE ONE OF: |
-|                               |   `JAVAX_VALIDATION` - Use `javax.validation` annotations in generated model classes (default) |
-|                               |   `JAKARTA_VALIDATION` - Use `jakarta.validation` annotations in generated model classes |
-|                               |   `NO_VALIDATION` - Use no validation annotations in generated model classes |
-
-
-### Command Line
-Fabrikt is packaged as an executable jar, allowing it to be integrated into any build tool. The CLI can be invoked as follows:
-```
-   java -jar fabrikt.jar \
-             --output-directory '/tmp' \
-             --base-package 'com.example' \
-             --api-file '/path-to-api/open-api.yaml' \
-             --targets 'client' \
-             --targets 'http_models' \
-             --http-client-opts resilience4j
-```
-
-### Gradle example
-
-Here is an example of a Gradle task with code generated to the `build/generated` directory, and execution linked to the compile task. 
-
-```kotlin
-val fabrikt: Configuration by configurations.creating
-
-val generationDir = "$buildDir/generated"
-val apiFile = "$buildDir/path-to-api/open-api.yaml"
-
-sourceSets {
-    main { java.srcDirs("$generationDir/src/main/kotlin") }
-    test { java.srcDirs("$generationDir/src/test/kotlin") }
-    ...
-}
-
-tasks {   
-    ...
-    val generateCode by creating(JavaExec::class) {
-        inputs.files(apiFile)
-        outputs.dir(generationDir)
-        outputs.cacheIf { true }
-        classpath(fabrikt)
-        mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
-        args = listOf(
-            "--output-directory", generationDir,
-            "--base-package", "com.example",
-            "--api-file", apiFile,
-            "--targets", "http_models",
-            "--targets", "client",
-            "--http-client-opts", "resilience4j"
-        )
-    }
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
-        dependsOn(generateCode)
-    }
-}
-
-dependencies {
-     fabrikt("com.cjbooms:fabrikt:+") // This should be pinned  
-     ...
-}
-```
-
-### Maven
-
-The [exec-maven-plugin](http://www.mojohaus.org/exec-maven-plugin/examples/example-exec-using-plugin-dependencies.html) is capable of downloading the Fabrikt library from Maven Central and executing its main method with defined arguments.
-
-## Building Locally
-
-Fabrikt is built with Gradle and requires an initialised git repository. The easiest way to build it is to clone the repo locally before executing the build command:
-```
-git clone git@github.com:cjbooms/fabrikt.git
-cd fabrikt/
-./gradlew clean build
-```
-
-## Publishing
-This library is published to [Sonatype's OSS](https://s01.oss.sonatype.org/#welcome) staging repository using Github actions when a release is drafted. It can be manually promoted from there to the release repository which is indexed by Maven Central.
-


### PR DESCRIPTION
This PR restructures and refreshes the README in order to bring it up to date with what Fabrikt offers as of September 2024.

The contents are more or less the same, but I have tried to cater more to the users and to put an emphasis on how to get started.