### PR TITLE
Fixed query parameters with type List<Int> for OkHttp client

### DIFF
--- a/src/main/resources/templates/client-code/http-util.kt.hbs
+++ b/src/main/resources/templates/client-code/http-util.kt.hbs
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }

--- a/src/test/resources/examples/byteArrayStream/client/HttpUtil.kt
+++ b/src/test/resources/examples/byteArrayStream/client/HttpUtil.kt
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }

--- a/src/test/resources/examples/externalReferences/aggressive/client/HttpUtil.kt
+++ b/src/test/resources/examples/externalReferences/aggressive/client/HttpUtil.kt
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }

--- a/src/test/resources/examples/multiMediaType/client/HttpUtil.kt
+++ b/src/test/resources/examples/multiMediaType/client/HttpUtil.kt
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }

--- a/src/test/resources/examples/okHttpClient/api.yaml
+++ b/src/test/resources/examples/okHttpClient/api.yaml
@@ -9,6 +9,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/ListQueryParamExploded"
         - $ref: "#/components/parameters/QueryParam2"
+        - $ref: "#/components/parameters/ListQueryParamInt"
       responses:
         200:
           description: "successful operation"
@@ -169,6 +170,15 @@ components:
           type: "string"
       required: false
       allowEmptyValue: false
+
+    ListQueryParamInt:
+      name: "int_list_query_param"
+      in: "query"
+      schema:
+        type: "array"
+        items:
+          type: "integer"
+      required: false
 
     PaginationLimitParam:
       name: limit

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -32,11 +32,13 @@ public class ExamplePath1Client(
      *
      * @param explodeListQueryParam
      * @param queryParam2
+     * @param intListQueryParam
      */
     @Throws(ApiException::class)
     public fun getExamplePath1(
         explodeListQueryParam: List<String>? = null,
         queryParam2: Int? = null,
+        intListQueryParam: List<Int>? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
         additionalQueryParameters: Map<String, String> = emptyMap(),
     ): ApiResponse<QueryResult> {
@@ -45,6 +47,7 @@ public class ExamplePath1Client(
             .newBuilder()
             .queryParam("explode_list_query_param", explodeListQueryParam, true)
             .queryParam("query_param2", queryParam2)
+            .queryParam("int_list_query_param", intListQueryParam, true)
             .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
             .build()
 

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -38,10 +38,11 @@ public class ExamplePath1Service(
     public fun getExamplePath1(
         explodeListQueryParam: List<String>? = null,
         queryParam2: Int? = null,
+        intListQueryParam: List<Int>? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
     ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.getExamplePath1(explodeListQueryParam, queryParam2, additionalHeaders)
+            apiClient.getExamplePath1(explodeListQueryParam, queryParam2, intListQueryParam, additionalHeaders)
         }
 
     @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }

--- a/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
+++ b/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }

--- a/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
@@ -21,9 +21,9 @@ fun <T : Any> FormBody.Builder.formParam(key: String, value: T?): FormBody.Build
 }
 
 @Suppress("unused")
-fun HttpUrl.Builder.queryParam(key: String, values: List<String>?, explode: Boolean = true) = this.apply {
+fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean = true) = this.apply {
     if (values != null) {
-        if (explode) values.forEach { addQueryParameter(key, it) }
+        if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
 }


### PR DESCRIPTION
Fixed client generation when inlined parameter definition specifies an array of integers:
```
openapi: 3.0.1
paths:
  /v1/someresource:
    delete:
      operationId: deleteSomeResource
      parameters:
        - name: ids
          in: query
          required: false
          schema:
            type: array
            items:
              type: integer
```

Closes #237