### PR TITLE
Fix correctly defined nullable enums causing a NPE

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -91,7 +91,7 @@ object KaizenParserExtensions {
 
     @Suppress("UNCHECKED_CAST")
     fun Schema.getEnumValues(): List<String> = when {
-        this.hasEnums() -> this.enums.map { it.toString() }.filterNot { it.isBlank() }
+        this.hasEnums() -> this.enums.filterNotNull().map { it.toString() }.filterNot { it.isBlank() }
         !MutableSettings.modelOptions().contains(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS) -> emptyList()
         else -> extensions[EXTENSIBLE_ENUM_KEY]?.let { it as List<String?> }?.filterNotNull()
             ?.filterNot { it.isBlank() } ?: emptyList()

--- a/src/test/resources/examples/enumExamples/api.yaml
+++ b/src/test/resources/examples/enumExamples/api.yaml
@@ -33,6 +33,8 @@ components:
           $ref: '#/components/schemas/ExtensibleEnumObject'
         list_enums:
           $ref: '#/components/schemas/ListEnums'
+        nullable_ref:
+          $ref: '#/components/schemas/NullableEnum'
 
     EnumObject:
       type: string
@@ -85,5 +87,7 @@ components:
           bar_prop:
             type: string
 
-
-
+    NullableEnum:
+      type: string
+      nullable: true
+      enum: [ "foo", "bar", null ]

--- a/src/test/resources/examples/enumExamples/models/EnumHolder.kt
+++ b/src/test/resources/examples/enumExamples/models/EnumHolder.kt
@@ -22,4 +22,7 @@ public data class EnumHolder(
   @param:JsonProperty("list_enums")
   @get:JsonProperty("list_enums")
   public val listEnums: List<ContentType>? = null,
+  @param:JsonProperty("nullable_ref")
+  @get:JsonProperty("nullable_ref")
+  public val nullableRef: NullableEnum? = null,
 )

--- a/src/test/resources/examples/enumExamples/models/NullableEnum.kt
+++ b/src/test/resources/examples/enumExamples/models/NullableEnum.kt
@@ -1,0 +1,20 @@
+package examples.enumExamples.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class NullableEnum(
+  @JsonValue
+  public val `value`: String,
+) {
+  FOO("foo"),
+  BAR("bar"),
+  ;
+
+  public companion object {
+    private val mapping: Map<String, NullableEnum> = entries.associateBy(NullableEnum::value)
+
+    public fun fromValue(`value`: String): NullableEnum? = mapping[value]
+  }
+}


### PR DESCRIPTION
Closes #357

It's simply fixing the NPE that causes the whole generation to fail if an enum has `null` in its list of allowed values, which is how nullable enums should be modeled if done correctly.

Nullable is still in a strange place in OpenAPI per se, since it's completely separate from `required` on the containing object property level. You can actually define some property as `required` even if that property is nullable per it's schema. That would mean that the property key in the JSON would need to be there, but the value could be null. And that is different from the property being completely left out as it would be possible if the property was not `required`. 

The main issue there is that that would be quite hard to model correctly in Kotlin. You would actually need some kind of `NULL` value within an enum that is nullable, to be able to seperate the two cases of it being null and the property being left our wholly. In the containing object, the reference to that enum being Kotlin-nullable would mean "property is optional", and that artificial `NULL` enum value would mean "property value should be null, but the property key should be there".

So with my change it's just working "correctly" for nullable enums that are optional as well, which is most likely the only real-world scenario that should occur anyway.