### PR TITLE
Allow having multiple authentication alternatives in Ktor controllers

### DIFF
--- a/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/KtorAuthenticationTest.kt
+++ b/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/KtorAuthenticationTest.kt
@@ -13,10 +13,7 @@ import io.ktor.client.request.header
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.auth.Authentication
-import io.ktor.server.auth.Principal
-import io.ktor.server.auth.UserIdPrincipal
-import io.ktor.server.auth.basic
+import io.ktor.server.auth.*
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
@@ -209,6 +206,12 @@ class KtorAuthenticationTest {
             // which uses top level security in OpenAPI spec
             basic("basicAuth") {
                 validate {
+                    UserIdPrincipal("defaultAuth") // always authenticate
+                }
+            }
+
+            bearer("BearerAuth") {
+                authenticate {
                     UserIdPrincipal("defaultAuth") // always authenticate
                 }
             }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -173,17 +173,18 @@ class KtorControllerInterfaceGenerator(
 
         val addAuth = securityOption.allowsAuthenticated && options.contains(ControllerCodeGenOptionType.AUTHENTICATION)
         if (addAuth) {
-            // Using the key from the first security requirement as the auth name
-            val authName = if (operation.hasSecurityRequirements()) {
-                operation.securityRequirements.first().requirements.keys.first()
+            val authNames = if (operation.hasSecurityRequirements()) {
+                operation.securityRequirements
+                    .filter { it.requirements.isNotEmpty() }
+                    .joinToString(", ") { "\"" + it.requirements.keys.first() + "\"" }
             } else {
                 // Fall back to the global security requirements
-                this.api.openApi3.securityRequirements.first().requirements.keys.first()
+                "\"" + this.api.openApi3.securityRequirements.first().requirements.keys.first() + "\""
             }
 
             builder
                 .addStatement(
-                    "%M(\"$authName\", optional = %L) {",
+                    "%M($authNames, optional = %L) {",
                     MemberName("io.ktor.server.auth", "authenticate"),
                     securityOption == SecuritySupport.AUTHENTICATION_OPTIONAL,
                 )

--- a/src/test/resources/examples/authentication/api.yaml
+++ b/src/test/resources/examples/authentication/api.yaml
@@ -9,6 +9,7 @@ paths:
       operationId: testPath
       security:
         - BasicAuth: [ ]
+        - BearerAuth: [ ]
       parameters:
         - in: query
           name: testString
@@ -78,5 +79,8 @@ components:
     BasicAuth:
       type: http
       scheme: basic
+    BearerAuth:
+      type: http
+      scheme: bearer
 security:
   - basicAuth: [ ]

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -42,7 +42,7 @@ public interface RequiredController {
          * - GET /required
          */
         public fun Route.requiredRoutes(controller: RequiredController) {
-            authenticate("BasicAuth", optional = false) {
+            authenticate("BasicAuth", "BearerAuth", optional = false) {
                 `get`("/required") {
                     val principal = call.principal<Principal>() ?: throw
                         IllegalStateException("Principal not found")


### PR DESCRIPTION
`authenticate()` accepts a vararg and by default allows the API access if at least one option is satisfied.
