### PR TITLE
Omit discriminator property for Kotlin serialization

### DIFF
--- a/end2end-tests/models-kotlinx/openapi/api.yaml
+++ b/end2end-tests/models-kotlinx/openapi/api.yaml
@@ -71,9 +71,12 @@ components:
     LandlinePhone:
       type: object
       required:
+        - type
         - number
         - area_code
       properties:
+        type:
+          type: string
         number:
           type: string
         area_code:
@@ -81,8 +84,11 @@ components:
     MobilePhone:
       type: object
       required:
+        - type
         - number
       properties:
+        type:
+          type: string
         number:
           type: string
     Error:

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -219,4 +219,33 @@ object GeneratorUtils {
     }
 
     private fun isNullable(parameter: Parameter): Boolean = !parameter.isRequired && parameter.schema.default == null
+
+    /**
+     * Converts a TypeSpec to an object by copying over all properties, functions, etc.
+     */
+    fun TypeSpec.toObjectTypeSpec(): TypeSpec {
+        require(name != null) { "Name must be set to convert to object" }
+
+        val objectBuilder = TypeSpec.objectBuilder(name!!)
+            .addAnnotations(annotations)
+            .addModifiers(modifiers)
+            .superclass(superclass)
+            .addProperties(propertySpecs)
+            .addFunctions(funSpecs)
+            .addKdoc(kdoc)
+
+        for ((typeName, _) in superinterfaces) {
+            objectBuilder.addSuperinterface(typeName)
+        }
+
+        if (initializerBlock.isNotEmpty()) {
+            objectBuilder.addInitializerBlock(initializerBlock)
+        }
+
+        for (nestedType in typeSpecs) {
+            objectBuilder.addType(nestedType)
+        }
+
+        return objectBuilder.build()
+    }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -6,6 +6,7 @@ import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.ClassSettings
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toObjectTypeSpec
 import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.generators.PropertyUtils.addToClass
 import com.cjbooms.fabrikt.generators.PropertyUtils.isNullable
@@ -498,7 +499,14 @@ class ModelGenerator(
 
         serializationAnnotations.addClassAnnotation(classBuilder)
 
-        return classBuilder.build()
+        val classTypeSpec = classBuilder.build()
+
+        return if (classBuilder.propertySpecs.isNotEmpty()) {
+            classTypeSpec
+        } else {
+            // properties have been filtered out in generation process so return an object instead
+            classTypeSpec.toObjectTypeSpec()
+        }
     }
 
     private fun polymorphicSuperSubType(

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
@@ -10,6 +10,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 
 object JacksonAnnotations : SerializationAnnotations {
+    override val supportsBackingPropertyForDiscriminator = true
     override val supportsAdditionalProperties = true
     override fun addIgnore(propertySpecBuilder: PropertySpec.Builder) =
         propertySpecBuilder.addAnnotation(JacksonMetadata.ignore)

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
@@ -10,6 +10,13 @@ import kotlinx.serialization.Serializable
 
 object KotlinxSerializationAnnotations : SerializationAnnotations {
     /**
+     * Polymorphic class discriminators are added as annotations in kotlinx serialization.
+     * Including them in the class definition causes compilation errors since the property name
+     * will conflict with the class discriminator name.
+     */
+    override val supportsBackingPropertyForDiscriminator = false
+
+    /**
      * Supporting "additionalProperties: true" for kotlinx serialization requires additional
      * research and work due to Any type in the map (val properties: MutableMap<String, Any?>)
      *
@@ -18,6 +25,7 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
      * See also https://github.com/Kotlin/kotlinx.serialization/issues/1978
      */
     override val supportsAdditionalProperties = false
+
     override fun addIgnore(propertySpecBuilder: PropertySpec.Builder) =
         propertySpecBuilder // not applicable
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -7,6 +7,11 @@ import com.squareup.kotlinpoet.TypeSpec
 
 sealed interface SerializationAnnotations {
     /**
+     * Whether to include backing property for a polymorphic discriminator
+     */
+    val supportsBackingPropertyForDiscriminator: Boolean
+
+    /**
      * Whether the annotation supports OpenAPI's additional properties
      * https://spec.openapis.org/oas/v3.0.0.html#model-with-map-dictionary-properties
      */

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/StateA.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/StateA.kt
@@ -1,13 +1,8 @@
 package examples.discriminatedOneOf.models
 
-import javax.validation.constraints.NotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @SerialName("a")
 @Serializable
-public data class StateA(
-  @SerialName("status")
-  @get:NotNull
-  public val status: Status = Status.A,
-) : State
+public object StateA : State

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/StateB.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/StateB.kt
@@ -10,7 +10,4 @@ public data class StateB(
   @SerialName("mode")
   @get:NotNull
   public val mode: StateBMode,
-  @SerialName("status")
-  @get:NotNull
-  public val status: Status = Status.B,
 ) : State


### PR DESCRIPTION
Discriminated oneOf models generated with Kotlin serialization will currently not work because the discriminator property causes a name conflict with Kotlin Serialization's class discriminator:

`Sealed class 'subclass' cannot be serialized as base class 'com.example.models.Superclass' because it has property name that conflicts with JSON class discriminator 'type'.`

The issue was not discovered earlier because the OpenAPI spec for end-2-end test for Kotlin serialization models did not define the discriminator property on the child schemas. This PR adds the missing `type` property to the test.

In order for the generated code to be valid with Kotlin serialization we must omit the property in the models. The solution in this PR is to simply skip adding the property as part of the code generation process.

Skipping properties in the generation process has the side effect that if the discriminator is the only property on the schema we are left with a class with zero properties which must then converted to an object ([example](src/test/resources/examples/discriminatedOneOf/models/kotlinx/StateA.kt)). It would be more clean to filter out the property before the generation step, but I am not sure where we would hook in in order to do so.

I am really open to feedback on this approach and to any suggestions for improvements.