### PR TITLE
Implement support for optional objects in openapi 3.1.0

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
@@ -77,6 +77,13 @@ object YamlUtils {
                         (node as ObjectNode).replace("type", nonNullType)
                         requiresNullable = true
                     }
+                    if (key == "oneOf" && maybeTypeArray.isArray && maybeTypeArray.size() == 2 && maybeTypeArray.any { it.isObject && it.has("type") && it.get("type") == NULL_TYPE }) {
+                        val nonNullOption = maybeTypeArray.first { !it.has("type") || it.get("type") != NULL_TYPE }
+                        (node as ObjectNode).putArray("allOf")
+                        (node.get("allOf") as ArrayNode).insert(0, nonNullOption)
+                        node.remove("oneOf")
+                        requiresNullable = true
+                    }
                     downgradeNullableSyntax(maybeTypeArray)
                 }
                 if (requiresNullable) {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -62,6 +62,7 @@ class ModelGeneratorTest {
         "instantDateTime",
         "discriminatedOneOf",
         "openapi310",
+        "openapi310OptionalObject",
         "binary",
         "oneOfMarkerInterface",
         "byteArrayStream",

--- a/src/test/resources/examples/openapi310OptionalObject/api.yaml
+++ b/src/test/resources/examples/openapi310OptionalObject/api.yaml
@@ -1,0 +1,16 @@
+openapi: 3.1.0
+components:
+  schemas:
+    NullableObject:
+      type: object
+      properties:
+        field:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/TheObject'
+    TheObject:
+      required:
+        - name
+      properties:
+        name:
+          type: string

--- a/src/test/resources/examples/openapi310OptionalObject/models/NullableObject.kt
+++ b/src/test/resources/examples/openapi310OptionalObject/models/NullableObject.kt
@@ -1,0 +1,11 @@
+package examples.openapi310OptionalObject.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+
+public data class NullableObject(
+  @param:JsonProperty("field")
+  @get:JsonProperty("field")
+  @get:Valid
+  public val `field`: TheObject? = null,
+)

--- a/src/test/resources/examples/openapi310OptionalObject/models/TheObject.kt
+++ b/src/test/resources/examples/openapi310OptionalObject/models/TheObject.kt
@@ -1,0 +1,12 @@
+package examples.openapi310OptionalObject.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class TheObject(
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  @get:NotNull
+  public val name: String,
+)


### PR DESCRIPTION
Currently mapping from openapi 3.1.0 nullable types only works with the types array which does not support object. This pr provides mapping for `oneOf (object | null)` to the legacy style mapping. See the following input openapi spec:

```yaml
openapi: 3.1.0
components:
  schemas:
    NullableObject:
      type: object
      properties:
        field:
          oneOf:
            - type: 'null'
            - $ref: '#/components/schemas/TheObject'
    TheObject:
      properties:
        name:
          type: string
```

It would be updated to this openapi spec after this pr:

```yaml
openapi: 3.1.0
components:
  schemas:
    NullableObject:
      type: object
      properties:
        field:
          allOf:
            - $ref: '#/components/schemas/TheObject'
          nullable: true
    TheObject:
      properties:
        name:
          type: string
```