### PR TITLE
JacksonModelGenerator is now simply ModelGenerator

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -11,11 +11,10 @@ import com.cjbooms.fabrikt.generators.client.OpenFeignInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.KtorControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.MicronautControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.SpringControllerInterfaceGenerator
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.generators.model.QuarkusReflectionModelGenerator
 import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.KotlinSourceSet
-import com.cjbooms.fabrikt.model.KotlinTypes
 import com.cjbooms.fabrikt.model.Models
 import com.cjbooms.fabrikt.model.ResourceFile
 import com.cjbooms.fabrikt.model.ResourceSourceSet
@@ -63,7 +62,7 @@ class CodeGenerator(
     private fun resourceSet(resFiles: Collection<ResourceFile>) = setOf(ResourceSourceSet(resFiles, resourcesPath))
 
     private fun models(): Models =
-        JacksonModelGenerator(packages, sourceApi).generate()
+        ModelGenerator(packages, sourceApi).generate()
 
     private fun resources(models: Models): List<ResourceFile> =
         listOfNotNull(QuarkusReflectionModelGenerator(models).generate())

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -1,6 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
+import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -9,7 +9,7 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleSuccessResponseS
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.OasDefault
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
+import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
@@ -1,6 +1,6 @@
 package com.cjbooms.fabrikt.generators.controller
 
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator.Companion.toModelType
+import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -68,7 +68,7 @@ import java.io.Serializable
 import java.net.MalformedURLException
 import java.net.URL
 
-class JacksonModelGenerator( // TODO: Rename to ModelGenerator
+class ModelGenerator(
     private val packages: Packages,
     private val sourceApi: SourceApi,
 ) {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
@@ -4,7 +4,7 @@ import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.cli.SerializationLibrary
 import com.cjbooms.fabrikt.configurations.Packages
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.model.KotlinSourceSet
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -54,7 +54,7 @@ class KotlinSerializationModelGeneratorTest {
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
         val expectedModels = readFolder(Path.of("src/test/resources/examples/$testCaseName/models/kotlinx/"))
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             sourceApi,
         ).generate()
@@ -85,7 +85,7 @@ class KotlinSerializationModelGeneratorTest {
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
 
         val e = assertThrows<UnsupportedOperationException> {
-            JacksonModelGenerator(Packages(basePackage), sourceApi,).generate()
+            ModelGenerator(Packages(basePackage), sourceApi,).generate()
         }
         assertThat(e.message).isEqualTo("Additional properties not supported by selected serialization library")
     }
@@ -97,7 +97,7 @@ class KotlinSerializationModelGeneratorTest {
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
 
         val e = assertThrows<UnsupportedOperationException> {
-            val models = JacksonModelGenerator(Packages(basePackage), sourceApi,).generate()
+            val models = ModelGenerator(Packages(basePackage), sourceApi,).generate()
             val sourceSet = setOf(KotlinSourceSet(models.files, Paths.get("")))
             println(sourceSet)
         }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -6,7 +6,7 @@ import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.cli.ValidationLibrary
 import com.cjbooms.fabrikt.configurations.Packages
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.model.KotlinSourceSet
 import com.cjbooms.fabrikt.model.Models
 import com.cjbooms.fabrikt.model.SourceApi
@@ -102,7 +102,7 @@ class ModelGeneratorTest {
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
         val expectedModels = readFolder(Path.of("src/test/resources/examples/$testCaseName/models/"))
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             sourceApi,
         ).generate()
@@ -137,7 +137,7 @@ class ModelGeneratorTest {
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
         val expectedModels = readFolder(Path.of("src/test/resources/examples/modelSuffix/models/"))
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             sourceApi,
         ).generate()
@@ -158,7 +158,7 @@ class ModelGeneratorTest {
             genTypes = setOf(CodeGenerationType.HTTP_MODELS),
             validationLibrary = ValidationLibrary.JAKARTA_VALIDATION
         )
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
         ).generate()
@@ -179,7 +179,7 @@ class ModelGeneratorTest {
             genTypes = setOf(CodeGenerationType.HTTP_MODELS),
             validationLibrary = ValidationLibrary.NO_VALIDATION
         )
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
         ).generate()
@@ -198,7 +198,7 @@ class ModelGeneratorTest {
         MutableSettings.updateSettings(
             modelOptions = setOf(ModelCodeGenOptionType.JAVA_SERIALIZATION),
         )
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
         )
@@ -241,7 +241,7 @@ class ModelGeneratorTest {
     private fun assertExceptionWithMessage(path: String, expectedMessage: String) {
         val spec = readTextResource(path)
         val exception = assertThrows<ParameterException> {
-            JacksonModelGenerator(Packages("blah"), SourceApi(spec))
+            ModelGenerator(Packages("blah"), SourceApi(spec))
                 .generate()
                 .toSingleFile()
         }
@@ -257,7 +257,7 @@ class ModelGeneratorTest {
             modelOptions = setOf(ModelCodeGenOptionType.QUARKUS_REFLECTION),
         )
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
         )
@@ -276,7 +276,7 @@ class ModelGeneratorTest {
             modelOptions = setOf(ModelCodeGenOptionType.MICRONAUT_INTROSPECTION),
         )
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
         )
@@ -295,7 +295,7 @@ class ModelGeneratorTest {
             modelOptions = setOf(ModelCodeGenOptionType.MICRONAUT_REFLECTION),
         )
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
         )
@@ -314,7 +314,7 @@ class ModelGeneratorTest {
             modelOptions = setOf(ModelCodeGenOptionType.INCLUDE_COMPANION_OBJECT),
         )
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             Packages(basePackage),
             SourceApi(spec),
         )

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -10,7 +10,7 @@ import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.client.OkHttpEnhancedClientGenerator
 import com.cjbooms.fabrikt.generators.client.OkHttpSimpleClientGenerator
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Models
 import com.cjbooms.fabrikt.model.SimpleFile
