### PR TITLE
Fix issue with generation of inlined items schema in arrays.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -30,7 +30,6 @@ import com.cjbooms.fabrikt.model.PropertyInfo.Companion.HTTP_SETTINGS
 import com.cjbooms.fabrikt.model.PropertyInfo.Companion.topLevelProperties
 import com.cjbooms.fabrikt.model.SchemaInfo
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.model.toEnclosingSchemaInfo
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.findOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getDiscriminatorForInLinedObjectUnderAllOf
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getSchemaRefName
@@ -192,7 +191,6 @@ class ModelGenerator(
                             schemaName = it.schema.safeName(),
                             enclosingSchema = it.schema,
                             apiDocUrl = it.schema.getDocumentUrl(),
-                            enclosingSchemaInfoName = it.name,
                     )
                 }
                 else -> {
@@ -278,7 +276,7 @@ class ModelGenerator(
                     } else {
                         val props = it.schema.topLevelProperties(HTTP_SETTINGS, sourceApi.openApi3, enclosingSchema)
                         val currentModel = standardDataClass(
-                            ModelNameRegistry.getOrRegister(it.schema, enclosingSchema.toEnclosingSchemaInfo()),
+                            ModelNameRegistry.getOrRegister(it.schema, enclosingSchema),
                             it.name,
                             props,
                             it.schema.extensions,
@@ -331,11 +329,8 @@ class ModelGenerator(
         schemaName: String,
         enclosingSchema: Schema,
         apiDocUrl: String,
-        enclosingSchemaInfoName: String? = null,
     ): Collection<TypeSpec> =
         schema.itemsSchema.let { items ->
-            val enclosingSchemaInfo = enclosingSchemaInfoName?.toEnclosingSchemaInfo()
-                ?: enclosingSchema.toEnclosingSchemaInfo()
             when {
                 items.isInlinedObjectDefinition() ->
                     items.topLevelProperties(HTTP_SETTINGS, sourceApi.openApi3, enclosingSchema).let { props ->
@@ -344,7 +339,7 @@ class ModelGenerator(
                             enclosingSchema = enclosingSchema,
                             apiDocUrl = apiDocUrl,
                         ) + standardDataClass(
-                            modelName = ModelNameRegistry.getOrRegister(schema, enclosingSchemaInfo),
+                            modelName = ModelNameRegistry.getOrRegister(schema, enclosingSchema),
                             schemaName = schemaName,
                             properties = props,
                             extensions = schema.extensions,
@@ -355,7 +350,7 @@ class ModelGenerator(
                 items.isInlinedEnumDefinition() ->
                     setOf(
                         buildEnumClass(
-                            KotlinTypeInfo.from(items, "items", enclosingSchemaInfo) as KotlinTypeInfo.Enum,
+                            KotlinTypeInfo.from(items, "items", enclosingSchema) as KotlinTypeInfo.Enum,
                         ),
                     )
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -70,7 +70,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
     companion object {
         private val logger = Logger.getGlobal()
         
-        fun from(schema: Schema, oasKey: String = "", enclosingSchema: EnclosingSchemaInfo? = null): KotlinTypeInfo =
+        fun from(schema: Schema, oasKey: String = "", enclosingSchema: Schema? = null): KotlinTypeInfo =
             when (schema.toOasType(oasKey)) {
                 OasType.Date -> {
                     if (MutableSettings.serializationLibrary() == KOTLINX_SERIALIZATION) KotlinxLocalDate

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -167,7 +167,7 @@ sealed class PropertyInfo {
         val enclosingSchema: Schema? = null
     ) : PropertyInfo() {
         override val typeInfo: KotlinTypeInfo =
-            KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toEnclosingSchemaInfo())
+            KotlinTypeInfo.from(schema, oasKey, enclosingSchema)
         val pattern: String? = schema.safeField(Schema::getPattern)
         val maxLength: Int? = schema.safeField(Schema::getMaxLength)
         val minLength: Int? = schema.safeField(Schema::getMinLength)
@@ -194,9 +194,9 @@ sealed class PropertyInfo {
     ) : PropertyInfo(), CollectionValidation {
         override val typeInfo: KotlinTypeInfo =
             if (isInherited) {
-                KotlinTypeInfo.from(schema, oasKey, parentSchema.toEnclosingSchemaInfo())
+                KotlinTypeInfo.from(schema, oasKey, parentSchema)
             } else {
-                KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toEnclosingSchemaInfo())
+                KotlinTypeInfo.from(schema, oasKey, enclosingSchema)
             }
         override val minItems: Int? = schema.minItems
         override val maxItems: Int? = schema.maxItems
@@ -232,9 +232,9 @@ sealed class PropertyInfo {
     ) : PropertyInfo() {
         override val typeInfo: KotlinTypeInfo =
             if (isInherited) {
-                KotlinTypeInfo.from(schema, oasKey, parentSchema.toEnclosingSchemaInfo())
+                KotlinTypeInfo.from(schema, oasKey, parentSchema)
             } else {
-                KotlinTypeInfo.from(schema, oasKey, enclosingSchema?.toEnclosingSchemaInfo())
+                KotlinTypeInfo.from(schema, oasKey, enclosingSchema)
             }
     }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
@@ -83,29 +83,3 @@ data class SourceApi(
             }
     }
 }
-
-/**
- * Enclosing schema can either be provided as:
- * - a schema from Kaizen as OAS3 model.
- * - provided as schema name based on names provided in spec file from SchemaInfo
- */
-enum class EnclosingSchemaInfoType {
-    NAME,
-    OAS_MODEL,
-}
-
-interface EnclosingSchemaInfo {
-    val type: EnclosingSchemaInfoType
-}
-
-data class EnclosingSchemaInfoName(val name: String) : EnclosingSchemaInfo {
-    override val type = EnclosingSchemaInfoType.NAME
-}
-
-data class EnclosingSchemaInfoOasModel(val schema: Schema) : EnclosingSchemaInfo {
-    override val type = EnclosingSchemaInfoType.OAS_MODEL
-}
-
-fun Schema.toEnclosingSchemaInfo() = EnclosingSchemaInfoOasModel(this)
-
-fun String.toEnclosingSchemaInfo() = EnclosingSchemaInfoName(this)

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -77,8 +77,8 @@ class ModelGeneratorTest {
         ModelNameRegistry.clear()
     }
 
-    // @Test
-    // fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("insert test case")
+    @Test
+    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("enumExamples")
 
     @ParameterizedTest
     @MethodSource("testCases")

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -33,6 +33,7 @@ class SpringControllerGeneratorTest {
 
     @Suppress("unused")
     private fun testCases(): Stream<String> = Stream.of(
+        "arrays",
         "githubApi",
         "singleAllOf",
         "pathLevelParameters",

--- a/src/test/resources/examples/arrays/api.yaml
+++ b/src/test/resources/examples/arrays/api.yaml
@@ -1,6 +1,24 @@
 openapi: 3.0.0
 info:
 paths:
+  /items:
+    get:
+      summary: Get items with a status filter
+      description: Retrieve a list of items filtered by their status.
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: Filter items by status.
+          schema:
+            $ref: '#/components/schemas/ArrayOfSomething'
+      responses:
+        "200":
+          description: A list of items.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayContainingComplexInlined'
 components:
   schemas:
     ContainsArrayOfArrays:
@@ -77,3 +95,11 @@ components:
         grams:
           type: integer
           example: 100
+
+    ArrayContainingComplexInlined:
+      type: array
+      items:
+        type: object
+        properties:
+          prop_one:
+            type: string

--- a/src/test/resources/examples/arrays/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/arrays/controllers/spring/Controllers.kt
@@ -1,0 +1,32 @@
+package examples.arrays.controllers
+
+import examples.arrays.models.ArrayContainingComplexInlined
+import examples.arrays.models.Something
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import org.springframework.web.bind.`annotation`.RequestParam
+import javax.validation.Valid
+import kotlin.collections.List
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface ItemsController {
+    /**
+     * Get items with a status filter
+     * Retrieve a list of items filtered by their status.
+     * @param status Filter items by status.
+     */
+    @RequestMapping(
+        value = ["/items"],
+        produces = ["application/json"],
+        method = [RequestMethod.GET],
+    )
+    public fun `get`(
+        @Valid @RequestParam(value = "status", required = false)
+        status: List<Something>?,
+    ): ResponseEntity<List<ArrayContainingComplexInlined>>
+}

--- a/src/test/resources/examples/arrays/models/ArrayContainingComplexInlined.kt
+++ b/src/test/resources/examples/arrays/models/ArrayContainingComplexInlined.kt
@@ -1,0 +1,10 @@
+package examples.arrays.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class ArrayContainingComplexInlined(
+  @param:JsonProperty("prop_one")
+  @get:JsonProperty("prop_one")
+  public val propOne: String? = null,
+)

--- a/src/test/resources/examples/enumExamples/models/Bar.kt
+++ b/src/test/resources/examples/enumExamples/models/Bar.kt
@@ -1,9 +1,9 @@
-package examples.modelSuffix.models
+package examples.enumExamples.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import kotlin.String
 
-public data class BarBarDto(
+public data class Bar(
   @param:JsonProperty("bar_prop")
   @get:JsonProperty("bar_prop")
   public val barProp: String? = null,

--- a/src/test/resources/examples/enumExamples/models/Foo.kt
+++ b/src/test/resources/examples/enumExamples/models/Foo.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.`annotation`.JsonValue
 import kotlin.String
 import kotlin.collections.Map
 
-public enum class FooFoo(
+public enum class Foo(
   @JsonValue
   public val `value`: String,
 ) {
@@ -13,8 +13,8 @@ public enum class FooFoo(
   ;
 
   public companion object {
-    private val mapping: Map<String, FooFoo> = entries.associateBy(FooFoo::value)
+    private val mapping: Map<String, Foo> = entries.associateBy(Foo::value)
 
-    public fun fromValue(`value`: String): FooFoo? = mapping[value]
+    public fun fromValue(`value`: String): Foo? = mapping[value]
   }
 }

--- a/src/test/resources/examples/modelSuffix/models/BarDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/BarDto.kt
@@ -1,9 +1,9 @@
-package examples.enumExamples.models
+package examples.modelSuffix.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import kotlin.String
 
-public data class BarBar(
+public data class BarDto(
   @param:JsonProperty("bar_prop")
   @get:JsonProperty("bar_prop")
   public val barProp: String? = null,

--- a/src/test/resources/examples/modelSuffix/models/FooDto.kt
+++ b/src/test/resources/examples/modelSuffix/models/FooDto.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.`annotation`.JsonValue
 import kotlin.String
 import kotlin.collections.Map
 
-public enum class FooFooDto(
+public enum class FooDto(
   @JsonValue
   public val `value`: String,
 ) {
@@ -13,8 +13,8 @@ public enum class FooFooDto(
   ;
 
   public companion object {
-    private val mapping: Map<String, FooFooDto> = entries.associateBy(FooFooDto::value)
+    private val mapping: Map<String, FooDto> = entries.associateBy(FooDto::value)
 
-    public fun fromValue(`value`: String): FooFooDto? = mapping[value]
+    public fun fromValue(`value`: String): FooDto? = mapping[value]
   }
 }


### PR DESCRIPTION
Fix issue with generation of inlined items schema in arrays, as seem in this screenshot, where the nested array items is getting duplicate model named, but is not referenced as such:
<img width="1179" alt="Screenshot 2025-01-28 at 18 25 43" src="https://github.com/user-attachments/assets/3fcc9bb1-2d64-4340-8bdf-3e92d2167a18" />

Related to #352 

