### PR TITLE
Add example controllers for model suffix

### DIFF
--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -37,6 +37,7 @@ class KtorControllerInterfaceGeneratorTest {
         "parameterNameClash",
         "requestBodyAsArray",
         "jakartaValidationAnnotations",
+        "modelSuffix",
     )
 
     private fun setupGithubApiTestEnv() {
@@ -65,6 +66,10 @@ class KtorControllerInterfaceGeneratorTest {
         val basePackage = "examples.$testCaseName"
         val api = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
         val expectedControllers = readTextResource("/examples/$testCaseName/controllers/ktor/Controllers.kt")
+
+        if (testCaseName == "modelSuffix") {
+            MutableSettings.updateSettings(modelSuffix = "Dto")
+        }
 
         val ktorControllers = KtorControllerInterfaceGenerator(
             Packages(basePackage),

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
@@ -39,6 +39,7 @@ class MicronautControllerGeneratorTest {
         "pathLevelParameters",
         "parameterNameClash",
         "jakartaValidationAnnotations",
+        "modelSuffix",
     )
 
     private fun setupGithubApiTestEnv(validationAnnotations: ValidationAnnotations = JavaxValidationAnnotations) {
@@ -64,6 +65,10 @@ class MicronautControllerGeneratorTest {
         val basePackage = "examples.$testCaseName"
         val api = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
         val expectedControllers = readTextResource("/examples/$testCaseName/controllers/micronaut/Controllers.kt")
+
+        if (testCaseName == "modelSuffix") {
+            MutableSettings.updateSettings(modelSuffix = "Dto")
+        }
 
         val controllers = MicronautControllerInterfaceGenerator(
             Packages(basePackage),

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -38,6 +38,7 @@ class SpringControllerGeneratorTest {
         "pathLevelParameters",
         "parameterNameClash",
         "jakartaValidationAnnotations",
+        "modelSuffix",
     )
 
     private fun setupGithubApiTestEnv(annotations: ValidationAnnotations = JavaxValidationAnnotations) {
@@ -60,6 +61,10 @@ class SpringControllerGeneratorTest {
         val basePackage = "examples.$testCaseName"
         val api = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
         val expectedControllers = readTextResource("/examples/$testCaseName/controllers/spring/Controllers.kt")
+
+        if (testCaseName == "modelSuffix") {
+            MutableSettings.updateSettings(modelSuffix = "Dto")
+        }
 
         val controllers = SpringControllerInterfaceGenerator(
             Packages(basePackage),

--- a/src/test/resources/examples/modelSuffix/api.yaml
+++ b/src/test/resources/examples/modelSuffix/api.yaml
@@ -1,5 +1,46 @@
 openapi: 3.0.0
+
+paths:
+  /example:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/ModeParameter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RootType'
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/CreateRootTypeRequestBody'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RootType'
+
 components:
+  parameters:
+    ModeParameter:
+      name: mode
+      in: query
+      required: true
+      schema:
+        type: string
+        enum:
+          - mode1
+          - mode2
+          - mode3
+  requestBodies:
+    CreateRootTypeRequestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RootType'
   schemas:
     # Deep nested polymorphism
     RootDiscriminator:

--- a/src/test/resources/examples/modelSuffix/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/modelSuffix/controllers/ktor/Controllers.kt
@@ -1,0 +1,115 @@
+package examples.modelSuffix.controllers
+
+import examples.modelSuffix.models.ModeParameterDto
+import examples.modelSuffix.models.RootTypeDto
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.`get`
+import io.ktor.server.routing.post
+import io.ktor.server.util.getOrFail
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
+import kotlin.String
+import kotlin.Suppress
+
+public interface ExampleController {
+    /**
+     * Route is expected to respond with [examples.modelSuffix.models.RootTypeDto].
+     * Use [examples.modelSuffix.controllers.TypedApplicationCall.respondTyped] to send the response.
+     *
+     * @param mode
+     * @param call Decorated ApplicationCall with additional typed respond methods
+     */
+    public suspend fun `get`(mode: ModeParameterDto, call: TypedApplicationCall<RootTypeDto>)
+
+    /**
+     * Route is expected to respond with [examples.modelSuffix.models.RootTypeDto].
+     * Use [examples.modelSuffix.controllers.TypedApplicationCall.respondTyped] to send the response.
+     *
+     * @param rootType
+     * @param call Decorated ApplicationCall with additional typed respond methods
+     */
+    public suspend fun post(rootType: RootTypeDto, call: TypedApplicationCall<RootTypeDto>)
+
+    public companion object {
+        /**
+         * Mounts all routes for the Example resource
+         *
+         * - GET /example
+         * - POST /example
+         */
+        public fun Route.exampleRoutes(controller: ExampleController) {
+            `get`("/example") {
+                val mode =
+                    call.request.queryParameters.getOrFail<examples.modelSuffix.models.ModeParameterDto>("mode")
+                controller.get(mode, TypedApplicationCall(call))
+            }
+            post("/example") {
+                val rootType = call.receive<RootTypeDto>()
+                controller.post(rootType, TypedApplicationCall(call))
+            }
+        }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using DefaultConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(name: String): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                DefaultConversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String = this[name] ?: throw
+            BadRequestException("Header " + name + " is required")
+    }
+}
+
+/**
+ * Decorator for Ktor's ApplicationCall that provides type safe variants of the [respond] functions.
+ *
+ * It can be used as a drop-in replacement for [io.ktor.server.application.ApplicationCall].
+ *
+ * @param R The type of the response body
+ */
+public class TypedApplicationCall<R : Any>(
+    private val applicationCall: ApplicationCall,
+) : ApplicationCall by applicationCall {
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(message: T) {
+        respond(message)
+    }
+
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(status: HttpStatusCode, message: T) {
+        respond(status, message)
+    }
+}

--- a/src/test/resources/examples/modelSuffix/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/modelSuffix/controllers/micronaut/Controllers.kt
@@ -1,0 +1,35 @@
+package examples.modelSuffix.controllers
+
+import examples.modelSuffix.models.ModeParameterDto
+import examples.modelSuffix.models.RootTypeDto
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.`annotation`.Body
+import io.micronaut.http.`annotation`.Consumes
+import io.micronaut.http.`annotation`.Controller
+import io.micronaut.http.`annotation`.Get
+import io.micronaut.http.`annotation`.Post
+import io.micronaut.http.`annotation`.Produces
+import io.micronaut.http.`annotation`.QueryValue
+import javax.validation.Valid
+
+@Controller
+public interface ExampleController {
+    /**
+     *
+     *
+     * @param mode
+     */
+    @Get(uri = "/example")
+    @Produces(value = ["application/json"])
+    public fun `get`(@QueryValue(value = "mode") mode: ModeParameterDto): HttpResponse<RootTypeDto>
+
+    /**
+     *
+     *
+     * @param rootType
+     */
+    @Post(uri = "/example")
+    @Consumes(value = ["application/json"])
+    @Produces(value = ["application/json"])
+    public fun post(@Body @Valid rootType: RootTypeDto): HttpResponse<RootTypeDto>
+}

--- a/src/test/resources/examples/modelSuffix/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/modelSuffix/controllers/spring/Controllers.kt
@@ -1,0 +1,42 @@
+package examples.modelSuffix.controllers
+
+import examples.modelSuffix.models.ModeParameterDto
+import examples.modelSuffix.models.RootTypeDto
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import org.springframework.web.bind.`annotation`.RequestParam
+import javax.validation.Valid
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface ExampleController {
+    /**
+     *
+     *
+     * @param mode
+     */
+    @RequestMapping(
+        value = ["/example"],
+        produces = ["application/json"],
+        method = [RequestMethod.GET],
+    )
+    public fun `get`(@RequestParam(value = "mode", required = true) mode: ModeParameterDto): ResponseEntity<RootTypeDto>
+
+    /**
+     *
+     *
+     * @param rootType
+     */
+    @RequestMapping(
+        value = ["/example"],
+        produces = ["application/json"],
+        method = [RequestMethod.POST],
+        consumes = ["application/json"],
+    )
+    public fun post(@RequestBody @Valid rootType: RootTypeDto): ResponseEntity<RootTypeDto>
+}

--- a/src/test/resources/examples/modelSuffix/models/ModeParameterDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ModeParameterDto.kt
@@ -1,0 +1,22 @@
+package examples.modelSuffix.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class ModeParameterDto(
+  @JsonValue
+  public val `value`: String,
+) {
+  MODE1("mode1"),
+  MODE2("mode2"),
+  MODE3("mode3"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, ModeParameterDto> =
+        values().associateBy(ModeParameterDto::value)
+
+    public fun fromValue(`value`: String): ModeParameterDto? = mapping[value]
+  }
+}


### PR DESCRIPTION
This PR adds controllers to the `modelSuffix` example to verify that the correct model names are used in the controllers.

No new functionality - just improved test coverage.