### PR TITLE
Add option to specify custom model suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                               |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
 |                               |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
 |                               |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
+|   `--http-model-suffix`       | Specify custom suffix for all generated model classes. Defaults to no suffix. |
 |   `--output-directory`        | Allows the generation dir to be overridden. Defaults to current dir |
 |   `--resources-path`          | Allows the path for generated resources to be overridden. Defaults to `src/main/resources` |
 |   `--src-path`                | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin` |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
@@ -28,6 +28,7 @@ object CodeGen {
             codeGenArgs.controllerOptions,
             codeGenArgs.controllerTarget,
             codeGenArgs.modelOptions,
+            codeGenArgs.modelSuffix,
             codeGenArgs.clientOptions,
             codeGenArgs.clientTarget,
             codeGenArgs.typeOverrides,
@@ -47,6 +48,7 @@ object CodeGen {
         controllerOptions: Set<ControllerCodeGenOptionType>,
         controllerTarget: ControllerCodeGenTargetType,
         modelOptions: Set<ModelCodeGenOptionType>,
+        modelSuffix: String,
         clientOptions: Set<ClientCodeGenOptionType>,
         clientTarget: ClientCodeGenTargetType,
         typeOverrides: Set<CodeGenTypeOverride>,
@@ -55,7 +57,18 @@ object CodeGen {
         validationLibrary: ValidationLibrary,
         externalRefResolutionMode: ExternalReferencesResolutionMode
     ) {
-        MutableSettings.updateSettings(codeGenTypes, controllerOptions, controllerTarget, modelOptions, clientOptions, clientTarget, typeOverrides, validationLibrary, externalRefResolutionMode)
+        MutableSettings.updateSettings(
+            codeGenTypes,
+            controllerOptions,
+            controllerTarget,
+            modelOptions,
+            modelSuffix,
+            clientOptions,
+            clientTarget,
+            typeOverrides,
+            validationLibrary,
+            externalRefResolutionMode
+        )
 
         val suppliedApi = pathToApi.toFile().readText()
         val baseDir = pathToApi.parent

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
@@ -8,11 +8,11 @@ import com.beust.jcommander.ParameterException
 import com.beust.jcommander.converters.PathConverter
 import com.cjbooms.fabrikt.model.Destinations
 import com.cjbooms.fabrikt.util.NormalisedString.isValidJavaPackage
+import com.cjbooms.fabrikt.util.toUpperCase
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.system.exitProcess
-import com.cjbooms.fabrikt.util.toUpperCase
 
 class CodeGenArgs {
 
@@ -98,6 +98,12 @@ class CodeGenArgs {
         converter = ModelCodeGenOptionConverter::class
     )
     var modelOptions: Set<ModelCodeGenOptionType> = emptySet()
+
+    @Parameter(
+        names = ["--http-model-suffix"],
+        description = "Specify custom suffix for all generated model classes. Defaults to no suffix."
+    )
+    var modelSuffix: String = ""
 
     @Parameter(
         names = ["--http-client-opts"],

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
@@ -7,6 +7,7 @@ object MutableSettings {
     private lateinit var controllerOptions: MutableSet<ControllerCodeGenOptionType>
     private lateinit var controllerTarget: ControllerCodeGenTargetType
     private lateinit var modelOptions: MutableSet<ModelCodeGenOptionType>
+    private lateinit var modelSuffix: String
     private lateinit var clientOptions: MutableSet<ClientCodeGenOptionType>
     private lateinit var clientTarget: ClientCodeGenTargetType
     private lateinit var typeOverrides: MutableSet<CodeGenTypeOverride>
@@ -18,6 +19,7 @@ object MutableSettings {
         controllerOptions: Set<ControllerCodeGenOptionType> = emptySet(),
         controllerTarget: ControllerCodeGenTargetType = ControllerCodeGenTargetType.SPRING,
         modelOptions: Set<ModelCodeGenOptionType> = emptySet(),
+        modelSuffix: String = "",
         clientOptions: Set<ClientCodeGenOptionType> = emptySet(),
         clientTarget: ClientCodeGenTargetType = ClientCodeGenTargetType.OK_HTTP,
         typeOverrides: Set<CodeGenTypeOverride> = emptySet(),
@@ -28,6 +30,7 @@ object MutableSettings {
         this.controllerOptions = controllerOptions.toMutableSet()
         this.controllerTarget = controllerTarget
         this.modelOptions = modelOptions.toMutableSet()
+        this.modelSuffix = modelSuffix
         this.clientOptions = clientOptions.toMutableSet()
         this.clientTarget = clientTarget
         this.typeOverrides = typeOverrides.toMutableSet()
@@ -42,6 +45,7 @@ object MutableSettings {
     fun controllerOptions() = this.controllerOptions.toSet()
     fun controllerTarget() = this.controllerTarget
     fun modelOptions() = this.modelOptions.toSet()
+    fun modelSuffix() = this.modelSuffix
     fun clientOptions() = this.clientOptions.toSet()
     fun clientTarget() = this.clientTarget
     fun typeOverrides() = this.typeOverrides.toSet()

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/ModelNameRegistry.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/ModelNameRegistry.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.util
 
+import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.model.EnclosingSchemaInfo
 import com.cjbooms.fabrikt.model.EnclosingSchemaInfoName
 import com.cjbooms.fabrikt.model.EnclosingSchemaInfoOasModel
@@ -59,6 +60,8 @@ object ModelNameRegistry {
         if (valueSuffix) {
             append("Value")
         }
+        val modelClassNameSuffix = MutableSettings.modelSuffix()
+        append(modelClassNameSuffix)
     }
 
     private fun EnclosingSchemaInfo.toModelClassName() =

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -125,6 +125,29 @@ class ModelGeneratorTest {
     }
 
     @Test
+    fun `generate models with suffix`() {
+        MutableSettings.updateSettings(
+            genTypes = setOf(CodeGenerationType.HTTP_MODELS),
+            modelSuffix = "Dto"
+        )
+        val basePackage = "examples.modelSuffix"
+        val apiLocation = javaClass.getResource("/examples/modelSuffix/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val expectedModels = readFolder(Path.of("src/test/resources/examples/modelSuffix/models/"))
+
+        val models = JacksonModelGenerator(
+            Packages(basePackage),
+            sourceApi,
+        ).generate()
+
+        models.files.forEach { file ->
+            val key = "${file.name}.kt"
+            val content = file.toString()
+            assertThat(content).isEqualTo(expectedModels[key])
+        }
+    }
+
+    @Test
     fun `generate models using jakarta validation`() {
         val basePackage = "examples.jakartaValidationAnnotations"
         val spec = readTextResource("/examples/jakartaValidationAnnotations/api.yaml")

--- a/src/test/resources/examples/modelSuffix/api.yaml
+++ b/src/test/resources/examples/modelSuffix/api.yaml
@@ -1,0 +1,347 @@
+openapi: 3.0.0
+components:
+  schemas:
+    # Deep nested polymorphism
+    RootDiscriminator:
+      type: string
+      enum:
+        - firstLevelChild
+
+    FirstLevelDiscriminator:
+      type: string
+      enum:
+        - secondLevelChild1
+        - secondLevelChild2
+
+    SecondLevelDiscriminator:
+      type: string
+      enum:
+        - thirdLevelChild1
+        - thirdLevelChild2
+
+    RootType:
+      type: object
+      required:
+        - rootField1
+      discriminator:
+        propertyName: rootDiscriminator
+        mapping:
+          firstLevelChild: '#/components/schemas/FirstLevelChild'
+      properties:
+        rootDiscriminator:
+          $ref: "#/components/schemas/RootDiscriminator"
+        rootField1:
+          type: string
+        rootField2:
+          type: boolean
+
+    FirstLevelChild:
+      allOf:
+        - $ref: '#/components/schemas/RootType'
+        - type: object
+          required:
+            - firstLevelField1
+          discriminator:
+            propertyName: firstLevelDiscriminator
+            mapping:
+              secondLevelChild1: '#/components/schemas/SecondLevelChild1'
+              secondLevelChild2: '#/components/schemas/SecondLevelChild2'
+          properties:
+            firstLevelDiscriminator:
+              $ref: '#/components/schemas/FirstLevelDiscriminator'
+            firstLevelField1:
+              type: string
+            firstLevelField2:
+              type: integer
+
+    SecondLevelChild1:
+      allOf:
+        - $ref: '#/components/schemas/FirstLevelChild'
+        - type: object
+          required:
+            - metadata
+          properties:
+            metadata:
+              $ref: '#/components/schemas/SecondLevelMetadata'
+
+    SecondLevelChild2:
+      allOf:
+        - $ref: '#/components/schemas/FirstLevelChild'
+        - type: object
+          required:
+            - metadata
+          properties:
+            metadata:
+              $ref: '#/components/schemas/SecondLevelMetadata'
+
+    SecondLevelMetadata:
+      type: object
+      required:
+        - obj
+      properties:
+        obj:
+          $ref: "#/components/schemas/CommonObject"
+
+    CommonObject:
+      type: object
+      required:
+        - field1
+        - field2
+      properties:
+        field1:
+          type: string
+          required: true
+          nullable: false
+        field2:
+          type: string
+          required: true
+          nullable: false
+
+    # Polymorphism
+    PolymorphicTypeOneRef:
+      $ref: "#/components/schemas/PolymorphicTypeOne"
+    PolymorphicSuperType:
+      type: object
+      discriminator:
+        propertyName: generation
+      required:
+        - generation
+        - first_name
+        - last_name
+      properties:
+        generation:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+    PolymorphicTypeOne:
+      allOf:
+        - $ref: "#/components/schemas/PolymorphicSuperType"
+        - type: object
+          properties:
+            child_one_name:
+              type: string
+    # Maps
+    MapHolder:
+      type: object
+      properties:
+        wild_card:
+          type: object
+        string_map:
+          $ref: '#/components/schemas/StringMap'
+        typed_object_map:
+          $ref: '#/components/schemas/TypedObjectMap'
+        object_map:
+          $ref: '#/components/schemas/ObjectMap'
+        inlined_string_map:
+          type: object
+          additionalProperties:
+            type: string
+        inlined_object_map:
+          type: object
+          additionalProperties:
+            type: object
+        inlined_unknown_map:
+          type: object
+          additionalProperties: true
+        inlined_typed_object_map:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              code:
+                type: integer
+              text:
+                type: string
+        complex_object_with_untyped_map:
+          $ref: '#/components/schemas/ComplexObjectWithUntypedMap'
+        complex_object_with_typed_map:
+          $ref: '#/components/schemas/ComplexObjectWithTypedMap'
+        inlined_complex_object_with_untyped_map:
+          type: object
+          properties:
+            text:
+              type: string
+            code:
+              type: integer
+          additionalProperties: true
+        inlined_complex_object_with_typed_map:
+          type: object
+          properties:
+            text:
+              type: string
+            code:
+              type: integer
+          additionalProperties:
+            type: object
+            properties:
+              other_text:
+                type: string
+              other_number:
+                type: integer
+      additionalProperties:
+        type: object
+        minProperties: 1
+        additionalProperties:
+          $ref: '#/components/schemas/ExternalObjectFour'
+
+    ExternalObjectFour:
+      type: object
+      properties:
+        blah:
+          type: string
+
+    ComplexObjectWithUntypedMap:
+      type: object
+      properties:
+        text:
+          type: string
+        code:
+          type: integer
+      additionalProperties:
+        type: object
+
+    ComplexObjectWithTypedMap:
+      type: object
+      properties:
+        text:
+          type: string
+        code:
+          type: integer
+      additionalProperties:
+        type: object
+        properties:
+          other_text:
+            type: string
+          other_number:
+            type: integer
+
+    ComplexObjectWithRefTypedMap:
+      type: object
+      properties:
+        text:
+          type: string
+        code:
+          type: integer
+      additionalProperties:
+        $ref: '#/components/schemas/SomeRef'
+
+    SomeRef:
+      type: object
+      properties:
+        other_text:
+          type: string
+        other_number:
+          type: integer
+
+    ComplexObjectWithMapsOfMaps:
+      type: object
+      required:
+        - errors
+      properties:
+        list-others:
+          type: array
+          items:
+            $ref: '#/components/schemas/BasicObject'
+        map-of-maps:
+          type: object
+          additionalProperties:
+            type: object
+            minProperties: 1
+            additionalProperties:
+              $ref: '#/components/schemas/BasicObject'
+
+    BasicObject:
+      type: object
+      properties:
+        one:
+          type: string
+    StringMap:
+      type: object
+      additionalProperties:
+        type: string
+
+    TypedObjectMap:
+      type: object
+      additionalProperties:
+        type: object
+        properties:
+          code:
+            type: integer
+          text:
+            type: string
+
+    ObjectMap:
+      type: object
+      additionalProperties:
+        type: object
+
+    # Enums
+    EnumHolder:
+      type: object
+      properties:
+        array_of_enums:
+          type: array
+          items:
+            type: string
+            x-extensible-enum:
+              - array_enum_one
+              - array_enum_two
+        inlined_enum:
+          type: string
+          enum:
+            - inlined_one
+            - inlined_two
+            - inlined_three
+        inlined_extensible_enum:
+          type: string
+          x-extensible-enum:
+            - inlined_one
+            - inlined_two
+            - inlined_three
+        enum_ref:
+          $ref: '#/components/schemas/EnumObject'
+        list_enums:
+          $ref: '#/components/schemas/ListEnums'
+
+    EnumObject:
+      type: string
+      enum:
+        - one
+        - two
+        - three
+        - 4
+        - -5
+        - _6
+
+    ListEnums:
+      type: array
+      items:
+        type: string
+
+    FooBars:
+      type: object
+      properties:
+        prop_one:
+          $ref: '#/components/schemas/Foo'
+        prop_two:
+          $ref: '#/components/schemas/Bar'
+
+    Foo:
+      type: array
+      items:
+        type: string
+        enum:
+          - X
+          - Y
+    Bar:
+      type: array
+      items:
+        type: object
+        properties:
+          bar_prop:
+            type: string
+
+
+

--- a/src/test/resources/examples/modelSuffix/models/BarBarDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/BarBarDto.kt
@@ -1,0 +1,10 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class BarBarDto(
+  @param:JsonProperty("bar_prop")
+  @get:JsonProperty("bar_prop")
+  public val barProp: String? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/BasicObjectDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/BasicObjectDto.kt
@@ -1,0 +1,10 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class BasicObjectDto(
+  @param:JsonProperty("one")
+  @get:JsonProperty("one")
+  public val one: String? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/CommonObjectDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/CommonObjectDto.kt
@@ -1,0 +1,16 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class CommonObjectDto(
+  @param:JsonProperty("field1")
+  @get:JsonProperty("field1")
+  @get:NotNull
+  public val field1: String,
+  @param:JsonProperty("field2")
+  @get:JsonProperty("field2")
+  @get:NotNull
+  public val field2: String,
+)

--- a/src/test/resources/examples/modelSuffix/models/ComplexObjectWithMapsOfMapsDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ComplexObjectWithMapsOfMapsDto.kt
@@ -1,0 +1,18 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import kotlin.String
+import kotlin.collections.List
+import kotlin.collections.Map
+
+public data class ComplexObjectWithMapsOfMapsDto(
+  @param:JsonProperty("list-others")
+  @get:JsonProperty("list-others")
+  @get:Valid
+  public val listOthers: List<BasicObjectDto>? = null,
+  @param:JsonProperty("map-of-maps")
+  @get:JsonProperty("map-of-maps")
+  @get:Valid
+  public val mapOfMaps: Map<String, Map<String, BasicObjectDto?>?>? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/ComplexObjectWithRefTypedMapDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ComplexObjectWithRefTypedMapDto.kt
@@ -1,0 +1,29 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class ComplexObjectWithRefTypedMapDto(
+  @param:JsonProperty("text")
+  @get:JsonProperty("text")
+  public val text: String? = null,
+  @param:JsonProperty("code")
+  @get:JsonProperty("code")
+  public val code: Int? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, SomeRefDto?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, SomeRefDto?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: SomeRefDto?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/ComplexObjectWithTypedMapDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ComplexObjectWithTypedMapDto.kt
@@ -1,0 +1,29 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class ComplexObjectWithTypedMapDto(
+  @param:JsonProperty("text")
+  @get:JsonProperty("text")
+  public val text: String? = null,
+  @param:JsonProperty("code")
+  @get:JsonProperty("code")
+  public val code: Int? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, ComplexObjectWithTypedMapValueDto?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, ComplexObjectWithTypedMapValueDto?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: ComplexObjectWithTypedMapValueDto?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/ComplexObjectWithTypedMapValueDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ComplexObjectWithTypedMapValueDto.kt
@@ -1,0 +1,14 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+
+public data class ComplexObjectWithTypedMapValueDto(
+  @param:JsonProperty("other_text")
+  @get:JsonProperty("other_text")
+  public val otherText: String? = null,
+  @param:JsonProperty("other_number")
+  @get:JsonProperty("other_number")
+  public val otherNumber: Int? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/ComplexObjectWithUntypedMapDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ComplexObjectWithUntypedMapDto.kt
@@ -1,0 +1,30 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class ComplexObjectWithUntypedMapDto(
+  @param:JsonProperty("text")
+  @get:JsonProperty("text")
+  public val text: String? = null,
+  @param:JsonProperty("code")
+  @get:JsonProperty("code")
+  public val code: Int? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, Any?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, Any?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: Any?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/EnumHolderDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/EnumHolderDto.kt
@@ -1,0 +1,23 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+import kotlin.collections.List
+
+public data class EnumHolderDto(
+  @param:JsonProperty("array_of_enums")
+  @get:JsonProperty("array_of_enums")
+  public val arrayOfEnums: List<String>? = null,
+  @param:JsonProperty("inlined_enum")
+  @get:JsonProperty("inlined_enum")
+  public val inlinedEnum: EnumHolderDtoInlinedEnumDto? = null,
+  @param:JsonProperty("inlined_extensible_enum")
+  @get:JsonProperty("inlined_extensible_enum")
+  public val inlinedExtensibleEnum: String? = null,
+  @param:JsonProperty("enum_ref")
+  @get:JsonProperty("enum_ref")
+  public val enumRef: EnumObjectDto? = null,
+  @param:JsonProperty("list_enums")
+  @get:JsonProperty("list_enums")
+  public val listEnums: List<String>? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/EnumHolderDtoInlinedEnumDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/EnumHolderDtoInlinedEnumDto.kt
@@ -1,0 +1,22 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class EnumHolderDtoInlinedEnumDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  INLINED_ONE("inlined_one"),
+  INLINED_TWO("inlined_two"),
+  INLINED_THREE("inlined_three"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, EnumHolderDtoInlinedEnumDto> =
+        values().associateBy(EnumHolderDtoInlinedEnumDto::value)
+
+    public fun fromValue(`value`: String): EnumHolderDtoInlinedEnumDto? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/EnumObjectDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/EnumObjectDto.kt
@@ -1,0 +1,24 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class EnumObjectDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  ONE("one"),
+  TWO("two"),
+  THREE("three"),
+  `4`("4"),
+  _5("-5"),
+  _6("_6"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, EnumObjectDto> = values().associateBy(EnumObjectDto::value)
+
+    public fun fromValue(`value`: String): EnumObjectDto? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/ExternalObjectFourDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ExternalObjectFourDto.kt
@@ -1,0 +1,10 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class ExternalObjectFourDto(
+  @param:JsonProperty("blah")
+  @get:JsonProperty("blah")
+  public val blah: String? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/FirstLevelChildDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FirstLevelChildDto.kt
@@ -1,0 +1,34 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import javax.validation.constraints.NotNull
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  property = "firstLevelDiscriminator",
+  visible = true,
+)
+@JsonSubTypes()
+public sealed class FirstLevelChildDto(
+  @param:JsonProperty("rootField1")
+  @get:JsonProperty("rootField1")
+  @get:NotNull
+  override val rootField1: String,
+  @param:JsonProperty("rootField2")
+  @get:JsonProperty("rootField2")
+  override val rootField2: Boolean? = null,
+  public open val firstLevelField1: String,
+  public open val firstLevelField2: Int? = null,
+  @get:JsonProperty("rootDiscriminator")
+  @get:NotNull
+  @param:JsonProperty("rootDiscriminator")
+  override val rootDiscriminator: RootDiscriminatorDto = RootDiscriminatorDto.FIRST_LEVEL_CHILD,
+) : RootTypeDto(rootField1, rootField2) {
+  public abstract val firstLevelDiscriminator: FirstLevelDiscriminatorDto
+}

--- a/src/test/resources/examples/modelSuffix/models/FirstLevelDiscriminatorDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FirstLevelDiscriminatorDto.kt
@@ -1,0 +1,21 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class FirstLevelDiscriminatorDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  SECOND_LEVEL_CHILD1("secondLevelChild1"),
+  SECOND_LEVEL_CHILD2("secondLevelChild2"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, FirstLevelDiscriminatorDto> =
+        values().associateBy(FirstLevelDiscriminatorDto::value)
+
+    public fun fromValue(`value`: String): FirstLevelDiscriminatorDto? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/FooBarsDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FooBarsDto.kt
@@ -1,0 +1,15 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import kotlin.collections.List
+
+public data class FooBarsDto(
+  @param:JsonProperty("prop_one")
+  @get:JsonProperty("prop_one")
+  public val propOne: List<FooBarsDtoFooDto>? = null,
+  @param:JsonProperty("prop_two")
+  @get:JsonProperty("prop_two")
+  @get:Valid
+  public val propTwo: List<FooBarsDtoBarDto>? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/FooBarsDtoBarDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FooBarsDtoBarDto.kt
@@ -1,0 +1,10 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class FooBarsDtoBarDto(
+  @param:JsonProperty("bar_prop")
+  @get:JsonProperty("bar_prop")
+  public val barProp: String? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/FooBarsDtoFooDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FooBarsDtoFooDto.kt
@@ -1,0 +1,21 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class FooBarsDtoFooDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  X("X"),
+  Y("Y"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, FooBarsDtoFooDto> =
+        values().associateBy(FooBarsDtoFooDto::value)
+
+    public fun fromValue(`value`: String): FooBarsDtoFooDto? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/FooFooDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FooFooDto.kt
@@ -1,0 +1,20 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class FooFooDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  X("X"),
+  Y("Y"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, FooFooDto> = values().associateBy(FooFooDto::value)
+
+    public fun fromValue(`value`: String): FooFooDto? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/InlinedComplexObjectWithTypedMapValueDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/InlinedComplexObjectWithTypedMapValueDto.kt
@@ -1,0 +1,14 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+
+public data class InlinedComplexObjectWithTypedMapValueDto(
+  @param:JsonProperty("other_text")
+  @get:JsonProperty("other_text")
+  public val otherText: String? = null,
+  @param:JsonProperty("other_number")
+  @get:JsonProperty("other_number")
+  public val otherNumber: Int? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/InlinedTypedObjectMapValueDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/InlinedTypedObjectMapValueDto.kt
@@ -1,0 +1,14 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+
+public data class InlinedTypedObjectMapValueDto(
+  @param:JsonProperty("code")
+  @get:JsonProperty("code")
+  public val code: Int? = null,
+  @param:JsonProperty("text")
+  @get:JsonProperty("text")
+  public val text: String? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/MapHolderDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/MapHolderDto.kt
@@ -1,0 +1,68 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import kotlin.Any
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class MapHolderDto(
+  @param:JsonProperty("wild_card")
+  @get:JsonProperty("wild_card")
+  public val wildCard: Map<String, Any?>? = null,
+  @param:JsonProperty("string_map")
+  @get:JsonProperty("string_map")
+  public val stringMap: Map<String, String?>? = null,
+  @param:JsonProperty("typed_object_map")
+  @get:JsonProperty("typed_object_map")
+  @get:Valid
+  public val typedObjectMap: Map<String, TypedObjectMapValueDto?>? = null,
+  @param:JsonProperty("object_map")
+  @get:JsonProperty("object_map")
+  public val objectMap: Map<String, Map<String, Any?>?>? = null,
+  @param:JsonProperty("inlined_string_map")
+  @get:JsonProperty("inlined_string_map")
+  public val inlinedStringMap: Map<String, String?>? = null,
+  @param:JsonProperty("inlined_object_map")
+  @get:JsonProperty("inlined_object_map")
+  public val inlinedObjectMap: Map<String, Map<String, Any?>?>? = null,
+  @param:JsonProperty("inlined_unknown_map")
+  @get:JsonProperty("inlined_unknown_map")
+  public val inlinedUnknownMap: Map<String, Any?>? = null,
+  @param:JsonProperty("inlined_typed_object_map")
+  @get:JsonProperty("inlined_typed_object_map")
+  @get:Valid
+  public val inlinedTypedObjectMap: Map<String, InlinedTypedObjectMapValueDto?>? = null,
+  @param:JsonProperty("complex_object_with_untyped_map")
+  @get:JsonProperty("complex_object_with_untyped_map")
+  @get:Valid
+  public val complexObjectWithUntypedMap: ComplexObjectWithUntypedMapDto? = null,
+  @param:JsonProperty("complex_object_with_typed_map")
+  @get:JsonProperty("complex_object_with_typed_map")
+  @get:Valid
+  public val complexObjectWithTypedMap: ComplexObjectWithTypedMapDto? = null,
+  @param:JsonProperty("inlined_complex_object_with_untyped_map")
+  @get:JsonProperty("inlined_complex_object_with_untyped_map")
+  @get:Valid
+  public val inlinedComplexObjectWithUntypedMap: MapHolderDtoInlinedComplexObjectWithUntypedMapDto?
+      = null,
+  @param:JsonProperty("inlined_complex_object_with_typed_map")
+  @get:JsonProperty("inlined_complex_object_with_typed_map")
+  @get:Valid
+  public val inlinedComplexObjectWithTypedMap: MapHolderDtoInlinedComplexObjectWithTypedMapDto? =
+      null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, Map<String, ExternalObjectFourDto?>?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, Map<String, ExternalObjectFourDto?>?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: Map<String, ExternalObjectFourDto?>?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/MapHolderDtoInlinedComplexObjectWithTypedMapDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/MapHolderDtoInlinedComplexObjectWithTypedMapDto.kt
@@ -1,0 +1,30 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class MapHolderDtoInlinedComplexObjectWithTypedMapDto(
+  @param:JsonProperty("text")
+  @get:JsonProperty("text")
+  public val text: String? = null,
+  @param:JsonProperty("code")
+  @get:JsonProperty("code")
+  public val code: Int? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, InlinedComplexObjectWithTypedMapValueDto?> =
+      mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, InlinedComplexObjectWithTypedMapValueDto?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: InlinedComplexObjectWithTypedMapValueDto?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/MapHolderDtoInlinedComplexObjectWithUntypedMapDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/MapHolderDtoInlinedComplexObjectWithUntypedMapDto.kt
@@ -1,0 +1,30 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class MapHolderDtoInlinedComplexObjectWithUntypedMapDto(
+  @param:JsonProperty("text")
+  @get:JsonProperty("text")
+  public val text: String? = null,
+  @param:JsonProperty("code")
+  @get:JsonProperty("code")
+  public val code: Int? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, Any?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, Any?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: Any?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/PolymorphicSuperTypeDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/PolymorphicSuperTypeDto.kt
@@ -1,0 +1,19 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  property = "generation",
+  visible = true,
+)
+@JsonSubTypes()
+public sealed class PolymorphicSuperTypeDto(
+  public open val firstName: String,
+  public open val lastName: String,
+) {
+  public abstract val generation: String
+}

--- a/src/test/resources/examples/modelSuffix/models/PolymorphicTypeOneDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/PolymorphicTypeOneDto.kt
@@ -1,0 +1,23 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class PolymorphicTypeOneDto(
+  @param:JsonProperty("first_name")
+  @get:JsonProperty("first_name")
+  @get:NotNull
+  override val firstName: String,
+  @param:JsonProperty("last_name")
+  @get:JsonProperty("last_name")
+  @get:NotNull
+  override val lastName: String,
+  @param:JsonProperty("child_one_name")
+  @get:JsonProperty("child_one_name")
+  public val childOneName: String? = null,
+  @get:JsonProperty("generation")
+  @get:NotNull
+  @param:JsonProperty("generation")
+  override val generation: String = "PolymorphicTypeOne",
+) : PolymorphicSuperTypeDto(firstName, lastName)

--- a/src/test/resources/examples/modelSuffix/models/PolymorphicTypeOneRefDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/PolymorphicTypeOneRefDto.kt
@@ -1,0 +1,23 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class PolymorphicTypeOneRefDto(
+  @param:JsonProperty("first_name")
+  @get:JsonProperty("first_name")
+  @get:NotNull
+  override val firstName: String,
+  @param:JsonProperty("last_name")
+  @get:JsonProperty("last_name")
+  @get:NotNull
+  override val lastName: String,
+  @param:JsonProperty("child_one_name")
+  @get:JsonProperty("child_one_name")
+  public val childOneName: String? = null,
+  @get:JsonProperty("generation")
+  @get:NotNull
+  @param:JsonProperty("generation")
+  override val generation: String = "PolymorphicTypeOne",
+) : PolymorphicSuperTypeDto(firstName, lastName)

--- a/src/test/resources/examples/modelSuffix/models/RootDiscriminatorDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/RootDiscriminatorDto.kt
@@ -1,0 +1,20 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class RootDiscriminatorDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  FIRST_LEVEL_CHILD("firstLevelChild"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, RootDiscriminatorDto> =
+        values().associateBy(RootDiscriminatorDto::value)
+
+    public fun fromValue(`value`: String): RootDiscriminatorDto? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/RootTypeDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/RootTypeDto.kt
@@ -1,0 +1,20 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  property = "rootDiscriminator",
+  visible = true,
+)
+@JsonSubTypes()
+public sealed class RootTypeDto(
+  public open val rootField1: String,
+  public open val rootField2: Boolean? = null,
+) {
+  public abstract val rootDiscriminator: RootDiscriminatorDto
+}

--- a/src/test/resources/examples/modelSuffix/models/SecondLevelChild1Dto.kt
+++ b/src/test/resources/examples/modelSuffix/models/SecondLevelChild1Dto.kt
@@ -1,0 +1,35 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
+public data class SecondLevelChild1Dto(
+  @param:JsonProperty("rootField1")
+  @get:JsonProperty("rootField1")
+  @get:NotNull
+  override val rootField1: String,
+  @param:JsonProperty("rootField2")
+  @get:JsonProperty("rootField2")
+  override val rootField2: Boolean? = null,
+  @param:JsonProperty("firstLevelField1")
+  @get:JsonProperty("firstLevelField1")
+  @get:NotNull
+  override val firstLevelField1: String,
+  @param:JsonProperty("firstLevelField2")
+  @get:JsonProperty("firstLevelField2")
+  override val firstLevelField2: Int? = null,
+  @param:JsonProperty("metadata")
+  @get:JsonProperty("metadata")
+  @get:NotNull
+  @get:Valid
+  public val metadata: SecondLevelMetadataDto,
+  @get:JsonProperty("firstLevelDiscriminator")
+  @get:NotNull
+  @param:JsonProperty("firstLevelDiscriminator")
+  override val firstLevelDiscriminator: FirstLevelDiscriminatorDto =
+      FirstLevelDiscriminatorDto.SECOND_LEVEL_CHILD1,
+) : FirstLevelChildDto(rootField1, rootField2, firstLevelField1, firstLevelField2)

--- a/src/test/resources/examples/modelSuffix/models/SecondLevelChild2Dto.kt
+++ b/src/test/resources/examples/modelSuffix/models/SecondLevelChild2Dto.kt
@@ -1,0 +1,35 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
+public data class SecondLevelChild2Dto(
+  @param:JsonProperty("rootField1")
+  @get:JsonProperty("rootField1")
+  @get:NotNull
+  override val rootField1: String,
+  @param:JsonProperty("rootField2")
+  @get:JsonProperty("rootField2")
+  override val rootField2: Boolean? = null,
+  @param:JsonProperty("firstLevelField1")
+  @get:JsonProperty("firstLevelField1")
+  @get:NotNull
+  override val firstLevelField1: String,
+  @param:JsonProperty("firstLevelField2")
+  @get:JsonProperty("firstLevelField2")
+  override val firstLevelField2: Int? = null,
+  @param:JsonProperty("metadata")
+  @get:JsonProperty("metadata")
+  @get:NotNull
+  @get:Valid
+  public val metadata: SecondLevelMetadataDto,
+  @get:JsonProperty("firstLevelDiscriminator")
+  @get:NotNull
+  @param:JsonProperty("firstLevelDiscriminator")
+  override val firstLevelDiscriminator: FirstLevelDiscriminatorDto =
+      FirstLevelDiscriminatorDto.SECOND_LEVEL_CHILD2,
+) : FirstLevelChildDto(rootField1, rootField2, firstLevelField1, firstLevelField2)

--- a/src/test/resources/examples/modelSuffix/models/SecondLevelDiscriminatorDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/SecondLevelDiscriminatorDto.kt
@@ -1,0 +1,21 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class SecondLevelDiscriminatorDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  THIRD_LEVEL_CHILD1("thirdLevelChild1"),
+  THIRD_LEVEL_CHILD2("thirdLevelChild2"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, SecondLevelDiscriminatorDto> =
+        values().associateBy(SecondLevelDiscriminatorDto::value)
+
+    public fun fromValue(`value`: String): SecondLevelDiscriminatorDto? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/modelSuffix/models/SecondLevelMetadataDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/SecondLevelMetadataDto.kt
@@ -1,0 +1,13 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+public data class SecondLevelMetadataDto(
+  @param:JsonProperty("obj")
+  @get:JsonProperty("obj")
+  @get:NotNull
+  @get:Valid
+  public val obj: CommonObjectDto,
+)

--- a/src/test/resources/examples/modelSuffix/models/SomeRefDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/SomeRefDto.kt
@@ -1,0 +1,14 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+
+public data class SomeRefDto(
+  @param:JsonProperty("other_text")
+  @get:JsonProperty("other_text")
+  public val otherText: String? = null,
+  @param:JsonProperty("other_number")
+  @get:JsonProperty("other_number")
+  public val otherNumber: Int? = null,
+)

--- a/src/test/resources/examples/modelSuffix/models/TypedObjectMapValueDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/TypedObjectMapValueDto.kt
@@ -1,0 +1,14 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+
+public data class TypedObjectMapValueDto(
+  @param:JsonProperty("code")
+  @get:JsonProperty("code")
+  public val code: Int? = null,
+  @param:JsonProperty("text")
+  @get:JsonProperty("text")
+  public val text: String? = null,
+)


### PR DESCRIPTION
This addition allows to specify a custom suffix for model classes, such `Dto` or `Api`.