### PR TITLE
Replace values() with entries() with in enums

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -418,7 +418,7 @@ class ModelGenerator(
         val companion = TypeSpec.companionObjectBuilder()
             .addProperty(
                 PropertySpec.builder("mapping", createMapOfStringToNonNullType(enumType))
-                    .initializer("values().associateBy(%T::value)", enumType)
+                    .initializer("entries.associateBy(%T::value)", enumType)
                     .addModifiers(KModifier.PRIVATE)
                     .build(),
             )

--- a/src/test/resources/examples/companionObject/models/Models.kt
+++ b/src/test/resources/examples/companionObject/models/Models.kt
@@ -74,7 +74,7 @@ public enum class DogBreed(
     ;
 
     public companion object {
-        private val mapping: Map<String, DogBreed> = values().associateBy(DogBreed::value)
+        private val mapping: Map<String, DogBreed> = entries.associateBy(DogBreed::value)
 
         public fun fromValue(`value`: String): DogBreed? = mapping[value]
     }

--- a/src/test/resources/examples/defaultValues/models/PersonWithDefaultsEnumDefault.kt
+++ b/src/test/resources/examples/defaultValues/models/PersonWithDefaultsEnumDefault.kt
@@ -14,7 +14,7 @@ public enum class PersonWithDefaultsEnumDefault(
 
   public companion object {
     private val mapping: Map<String, PersonWithDefaultsEnumDefault> =
-        values().associateBy(PersonWithDefaultsEnumDefault::value)
+        entries.associateBy(PersonWithDefaultsEnumDefault::value)
 
     public fun fromValue(`value`: String): PersonWithDefaultsEnumDefault? = mapping[value]
   }

--- a/src/test/resources/examples/defaultValues/models/PersonWithDefaultsEnumQuotedDefault.kt
+++ b/src/test/resources/examples/defaultValues/models/PersonWithDefaultsEnumQuotedDefault.kt
@@ -14,7 +14,7 @@ public enum class PersonWithDefaultsEnumQuotedDefault(
 
   public companion object {
     private val mapping: Map<String, PersonWithDefaultsEnumQuotedDefault> =
-        values().associateBy(PersonWithDefaultsEnumQuotedDefault::value)
+        entries.associateBy(PersonWithDefaultsEnumQuotedDefault::value)
 
     public fun fromValue(`value`: String): PersonWithDefaultsEnumQuotedDefault? = mapping[value]
   }

--- a/src/test/resources/examples/discriminatedOneOf/models/StateBMode.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/StateBMode.kt
@@ -13,7 +13,7 @@ public enum class StateBMode(
   ;
 
   public companion object {
-    private val mapping: Map<String, StateBMode> = values().associateBy(StateBMode::value)
+    private val mapping: Map<String, StateBMode> = entries.associateBy(StateBMode::value)
 
     public fun fromValue(`value`: String): StateBMode? = mapping[value]
   }

--- a/src/test/resources/examples/discriminatedOneOf/models/Status.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/Status.kt
@@ -13,7 +13,7 @@ public enum class Status(
   ;
 
   public companion object {
-    private val mapping: Map<String, Status> = values().associateBy(Status::value)
+    private val mapping: Map<String, Status> = entries.associateBy(Status::value)
 
     public fun fromValue(`value`: String): Status? = mapping[value]
   }

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/StateBMode.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/StateBMode.kt
@@ -14,7 +14,7 @@ public enum class StateBMode(
   ;
 
   public companion object {
-    private val mapping: Map<String, StateBMode> = values().associateBy(StateBMode::value)
+    private val mapping: Map<String, StateBMode> = entries.associateBy(StateBMode::value)
 
     public fun fromValue(`value`: String): StateBMode? = mapping[value]
   }

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/Status.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/Status.kt
@@ -14,7 +14,7 @@ public enum class Status(
   ;
 
   public companion object {
-    private val mapping: Map<String, Status> = values().associateBy(Status::value)
+    private val mapping: Map<String, Status> = entries.associateBy(Status::value)
 
     public fun fromValue(`value`: String): Status? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/ContentType.kt
+++ b/src/test/resources/examples/enumExamples/models/ContentType.kt
@@ -14,7 +14,7 @@ public enum class ContentType(
   ;
 
   public companion object {
-    private val mapping: Map<String, ContentType> = values().associateBy(ContentType::value)
+    private val mapping: Map<String, ContentType> = entries.associateBy(ContentType::value)
 
     public fun fromValue(`value`: String): ContentType? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/EnumHolderArrayOfEnums.kt
+++ b/src/test/resources/examples/enumExamples/models/EnumHolderArrayOfEnums.kt
@@ -14,7 +14,7 @@ public enum class EnumHolderArrayOfEnums(
 
   public companion object {
     private val mapping: Map<String, EnumHolderArrayOfEnums> =
-        values().associateBy(EnumHolderArrayOfEnums::value)
+        entries.associateBy(EnumHolderArrayOfEnums::value)
 
     public fun fromValue(`value`: String): EnumHolderArrayOfEnums? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/EnumHolderInlinedEnum.kt
+++ b/src/test/resources/examples/enumExamples/models/EnumHolderInlinedEnum.kt
@@ -15,7 +15,7 @@ public enum class EnumHolderInlinedEnum(
 
   public companion object {
     private val mapping: Map<String, EnumHolderInlinedEnum> =
-        values().associateBy(EnumHolderInlinedEnum::value)
+        entries.associateBy(EnumHolderInlinedEnum::value)
 
     public fun fromValue(`value`: String): EnumHolderInlinedEnum? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/EnumHolderInlinedExtensibleEnum.kt
+++ b/src/test/resources/examples/enumExamples/models/EnumHolderInlinedExtensibleEnum.kt
@@ -15,7 +15,7 @@ public enum class EnumHolderInlinedExtensibleEnum(
 
   public companion object {
     private val mapping: Map<String, EnumHolderInlinedExtensibleEnum> =
-        values().associateBy(EnumHolderInlinedExtensibleEnum::value)
+        entries.associateBy(EnumHolderInlinedExtensibleEnum::value)
 
     public fun fromValue(`value`: String): EnumHolderInlinedExtensibleEnum? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/EnumObject.kt
+++ b/src/test/resources/examples/enumExamples/models/EnumObject.kt
@@ -17,7 +17,7 @@ public enum class EnumObject(
   ;
 
   public companion object {
-    private val mapping: Map<String, EnumObject> = values().associateBy(EnumObject::value)
+    private val mapping: Map<String, EnumObject> = entries.associateBy(EnumObject::value)
 
     public fun fromValue(`value`: String): EnumObject? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/ExtensibleEnumObject.kt
+++ b/src/test/resources/examples/enumExamples/models/ExtensibleEnumObject.kt
@@ -14,7 +14,7 @@ public enum class ExtensibleEnumObject(
 
   public companion object {
     private val mapping: Map<String, ExtensibleEnumObject> =
-        values().associateBy(ExtensibleEnumObject::value)
+        entries.associateBy(ExtensibleEnumObject::value)
 
     public fun fromValue(`value`: String): ExtensibleEnumObject? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/FooBarsFoo.kt
+++ b/src/test/resources/examples/enumExamples/models/FooBarsFoo.kt
@@ -13,7 +13,7 @@ public enum class FooBarsFoo(
   ;
 
   public companion object {
-    private val mapping: Map<String, FooBarsFoo> = values().associateBy(FooBarsFoo::value)
+    private val mapping: Map<String, FooBarsFoo> = entries.associateBy(FooBarsFoo::value)
 
     public fun fromValue(`value`: String): FooBarsFoo? = mapping[value]
   }

--- a/src/test/resources/examples/enumExamples/models/FooFoo.kt
+++ b/src/test/resources/examples/enumExamples/models/FooFoo.kt
@@ -13,7 +13,7 @@ public enum class FooFoo(
   ;
 
   public companion object {
-    private val mapping: Map<String, FooFoo> = values().associateBy(FooFoo::value)
+    private val mapping: Map<String, FooFoo> = entries.associateBy(FooFoo::value)
 
     public fun fromValue(`value`: String): FooFoo? = mapping[value]
   }

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/models/ChildDefinitionInlineEnum.kt
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/models/ChildDefinitionInlineEnum.kt
@@ -15,7 +15,7 @@ public enum class ChildDefinitionInlineEnum(
 
   public companion object {
     private val mapping: Map<String, ChildDefinitionInlineEnum> =
-        values().associateBy(ChildDefinitionInlineEnum::value)
+        entries.associateBy(ChildDefinitionInlineEnum::value)
 
     public fun fromValue(`value`: String): ChildDefinitionInlineEnum? = mapping[value]
   }

--- a/src/test/resources/examples/enumPolymorphicDiscriminator/models/ChildDiscriminator.kt
+++ b/src/test/resources/examples/enumPolymorphicDiscriminator/models/ChildDiscriminator.kt
@@ -16,7 +16,7 @@ public enum class ChildDiscriminator(
 
   public companion object {
     private val mapping: Map<String, ChildDiscriminator> =
-        values().associateBy(ChildDiscriminator::value)
+        entries.associateBy(ChildDiscriminator::value)
 
     public fun fromValue(`value`: String): ChildDiscriminator? = mapping[value]
   }

--- a/src/test/resources/examples/externalReferences/aggressive/models/ClientModels.kt
+++ b/src/test/resources/examples/externalReferences/aggressive/models/ClientModels.kt
@@ -86,7 +86,7 @@ public enum class ExternalObjectThreeEnum(
 
     public companion object {
         private val mapping: Map<String, ExternalObjectThreeEnum> =
-            values().associateBy(ExternalObjectThreeEnum::value)
+            entries.associateBy(ExternalObjectThreeEnum::value)
 
         public fun fromValue(`value`: String): ExternalObjectThreeEnum? = mapping[value]
     }
@@ -120,7 +120,7 @@ public enum class ExternalParameter(
 
     public companion object {
         private val mapping: Map<String, ExternalParameter> =
-            values().associateBy(ExternalParameter::value)
+            entries.associateBy(ExternalParameter::value)
 
         public fun fromValue(`value`: String): ExternalParameter? = mapping[value]
     }

--- a/src/test/resources/examples/externalReferences/targeted/models/ExternalObjectThreeEnum.kt
+++ b/src/test/resources/examples/externalReferences/targeted/models/ExternalObjectThreeEnum.kt
@@ -15,7 +15,7 @@ public enum class ExternalObjectThreeEnum(
 
   public companion object {
     private val mapping: Map<String, ExternalObjectThreeEnum> =
-        values().associateBy(ExternalObjectThreeEnum::value)
+        entries.associateBy(ExternalObjectThreeEnum::value)
 
     public fun fromValue(`value`: String): ExternalObjectThreeEnum? = mapping[value]
   }

--- a/src/test/resources/examples/githubApi/models/ContributorStatus.kt
+++ b/src/test/resources/examples/githubApi/models/ContributorStatus.kt
@@ -14,7 +14,7 @@ public enum class ContributorStatus(
 
   public companion object {
     private val mapping: Map<String, ContributorStatus> =
-        values().associateBy(ContributorStatus::value)
+        entries.associateBy(ContributorStatus::value)
 
     public fun fromValue(`value`: String): ContributorStatus? = mapping[value]
   }

--- a/src/test/resources/examples/githubApi/models/OrganisationStatus.kt
+++ b/src/test/resources/examples/githubApi/models/OrganisationStatus.kt
@@ -14,7 +14,7 @@ public enum class OrganisationStatus(
 
   public companion object {
     private val mapping: Map<String, OrganisationStatus> =
-        values().associateBy(OrganisationStatus::value)
+        entries.associateBy(OrganisationStatus::value)
 
     public fun fromValue(`value`: String): OrganisationStatus? = mapping[value]
   }

--- a/src/test/resources/examples/githubApi/models/PullRequestStatus.kt
+++ b/src/test/resources/examples/githubApi/models/PullRequestStatus.kt
@@ -14,7 +14,7 @@ public enum class PullRequestStatus(
 
   public companion object {
     private val mapping: Map<String, PullRequestStatus> =
-        values().associateBy(PullRequestStatus::value)
+        entries.associateBy(PullRequestStatus::value)
 
     public fun fromValue(`value`: String): PullRequestStatus? = mapping[value]
   }

--- a/src/test/resources/examples/githubApi/models/RepositoryStatus.kt
+++ b/src/test/resources/examples/githubApi/models/RepositoryStatus.kt
@@ -14,7 +14,7 @@ public enum class RepositoryStatus(
 
   public companion object {
     private val mapping: Map<String, RepositoryStatus> =
-        values().associateBy(RepositoryStatus::value)
+        entries.associateBy(RepositoryStatus::value)
 
     public fun fromValue(`value`: String): RepositoryStatus? = mapping[value]
   }

--- a/src/test/resources/examples/githubApi/models/RepositoryVisibility.kt
+++ b/src/test/resources/examples/githubApi/models/RepositoryVisibility.kt
@@ -14,7 +14,7 @@ public enum class RepositoryVisibility(
 
   public companion object {
     private val mapping: Map<String, RepositoryVisibility> =
-        values().associateBy(RepositoryVisibility::value)
+        entries.associateBy(RepositoryVisibility::value)
 
     public fun fromValue(`value`: String): RepositoryVisibility? = mapping[value]
   }

--- a/src/test/resources/examples/githubApi/models/StatusQueryParam.kt
+++ b/src/test/resources/examples/githubApi/models/StatusQueryParam.kt
@@ -15,7 +15,7 @@ public enum class StatusQueryParam(
 
   public companion object {
     private val mapping: Map<String, StatusQueryParam> =
-        values().associateBy(StatusQueryParam::value)
+        entries.associateBy(StatusQueryParam::value)
 
     public fun fromValue(`value`: String): StatusQueryParam? = mapping[value]
   }

--- a/src/test/resources/examples/javaSerializableModels/models/Models.kt
+++ b/src/test/resources/examples/javaSerializableModels/models/Models.kt
@@ -55,7 +55,7 @@ public enum class ContentModelType(
 
     public companion object {
         private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+            entries.associateBy(ContentModelType::value)
 
         public fun fromValue(`value`: String): ContentModelType? = mapping[value]
     }
@@ -71,7 +71,7 @@ public enum class ContentThirdAttr(
 
     public companion object {
         private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
+            entries.associateBy(ContentThirdAttr::value)
 
         public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
     }

--- a/src/test/resources/examples/micronautIntrospectedModels/models/Models.kt
+++ b/src/test/resources/examples/micronautIntrospectedModels/models/Models.kt
@@ -57,7 +57,7 @@ public enum class ContentModelType(
 
     public companion object {
         private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+            entries.associateBy(ContentModelType::value)
 
         public fun fromValue(`value`: String): ContentModelType? = mapping[value]
     }
@@ -74,7 +74,7 @@ public enum class ContentThirdAttr(
 
     public companion object {
         private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
+            entries.associateBy(ContentThirdAttr::value)
 
         public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
     }

--- a/src/test/resources/examples/micronautReflectionModels/models/Models.kt
+++ b/src/test/resources/examples/micronautReflectionModels/models/Models.kt
@@ -57,7 +57,7 @@ public enum class ContentModelType(
 
     public companion object {
         private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+            entries.associateBy(ContentModelType::value)
 
         public fun fromValue(`value`: String): ContentModelType? = mapping[value]
     }
@@ -74,7 +74,7 @@ public enum class ContentThirdAttr(
 
     public companion object {
         private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
+            entries.associateBy(ContentThirdAttr::value)
 
         public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
     }

--- a/src/test/resources/examples/modelSuffix/models/EnumHolderDtoInlinedEnumDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/EnumHolderDtoInlinedEnumDto.kt
@@ -15,7 +15,7 @@ public enum class EnumHolderDtoInlinedEnumDto(
 
   public companion object {
     private val mapping: Map<String, EnumHolderDtoInlinedEnumDto> =
-        values().associateBy(EnumHolderDtoInlinedEnumDto::value)
+        entries.associateBy(EnumHolderDtoInlinedEnumDto::value)
 
     public fun fromValue(`value`: String): EnumHolderDtoInlinedEnumDto? = mapping[value]
   }

--- a/src/test/resources/examples/modelSuffix/models/EnumObjectDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/EnumObjectDto.kt
@@ -17,7 +17,7 @@ public enum class EnumObjectDto(
   ;
 
   public companion object {
-    private val mapping: Map<String, EnumObjectDto> = values().associateBy(EnumObjectDto::value)
+    private val mapping: Map<String, EnumObjectDto> = entries.associateBy(EnumObjectDto::value)
 
     public fun fromValue(`value`: String): EnumObjectDto? = mapping[value]
   }

--- a/src/test/resources/examples/modelSuffix/models/FirstLevelDiscriminatorDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FirstLevelDiscriminatorDto.kt
@@ -14,7 +14,7 @@ public enum class FirstLevelDiscriminatorDto(
 
   public companion object {
     private val mapping: Map<String, FirstLevelDiscriminatorDto> =
-        values().associateBy(FirstLevelDiscriminatorDto::value)
+        entries.associateBy(FirstLevelDiscriminatorDto::value)
 
     public fun fromValue(`value`: String): FirstLevelDiscriminatorDto? = mapping[value]
   }

--- a/src/test/resources/examples/modelSuffix/models/FooBarsDtoFooDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FooBarsDtoFooDto.kt
@@ -14,7 +14,7 @@ public enum class FooBarsDtoFooDto(
 
   public companion object {
     private val mapping: Map<String, FooBarsDtoFooDto> =
-        values().associateBy(FooBarsDtoFooDto::value)
+        entries.associateBy(FooBarsDtoFooDto::value)
 
     public fun fromValue(`value`: String): FooBarsDtoFooDto? = mapping[value]
   }

--- a/src/test/resources/examples/modelSuffix/models/FooFooDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FooFooDto.kt
@@ -13,7 +13,7 @@ public enum class FooFooDto(
   ;
 
   public companion object {
-    private val mapping: Map<String, FooFooDto> = values().associateBy(FooFooDto::value)
+    private val mapping: Map<String, FooFooDto> = entries.associateBy(FooFooDto::value)
 
     public fun fromValue(`value`: String): FooFooDto? = mapping[value]
   }

--- a/src/test/resources/examples/modelSuffix/models/ModeParameterDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/ModeParameterDto.kt
@@ -15,7 +15,7 @@ public enum class ModeParameterDto(
 
   public companion object {
     private val mapping: Map<String, ModeParameterDto> =
-        values().associateBy(ModeParameterDto::value)
+        entries.associateBy(ModeParameterDto::value)
 
     public fun fromValue(`value`: String): ModeParameterDto? = mapping[value]
   }

--- a/src/test/resources/examples/modelSuffix/models/RootDiscriminatorDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/RootDiscriminatorDto.kt
@@ -13,7 +13,7 @@ public enum class RootDiscriminatorDto(
 
   public companion object {
     private val mapping: Map<String, RootDiscriminatorDto> =
-        values().associateBy(RootDiscriminatorDto::value)
+        entries.associateBy(RootDiscriminatorDto::value)
 
     public fun fromValue(`value`: String): RootDiscriminatorDto? = mapping[value]
   }

--- a/src/test/resources/examples/modelSuffix/models/SecondLevelDiscriminatorDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/SecondLevelDiscriminatorDto.kt
@@ -14,7 +14,7 @@ public enum class SecondLevelDiscriminatorDto(
 
   public companion object {
     private val mapping: Map<String, SecondLevelDiscriminatorDto> =
-        values().associateBy(SecondLevelDiscriminatorDto::value)
+        entries.associateBy(SecondLevelDiscriminatorDto::value)
 
     public fun fromValue(`value`: String): SecondLevelDiscriminatorDto? = mapping[value]
   }

--- a/src/test/resources/examples/multiMediaType/models/ClientModels.kt
+++ b/src/test/resources/examples/multiMediaType/models/ClientModels.kt
@@ -63,7 +63,7 @@ public enum class ContentModelType(
 
     public companion object {
         private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+            entries.associateBy(ContentModelType::value)
 
         public fun fromValue(`value`: String): ContentModelType? = mapping[value]
     }
@@ -79,7 +79,7 @@ public enum class ContentThirdAttr(
 
     public companion object {
         private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
+            entries.associateBy(ContentThirdAttr::value)
 
         public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
     }
@@ -94,7 +94,7 @@ public enum class ContentType(
     ;
 
     public companion object {
-        private val mapping: Map<String, ContentType> = values().associateBy(ContentType::value)
+        private val mapping: Map<String, ContentType> = entries.associateBy(ContentType::value)
 
         public fun fromValue(`value`: String): ContentType? = mapping[value]
     }

--- a/src/test/resources/examples/nestedPolymorphicModels/models/FirstLevelDiscriminator.kt
+++ b/src/test/resources/examples/nestedPolymorphicModels/models/FirstLevelDiscriminator.kt
@@ -14,7 +14,7 @@ public enum class FirstLevelDiscriminator(
 
   public companion object {
     private val mapping: Map<String, FirstLevelDiscriminator> =
-        values().associateBy(FirstLevelDiscriminator::value)
+        entries.associateBy(FirstLevelDiscriminator::value)
 
     public fun fromValue(`value`: String): FirstLevelDiscriminator? = mapping[value]
   }

--- a/src/test/resources/examples/nestedPolymorphicModels/models/RootDiscriminator.kt
+++ b/src/test/resources/examples/nestedPolymorphicModels/models/RootDiscriminator.kt
@@ -13,7 +13,7 @@ public enum class RootDiscriminator(
 
   public companion object {
     private val mapping: Map<String, RootDiscriminator> =
-        values().associateBy(RootDiscriminator::value)
+        entries.associateBy(RootDiscriminator::value)
 
     public fun fromValue(`value`: String): RootDiscriminator? = mapping[value]
   }

--- a/src/test/resources/examples/nestedPolymorphicModels/models/SecondLevelDiscriminator.kt
+++ b/src/test/resources/examples/nestedPolymorphicModels/models/SecondLevelDiscriminator.kt
@@ -14,7 +14,7 @@ public enum class SecondLevelDiscriminator(
 
   public companion object {
     private val mapping: Map<String, SecondLevelDiscriminator> =
-        values().associateBy(SecondLevelDiscriminator::value)
+        entries.associateBy(SecondLevelDiscriminator::value)
 
     public fun fromValue(`value`: String): SecondLevelDiscriminator? = mapping[value]
   }

--- a/src/test/resources/examples/okHttpClient/models/ClientModels.kt
+++ b/src/test/resources/examples/okHttpClient/models/ClientModels.kt
@@ -55,7 +55,7 @@ public enum class ContentModelType(
 
     public companion object {
         private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+            entries.associateBy(ContentModelType::value)
 
         public fun fromValue(`value`: String): ContentModelType? = mapping[value]
     }
@@ -71,7 +71,7 @@ public enum class ContentThirdAttr(
 
     public companion object {
         private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
+            entries.associateBy(ContentThirdAttr::value)
 
         public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
     }

--- a/src/test/resources/examples/oneOfPolymorphicModels/models/ParentType.kt
+++ b/src/test/resources/examples/oneOfPolymorphicModels/models/ParentType.kt
@@ -13,7 +13,7 @@ public enum class ParentType(
   ;
 
   public companion object {
-    private val mapping: Map<String, ParentType> = values().associateBy(ParentType::value)
+    private val mapping: Map<String, ParentType> = entries.associateBy(ParentType::value)
 
     public fun fromValue(`value`: String): ParentType? = mapping[value]
   }

--- a/src/test/resources/examples/openFeignClient/models/ClientModels.kt
+++ b/src/test/resources/examples/openFeignClient/models/ClientModels.kt
@@ -54,7 +54,7 @@ public enum class ContentModelType(
 
     public companion object {
         private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+            entries.associateBy(ContentModelType::value)
 
         public fun fromValue(`value`: String): ContentModelType? = mapping[value]
     }
@@ -70,7 +70,7 @@ public enum class ContentThirdAttr(
 
     public companion object {
         private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
+            entries.associateBy(ContentThirdAttr::value)
 
         public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
     }

--- a/src/test/resources/examples/quarkusReflectionModels/models/Models.kt
+++ b/src/test/resources/examples/quarkusReflectionModels/models/Models.kt
@@ -57,7 +57,7 @@ public enum class ContentModelType(
 
     public companion object {
         private val mapping: Map<String, ContentModelType> =
-            values().associateBy(ContentModelType::value)
+            entries.associateBy(ContentModelType::value)
 
         public fun fromValue(`value`: String): ContentModelType? = mapping[value]
     }
@@ -74,7 +74,7 @@ public enum class ContentThirdAttr(
 
     public companion object {
         private val mapping: Map<String, ContentThirdAttr> =
-            values().associateBy(ContentThirdAttr::value)
+            entries.associateBy(ContentThirdAttr::value)
 
         public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
     }


### PR DESCRIPTION
Hi there - I was digging into the generated code and I realized there was a recommendation to replace `values()` with `entries` when using enums: https://www.jetbrains.com/help/inspectopedia/EnumValuesSoftDeprecate.html

Since I wanted to contribute back to this library that we started using recently, I figured it was worth a shot. The tests are failing right now because I couldn't figure out how to rebuild the expected models in `src/test/resources/examples`, if you can point me toward the way to do that, I'll finish the work on this pull-request, assuming that's something you'd like. 