### PR TITLE
Upgrade to Kotlin 2.0.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.20" // Apply the Kotlin JVM plugin to add support for Kotlin.
+    id("org.jetbrains.kotlin.jvm") version "2.0.20"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("org.jetbrains.dokka") version "1.8.10"
     id("com.palantir.git-version") version "3.0.0"
@@ -41,7 +41,7 @@ allprojects {
 val jacksonVersion by extra { "2.15.1" }
 val junitVersion by extra { "5.9.2" }
 val ktorVersion by extra { "2.3.9" }
-val kotlinxSerializationVersion by extra { "1.6.3" }
+val kotlinxSerializationVersion by extra { "1.7.3" }
 val kotlinxDateTimeVersion by extra { "0.6.1" }
 
 dependencies {

--- a/end2end-tests/ktor/build.gradle.kts
+++ b/end2end-tests/ktor/build.gradle.kts
@@ -8,7 +8,7 @@ sourceSets {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.20" // Apply the Kotlin JVM plugin to add support for Kotlin.
+    kotlin("jvm")
 }
 
 java {

--- a/end2end-tests/models-jackson/build.gradle.kts
+++ b/end2end-tests/models-jackson/build.gradle.kts
@@ -9,7 +9,7 @@ sourceSets {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.20" // Apply the Kotlin JVM plugin to add support for Kotlin.
+    kotlin("jvm")
 }
 
 java {

--- a/end2end-tests/models-kotlinx/build.gradle.kts
+++ b/end2end-tests/models-kotlinx/build.gradle.kts
@@ -9,8 +9,8 @@ sourceSets {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.20" // Apply the Kotlin JVM plugin to add support for Kotlin.
-    kotlin("plugin.serialization") version "1.8.20"
+    kotlin("jvm")
+    kotlin("plugin.serialization") version "2.0.20"
 }
 
 java {

--- a/end2end-tests/okhttp/build.gradle.kts
+++ b/end2end-tests/okhttp/build.gradle.kts
@@ -9,7 +9,7 @@ sourceSets {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.20" // Apply the Kotlin JVM plugin to add support for Kotlin.
+    kotlin("jvm")
 }
 
 java {

--- a/end2end-tests/openfeign/build.gradle.kts
+++ b/end2end-tests/openfeign/build.gradle.kts
@@ -9,7 +9,7 @@ sourceSets {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.20" // Apply the Kotlin JVM plugin to add support for Kotlin.
+    kotlin("jvm")
 }
 
 java {


### PR DESCRIPTION
Upgrades Kotlin to 2.0.20. Shouldn't change anything, but we might as well keep up with the latest major version of Kotlin.

`Kotlinx.Serialization` is also upgraded as `1.7.3` [uses 2.0.20 by default](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.7.3). This affects only the end2end test.