### PR TITLE
Add support for additional properties with simple types.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -69,11 +69,18 @@ object PropertyUtils {
             constructorBuilder.addParameter(constructorParameter.build())
 
             val value =
-                if (typeInfo is KotlinTypeInfo.MapTypeAdditionalProperties) {
-                    Map::class.asTypeName()
-                        .parameterizedBy(String::class.asTypeName(), parameterizedType.maybeMakeMapValueNullable())
-                } else {
-                    parameterizedType
+                when (typeInfo) {
+                    is KotlinTypeInfo.MapTypeAdditionalProperties -> {
+                        Map::class.asTypeName()
+                            .parameterizedBy(String::class.asTypeName(), parameterizedType.maybeMakeMapValueNullable())
+                    }
+                    is KotlinTypeInfo.SimpleTypedAdditionalProperties -> {
+                        (typeInfo as KotlinTypeInfo.SimpleTypedAdditionalProperties).parameterizedType.modelKClass.asTypeName()
+                            .maybeMakeMapValueNullable()
+                    }
+                    else -> {
+                        parameterizedType
+                    }
                 }.maybeMakeMapValueNullable()
 
             val getterSpecBuilder = FunSpec.builder("get")

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -131,6 +131,12 @@ class ModelGenerator(
                         typeInfo.parameterizedType,
                     ),
                 )
+                is KotlinTypeInfo.SimpleTypedAdditionalProperties -> createMutableMapOfStringToType(
+                    toModelType(
+                        basePackage,
+                        typeInfo.parameterizedType,
+                    ),
+                )
 
                 else -> className
             }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -53,6 +53,8 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
     data class GeneratedTypedAdditionalProperties(val simpleClassName: String) :
         KotlinTypeInfo(GeneratedType::class, simpleClassName)
 
+    data class SimpleTypedAdditionalProperties(val parameterizedType: KotlinTypeInfo) : KotlinTypeInfo(Map::class)
+
     data class MapTypeAdditionalProperties(val parameterizedType: KotlinTypeInfo) :
         KotlinTypeInfo(Map::class)
 
@@ -106,11 +108,14 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
 
                 OasType.Object -> Object(ModelNameRegistry.getOrRegister(schema, enclosingSchema))
                 OasType.Map ->
-                    Map(from(schema.additionalPropertiesSchema, "", enclosingSchema))
+                    Map(from(schema.additionalPropertiesSchema, OasType.ADDITIONAL_PROPERTIES_VALUE, enclosingSchema))
 
                 OasType.TypedObjectAdditionalProperties -> GeneratedTypedAdditionalProperties(
                     ModelNameRegistry.getOrRegister(schema, valueSuffix = schema.isInlinedTypedAdditionalProperties())
                 )
+
+                OasType.SimpleTypedAdditionalProperties ->
+                    SimpleTypedAdditionalProperties(from(schema, OasType.ADDITIONAL_PROPERTIES_VALUE))
 
                 OasType.UntypedObjectAdditionalProperties -> UntypedObjectAdditionalProperties
                 OasType.UntypedObject -> UntypedObject

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -103,6 +103,9 @@ object KaizenParserExtensions {
     fun Schema.isTypedAdditionalProperties(oasKey: String) = type == OasType.Object.type &&
         (getSchemaNameInParent() == "additionalProperties" || oasKey == "additionalProperties") && properties?.isEmpty() != true
 
+    fun Schema.isSimpleTypedAdditionalProperties(oasKey: String) = isSimpleType() &&
+        (getSchemaNameInParent() == "additionalProperties" || oasKey == "additionalProperties") && properties?.isEmpty() == true
+
     fun Schema.isMapTypeAdditionalProperties(oasKey: String) = type == OasType.Object.type &&
         (oasKey == "additionalProperties") && properties?.isEmpty() == true &&
         hasAdditionalProperties()

--- a/src/test/resources/examples/mapExamples/api.yaml
+++ b/src/test/resources/examples/mapExamples/api.yaml
@@ -108,7 +108,7 @@ components:
           type: integer
       additionalProperties:
         $ref: '#/components/schemas/SomeRef'
-        
+
     SomeRef:
       type: object
       properties:
@@ -116,7 +116,7 @@ components:
           type: string
         other_number:
           type: integer
-          
+
     ComplexObjectWithMapsOfMaps:
       type: object
       required:
@@ -133,10 +133,10 @@ components:
             minProperties: 1
             additionalProperties:
               $ref: '#/components/schemas/BasicObject'
-          
+
     BasicObject:
       type: object
-      properties: 
+      properties:
         one:
           type: string
     StringMap:
@@ -159,3 +159,29 @@ components:
       additionalProperties:
         type: object
 
+
+    BasicObjectWithStringMap:
+      type: object
+      properties:
+        one:
+          type: string
+      additionalProperties:
+        type: string
+
+
+    BasicObjectWithNumberMap:
+      type: object
+      properties:
+        one:
+          type: string
+      additionalProperties:
+        type: integer
+
+
+    BasicObjectWithBooleanMap:
+      type: object
+      properties:
+        one:
+          type: string
+      additionalProperties:
+        type: boolean

--- a/src/test/resources/examples/mapExamples/models/BasicObjectWithBooleanMap.kt
+++ b/src/test/resources/examples/mapExamples/models/BasicObjectWithBooleanMap.kt
@@ -1,0 +1,26 @@
+package examples.mapExamples.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class BasicObjectWithBooleanMap(
+  @param:JsonProperty("one")
+  @get:JsonProperty("one")
+  public val one: String? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, Boolean?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, Boolean?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: Boolean?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/mapExamples/models/BasicObjectWithNumberMap.kt
+++ b/src/test/resources/examples/mapExamples/models/BasicObjectWithNumberMap.kt
@@ -1,0 +1,26 @@
+package examples.mapExamples.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class BasicObjectWithNumberMap(
+  @param:JsonProperty("one")
+  @get:JsonProperty("one")
+  public val one: String? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, Int?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, Int?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: Int?) {
+    properties[name] = value
+  }
+}

--- a/src/test/resources/examples/mapExamples/models/BasicObjectWithStringMap.kt
+++ b/src/test/resources/examples/mapExamples/models/BasicObjectWithStringMap.kt
@@ -1,0 +1,25 @@
+package examples.mapExamples.models
+
+import com.fasterxml.jackson.`annotation`.JsonAnyGetter
+import com.fasterxml.jackson.`annotation`.JsonAnySetter
+import com.fasterxml.jackson.`annotation`.JsonIgnore
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.MutableMap
+
+public data class BasicObjectWithStringMap(
+  @param:JsonProperty("one")
+  @get:JsonProperty("one")
+  public val one: String? = null,
+  @get:JsonIgnore
+  public val properties: MutableMap<String, String?> = mutableMapOf(),
+) {
+  @JsonAnyGetter
+  public fun `get`(): Map<String, String?> = properties
+
+  @JsonAnySetter
+  public fun `set`(name: String, `value`: String?) {
+    properties[name] = value
+  }
+}


### PR DESCRIPTION
I encountered this issue in Zalando today. The additional properties declaring simple types was not working.

The code generation in this area is crazy brittle and hard to follow, but I think I have a solution here that gets this working in the most minimally impactful way.