### PR TITLE
Upgrade to Ktor Server 3.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,8 @@ allprojects {
 
 val jacksonVersion by extra { "2.15.1" }
 val junitVersion by extra { "5.9.2" }
-val ktorVersion by extra { "2.3.9" }
 val kotlinxSerializationVersion by extra { "1.6.3" }
+val ktorVersion by extra { "3.0.1" }
 val kotlinxDateTimeVersion by extra { "0.6.1" }
 
 dependencies {

--- a/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/KtorAuthenticationTest.kt
+++ b/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/KtorAuthenticationTest.kt
@@ -41,10 +41,9 @@ class KtorAuthenticationTest {
                     optionalRoutes(object : OptionalController {
                         override suspend fun testPath(
                             testString: String,
-                            principal: Principal?,
                             call: ApplicationCall
                         ) {
-                            principalCaptureSlot.captured = principal as? UserIdPrincipal
+                            principalCaptureSlot.captured = call.principal<UserIdPrincipal>()
                             call.respond(HttpStatusCode.OK)
                         }
                     })
@@ -70,10 +69,9 @@ class KtorAuthenticationTest {
                     optionalRoutes(object : OptionalController {
                         override suspend fun testPath(
                             testString: String,
-                            principal: Principal?,
                             call: ApplicationCall
                         ) {
-                            principalCaptureSlot.captured = principal as? UserIdPrincipal
+                            principalCaptureSlot.captured = call.principal<UserIdPrincipal>()
                             call.respond(HttpStatusCode.OK)
                         }
                     })
@@ -97,8 +95,8 @@ class KtorAuthenticationTest {
 
                 routing {
                     requiredRoutes(object : RequiredController {
-                        override suspend fun testPath(testString: String, principal: Principal, call: ApplicationCall) {
-                            principalCaptureSlot.captured = principal as UserIdPrincipal
+                        override suspend fun testPath(testString: String, call: ApplicationCall) {
+                            principalCaptureSlot.captured = call.principal<UserIdPrincipal>()
                             call.respond(HttpStatusCode.OK)
                         }
                     })
@@ -122,8 +120,8 @@ class KtorAuthenticationTest {
 
                 routing {
                     requiredRoutes(object : RequiredController {
-                        override suspend fun testPath(testString: String, principal: Principal, call: ApplicationCall) {
-                            principalCaptureSlot.captured = principal as UserIdPrincipal // should not get called
+                        override suspend fun testPath(testString: String, call: ApplicationCall) {
+                            principalCaptureSlot.captured = call.principal<UserIdPrincipal>() // should not get called
                             call.respond(HttpStatusCode.OK)
                         }
                     })
@@ -170,8 +168,8 @@ class KtorAuthenticationTest {
 
                 routing {
                     defaultRoutes(object : DefaultController {
-                        override suspend fun testPath(testString: String, principal: Principal, call: ApplicationCall) {
-                            principalCaptureSlot.captured = principal as UserIdPrincipal
+                        override suspend fun testPath(testString: String, call: ApplicationCall) {
+                            principalCaptureSlot.captured = call.principal<UserIdPrincipal>()
                             call.respond(HttpStatusCode.OK)
                         }
                     })

--- a/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/authentication/controllers/ktor/Controllers.kt
@@ -5,9 +5,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
-import io.ktor.server.auth.Principal
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.principal
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.ParameterConversionException
 import io.ktor.server.response.respond
@@ -17,7 +15,6 @@ import io.ktor.server.util.getOrFail
 import io.ktor.util.converters.DefaultConversionService
 import io.ktor.util.reflect.typeInfo
 import kotlin.Any
-import kotlin.IllegalStateException
 import kotlin.String
 import kotlin.Suppress
 
@@ -29,11 +26,7 @@ public interface RequiredController {
      * @param testString
      * @param call The Ktor application call
      */
-    public suspend fun testPath(
-        testString: String,
-        principal: Principal,
-        call: ApplicationCall,
-    )
+    public suspend fun testPath(testString: String, call: ApplicationCall)
 
     public companion object {
         /**
@@ -44,10 +37,8 @@ public interface RequiredController {
         public fun Route.requiredRoutes(controller: RequiredController) {
             authenticate("BasicAuth", "BearerAuth", optional = false) {
                 `get`("/required") {
-                    val principal = call.principal<Principal>() ?: throw
-                        IllegalStateException("Principal not found")
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    controller.testPath(testString, principal, call)
+                    controller.testPath(testString, call)
                 }
             }
         }
@@ -151,11 +142,7 @@ public interface OptionalController {
      * @param testString
      * @param call The Ktor application call
      */
-    public suspend fun testPath(
-        testString: String,
-        principal: Principal?,
-        call: ApplicationCall,
-    )
+    public suspend fun testPath(testString: String, call: ApplicationCall)
 
     public companion object {
         /**
@@ -166,9 +153,8 @@ public interface OptionalController {
         public fun Route.optionalRoutes(controller: OptionalController) {
             authenticate("BasicAuth", optional = true) {
                 `get`("/optional") {
-                    val principal = call.principal<Principal>()
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    controller.testPath(testString, principal, call)
+                    controller.testPath(testString, call)
                 }
             }
         }
@@ -272,11 +258,7 @@ public interface DefaultController {
      * @param testString
      * @param call The Ktor application call
      */
-    public suspend fun testPath(
-        testString: String,
-        principal: Principal,
-        call: ApplicationCall,
-    )
+    public suspend fun testPath(testString: String, call: ApplicationCall)
 
     public companion object {
         /**
@@ -287,10 +269,8 @@ public interface DefaultController {
         public fun Route.defaultRoutes(controller: DefaultController) {
             authenticate("basicAuth", optional = false) {
                 `get`("/default") {
-                    val principal = call.principal<Principal>() ?: throw
-                        IllegalStateException("Principal not found")
                     val testString = call.request.queryParameters.getOrFail<kotlin.String>("testString")
-                    controller.testPath(testString, principal, call)
+                    controller.testPath(testString, call)
                 }
             }
         }


### PR DESCRIPTION
This PR adapts the Ktor Controller Interface Generator to support Ktor Server 3.0.1.

Upgrading to Ktor Server 3.0.1 means letting go of the 'principal' parameter to the controller functions. The [Principal interface](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) is no longer available and thus we cannot provide a common supertype of the different Principals. Instead the user should get the principal with `call.principal<P>()` in the implementation. This will work just fine with Ktor 2.3.x too.