@@ -62,7 +62,7 @@ class OkHttpClientGeneratorTest {
         val expectedModel = readTextResource("/examples/$testCaseName/models/ClientModels.kt")
         val expectedClient = readTextResource("/examples/$testCaseName/client/ApiClient.kt")
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             packages,
             sourceApi
         ).generate().toSingleFile()
@@ -145,7 +145,7 @@ class OkHttpClientGeneratorTest {
             externalRefResolutionMode = ExternalReferencesResolutionMode.AGGRESSIVE,
         )
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             packages,
             sourceApi,
         ).generate().toSingleFile()

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
@@ -6,7 +6,7 @@ import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.client.OpenFeignInterfaceGenerator
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Models
 import com.cjbooms.fabrikt.model.SourceApi
@@ -78,7 +78,7 @@ class OpenFeignClientGeneratorTest {
         val expectedModel = readTextResource("/examples/$testCaseName/models/ClientModels.kt")
         val expectedClient = readTextResource("/examples/$testCaseName/client/$clientFileName")
 
-        val models = JacksonModelGenerator(
+        val models = ModelGenerator(
             packages,
             sourceApi,
         ).generate().toSingleFile()

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
@@ -2,7 +2,7 @@ package com.cjbooms.fabrikt.generators
 
 import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.configurations.Packages
-import com.cjbooms.fabrikt.generators.model.JacksonModelGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.generators.model.QuarkusReflectionModelGenerator
 import com.cjbooms.fabrikt.model.ResourceFile
 import com.cjbooms.fabrikt.model.SourceApi
@@ -43,7 +43,7 @@ class ResourceGeneratorTest {
             genTypes = setOf(CodeGenerationType.QUARKUS_REFLECTION_CONFIG),
         )
 
-        val models = JacksonModelGenerator(Packages(basePackage), sourceApi).generate()
+        val models = ModelGenerator(Packages(basePackage), sourceApi).generate()
 
         val resources = QuarkusReflectionModelGenerator(models).generate()?.toSingleFile()
 


### PR DESCRIPTION
With the addition of `kotlinx.serialization` (#327) JacksonModelGenerator is now simply `ModelGenerator`.