### PR TITLE
Kotlin serialization: Numbers

### DIFF
--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
@@ -58,35 +58,10 @@ class KotlinxSerializationPrimitiveTypesTest {
         }
     }
 
-    /**
-     * Custom serializer for [ByteArray] that serializes the value as a base64 string.
-     *
-     * https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#base64
-     */
-    @OptIn(ExperimentalEncodingApi::class)
-    object Base64AsStringSerializer : KSerializer<ByteArray> {
-        private val base64 = Base64.Default
-
-        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
-            "ByteArrayAsBase64Serializer", PrimitiveKind.STRING
-        )
-
-        override fun serialize(encoder: Encoder, value: ByteArray) {
-            val base64Encoded = base64.encode(value)
-            encoder.encodeString(base64Encoded)
-        }
-
-        override fun deserialize(decoder: Decoder): ByteArray {
-            val base64Decoded = decoder.decodeString()
-            return base64.decode(base64Decoded)
-        }
-    }
-
     private val jsonWithCustomSerializers = Json {
         serializersModule = SerializersModule {
             // register contextual custom serializers
             contextual(BigDecimalSerializer)
-            contextual(Base64AsStringSerializer)
         }
         prettyPrint = true
     }
@@ -106,8 +81,8 @@ class KotlinxSerializationPrimitiveTypesTest {
             number = BigDecimal("109288282772724.4225837838838383888"),
             numberFloat = 1.23f,
             numberDouble = 4.56,
-            base64 = byteArrayOf(1, 2, 3),
-            binary = byteArrayOf(4, 5, 6)
+            base64 = "AQID",
+            binary = "BAUG"
         )
 
         val result = jsonWithCustomSerializers.encodeToString(content)
@@ -136,8 +111,8 @@ class KotlinxSerializationPrimitiveTypesTest {
             number = BigDecimal("109288282772724.4225837838838383888"),
             numberFloat = 1.23f,
             numberDouble = 4.56,
-            base64 = byteArrayOf(1, 2, 3),
-            binary = byteArrayOf(4, 5, 6)
+            base64 = "AQID",
+            binary = "BAUG"
         )
 
         assertThat(content.integer).isEqualTo(expectedContent.integer)

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -23,8 +22,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 class KotlinxSerializationPrimitiveTypesTest {
 
@@ -81,8 +78,6 @@ class KotlinxSerializationPrimitiveTypesTest {
             number = BigDecimal("109288282772724.4225837838838383888"),
             numberFloat = 1.23f,
             numberDouble = 4.56,
-            base64 = "AQID",
-            binary = "BAUG"
         )
 
         val result = jsonWithCustomSerializers.encodeToString(content)
@@ -111,8 +106,6 @@ class KotlinxSerializationPrimitiveTypesTest {
             number = BigDecimal("109288282772724.4225837838838383888"),
             numberFloat = 1.23f,
             numberDouble = 4.56,
-            base64 = "AQID",
-            binary = "BAUG"
         )
 
         assertThat(content.integer).isEqualTo(expectedContent.integer)
@@ -127,8 +120,6 @@ class KotlinxSerializationPrimitiveTypesTest {
         assertThat(content.number).isEqualTo(expectedContent.number)
         assertThat(content.numberFloat).isEqualTo(expectedContent.numberFloat)
         assertThat(content.numberDouble).isEqualTo(expectedContent.numberDouble)
-        assertThat(content.base64.contentEquals(expectedContent.base64)).isTrue()
-        assertThat(content.binary.contentEquals(expectedContent.binary)).isTrue()
     }
 
     @Test

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
@@ -1,0 +1,169 @@
+package com.cjbooms.fabrikt.models.kotlinx
+
+import com.example.primitives.models.Content
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonUnquotedLiteral
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+class KotlinxSerializationPrimitiveTypesTest {
+
+    /**
+     * Custom serializer for [BigDecimal] that serializes the value as a string without quotes.
+     *
+     * https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#serializing-large-decimal-numbers
+     */
+    object BigDecimalSerializer : KSerializer<BigDecimal> {
+        override val descriptor = PrimitiveSerialDescriptor(
+            "java.math.BigDecimal", PrimitiveKind.STRING
+        )
+
+        override fun deserialize(decoder: Decoder): BigDecimal {
+            return if (decoder is JsonDecoder) {
+                BigDecimal(decoder.decodeJsonElement().jsonPrimitive.content)
+            } else {
+                BigDecimal(decoder.decodeString())
+            }
+        }
+
+        @OptIn(ExperimentalSerializationApi::class)
+        override fun serialize(encoder: Encoder, value: BigDecimal) {
+            val bigDecimalString = value.toPlainString()
+
+            if (encoder is JsonEncoder) {
+                encoder.encodeJsonElement(JsonUnquotedLiteral(bigDecimalString))
+            } else {
+                encoder.encodeString(bigDecimalString)
+            }
+        }
+    }
+
+    /**
+     * Custom serializer for [ByteArray] that serializes the value as a base64 string.
+     *
+     * https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#base64
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    object Base64AsStringSerializer : KSerializer<ByteArray> {
+        private val base64 = Base64.Default
+
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+            "ByteArrayAsBase64Serializer", PrimitiveKind.STRING
+        )
+
+        override fun serialize(encoder: Encoder, value: ByteArray) {
+            val base64Encoded = base64.encode(value)
+            encoder.encodeString(base64Encoded)
+        }
+
+        override fun deserialize(decoder: Decoder): ByteArray {
+            val base64Decoded = decoder.decodeString()
+            return base64.decode(base64Decoded)
+        }
+    }
+
+    private val jsonWithCustomSerializers = Json {
+        serializersModule = SerializersModule {
+            // register contextual custom serializers
+            contextual(BigDecimalSerializer)
+            contextual(Base64AsStringSerializer)
+        }
+        prettyPrint = true
+    }
+
+    @Test
+    fun `must serialize Content`() {
+        val content = Content(
+            integer = 1,
+            integer32 = 2147483647,
+            integer64 = 9223372036854775807,
+            boolean = true,
+            string = "example",
+            stringUuid = "123e4567-e89b-12d3-a456-426614174000",
+            stringUri = "https://example.org",
+            stringDate = LocalDate.parse("2020-02-04"),
+            stringDateTime = Instant.parse("2024-11-04T12:00:00Z"),
+            number = BigDecimal("109288282772724.4225837838838383888"),
+            numberFloat = 1.23f,
+            numberDouble = 4.56,
+            base64 = byteArrayOf(1, 2, 3),
+            binary = byteArrayOf(4, 5, 6)
+        )
+
+        val result = jsonWithCustomSerializers.encodeToString(content)
+
+        val expected = javaClass.getResource("/primitive_types/content_valid.json")!!.readText()
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `must deserialize Content`() {
+        val jsonString = javaClass.getResource("/primitive_types/content_valid.json")!!.readText()
+
+        val content: Content = jsonWithCustomSerializers.decodeFromString(jsonString)
+
+        val expectedContent = Content(
+            integer = 1,
+            integer32 = 2147483647,
+            integer64 = 9223372036854775807,
+            boolean = true,
+            string = "example",
+            stringUuid = "123e4567-e89b-12d3-a456-426614174000",
+            stringUri = "https://example.org",
+            stringDate = LocalDate.parse("2020-02-04"),
+            stringDateTime = Instant.parse("2024-11-04T12:00:00Z"),
+            number = BigDecimal("109288282772724.4225837838838383888"),
+            numberFloat = 1.23f,
+            numberDouble = 4.56,
+            base64 = byteArrayOf(1, 2, 3),
+            binary = byteArrayOf(4, 5, 6)
+        )
+
+        assertThat(content.integer).isEqualTo(expectedContent.integer)
+        assertThat(content.integer32).isEqualTo(expectedContent.integer32)
+        assertThat(content.integer64).isEqualTo(expectedContent.integer64)
+        assertThat(content.boolean).isEqualTo(expectedContent.boolean)
+        assertThat(content.string).isEqualTo(expectedContent.string)
+        assertThat(content.stringUuid).isEqualTo(expectedContent.stringUuid)
+        assertThat(content.stringUri).isEqualTo(expectedContent.stringUri)
+        assertThat(content.stringDate).isEqualTo(expectedContent.stringDate)
+        assertThat(content.stringDateTime).isEqualTo(expectedContent.stringDateTime)
+        assertThat(content.number).isEqualTo(expectedContent.number)
+        assertThat(content.numberFloat).isEqualTo(expectedContent.numberFloat)
+        assertThat(content.numberDouble).isEqualTo(expectedContent.numberDouble)
+        assertThat(content.base64.contentEquals(expectedContent.base64)).isTrue()
+        assertThat(content.binary.contentEquals(expectedContent.binary)).isTrue()
+    }
+
+    @Test
+    fun `fails to deserialize if custom serializer is not found`() {
+        val jsonString = javaClass.getResource("/primitive_types/content_valid.json")!!.readText()
+
+        val e = assertThrows<SerializationException> {
+            Json.decodeFromString<Content>(jsonString)
+        }
+
+        assertThat(e.message).contains("Serializer for class 'BigDecimal' is not found.")
+    }
+}

--- a/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid.json
+++ b/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid.json
@@ -10,7 +10,5 @@
     "stringDateTime": "2024-11-04T12:00:00Z",
     "number": 109288282772724.4225837838838383888,
     "numberFloat": 1.23,
-    "numberDouble": 4.56,
-    "base64": "AQID",
-    "binary": "BAUG"
+    "numberDouble": 4.56
 }

--- a/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid.json
+++ b/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid.json
@@ -1,0 +1,16 @@
+{
+    "integer": 1,
+    "integer32": 2147483647,
+    "integer64": 9223372036854775807,
+    "boolean": true,
+    "string": "example",
+    "stringUuid": "123e4567-e89b-12d3-a456-426614174000",
+    "stringUri": "https://example.org",
+    "stringDate": "2020-02-04",
+    "stringDateTime": "2024-11-04T12:00:00Z",
+    "number": 109288282772724.4225837838838383888,
+    "numberFloat": 1.23,
+    "numberDouble": 4.56,
+    "base64": "AQID",
+    "binary": "BAUG"
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -115,18 +115,18 @@ object PropertyUtils {
                         }
                         serializationAnnotations.addParameter(property, oasKey)
                     }
-                    serializationAnnotations.addProperty(property, oasKey)
+                    serializationAnnotations.addProperty(property, oasKey, typeInfo)
                     property.addValidationAnnotations(this, validationAnnotations)
                 }
 
                 ClassSettings.PolymorphyType.NONE -> {
                     serializationAnnotations.addParameter(property, oasKey)
-                    serializationAnnotations.addProperty(property, oasKey)
+                    serializationAnnotations.addProperty(property, oasKey, typeInfo)
                     property.addValidationAnnotations(this, validationAnnotations)
                 }
 
                 ClassSettings.PolymorphyType.ONE_OF -> {
-                    serializationAnnotations.addProperty(property, oasKey)
+                    serializationAnnotations.addProperty(property, oasKey, typeInfo)
                     property.addValidationAnnotations(this, validationAnnotations)
                 }
             }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
@@ -21,7 +21,7 @@ object JacksonAnnotations : SerializationAnnotations {
     override fun addSetter(funSpecBuilder: FunSpec.Builder) =
         funSpecBuilder.addAnnotation(JacksonMetadata.anySetter)
 
-    override fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String) =
+    override fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String, kotlinTypeInfo: KotlinTypeInfo): PropertySpec.Builder =
         propertySpecBuilder.addAnnotation(JacksonMetadata.jacksonPropertyAnnotation(oasKey))
 
     override fun addParameter(propertySpecBuilder: PropertySpec.Builder, oasKey: String) =

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -109,10 +109,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                 OasType.Binary -> getOverridableByteArray()
                 OasType.Double -> Double
                 OasType.Float -> Float
-                OasType.Number -> {
-                    if (MutableSettings.serializationLibrary() == KOTLINX_SERIALIZATION) Double
-                    else Numeric
-                }
+                OasType.Number -> Numeric
                 OasType.Int32 -> Integer
                 OasType.Int64 -> BigInt
                 OasType.Integer -> Integer

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -105,8 +105,14 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                     else Uri
                 }
 
-                OasType.Base64String -> ByteArray
-                OasType.Binary -> getOverridableByteArray()
+                OasType.Base64String -> {
+                    if (MutableSettings.serializationLibrary() == KOTLINX_SERIALIZATION) Text // no native ByteArray in kotlinx.serialization
+                    else ByteArray
+                }
+                OasType.Binary -> {
+                    if (MutableSettings.serializationLibrary() == KOTLINX_SERIALIZATION) Text // no native Binary in kotlinx.serialization
+                    else getOverridableByteArray()
+                }
                 OasType.Double -> Double
                 OasType.Float -> Float
                 OasType.Number -> Numeric

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -109,7 +109,10 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                 OasType.Binary -> getOverridableByteArray()
                 OasType.Double -> Double
                 OasType.Float -> Float
-                OasType.Number -> Numeric
+                OasType.Number -> {
+                    if (MutableSettings.serializationLibrary() == KOTLINX_SERIALIZATION) Double
+                    else Numeric
+                }
                 OasType.Int32 -> Integer
                 OasType.Int64 -> BigInt
                 OasType.Integer -> Integer

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -105,14 +105,8 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                     else Uri
                 }
 
-                OasType.Base64String -> {
-                    if (MutableSettings.serializationLibrary() == KOTLINX_SERIALIZATION) Text // no native ByteArray in kotlinx.serialization
-                    else ByteArray
-                }
-                OasType.Binary -> {
-                    if (MutableSettings.serializationLibrary() == KOTLINX_SERIALIZATION) Text // no native Binary in kotlinx.serialization
-                    else getOverridableByteArray()
-                }
+                OasType.Base64String -> ByteArray
+                OasType.Binary -> getOverridableByteArray()
                 OasType.Double -> Double
                 OasType.Float -> Float
                 OasType.Number -> Numeric

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
@@ -42,7 +42,7 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
         funSpecBuilder // not applicable
 
     override fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String, kotlinTypeInfo: KotlinTypeInfo): PropertySpec.Builder {
-        if (kotlinTypeInfo is KotlinTypeInfo.Numeric || kotlinTypeInfo is KotlinTypeInfo.ByteArray) {
+        if (kotlinTypeInfo is KotlinTypeInfo.Numeric) {
             propertySpecBuilder.addAnnotation(AnnotationSpec.builder(Contextual::class).build())
         }
         propertySpecBuilder.addAnnotation(

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
@@ -6,6 +6,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -40,8 +41,15 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
     override fun addSetter(funSpecBuilder: FunSpec.Builder) =
         funSpecBuilder // not applicable
 
-    override fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String) =
-        propertySpecBuilder.addAnnotation(AnnotationSpec.builder(SerialName::class).addMember("%S", oasKey).build())
+    override fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String, kotlinTypeInfo: KotlinTypeInfo): PropertySpec.Builder {
+        if (kotlinTypeInfo is KotlinTypeInfo.Numeric || kotlinTypeInfo is KotlinTypeInfo.ByteArray) {
+            propertySpecBuilder.addAnnotation(AnnotationSpec.builder(Contextual::class).build())
+        }
+        propertySpecBuilder.addAnnotation(
+            AnnotationSpec.builder(SerialName::class).addMember("%S", oasKey).build()
+        )
+        return propertySpecBuilder
+    }
 
     override fun addParameter(propertySpecBuilder: PropertySpec.Builder, oasKey: String) =
         propertySpecBuilder // not applicable

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -20,7 +20,7 @@ sealed interface SerializationAnnotations {
     fun addIgnore(propertySpecBuilder: PropertySpec.Builder): PropertySpec.Builder
     fun addGetter(funSpecBuilder: FunSpec.Builder): FunSpec.Builder
     fun addSetter(funSpecBuilder: FunSpec.Builder): FunSpec.Builder
-    fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String): PropertySpec.Builder
+    fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String, kotlinTypeInfo: KotlinTypeInfo): PropertySpec.Builder
     fun addParameter(propertySpecBuilder: PropertySpec.Builder, oasKey: String): PropertySpec.Builder
     fun addClassAnnotation(typeSpecBuilder: TypeSpec.Builder): TypeSpec.Builder
     fun addBasePolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, propertyName: String): TypeSpec.Builder

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
@@ -28,6 +28,7 @@ class KotlinSerializationModelGeneratorTest {
     @Suppress("unused")
     private fun testCases(): Stream<String> = Stream.of(
         "discriminatedOneOf",
+        "primitiveTypes",
     )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -67,6 +67,7 @@ class ModelGeneratorTest {
         "oneOfMarkerInterface",
         "byteArrayStream",
         "untypedObject",
+        "primitiveTypes",
     )
 
     @BeforeEach

--- a/src/test/resources/examples/primitiveTypes/api.yaml
+++ b/src/test/resources/examples/primitiveTypes/api.yaml
@@ -38,9 +38,3 @@ components:
         numberDouble:
           type: number
           format: double
-        base64:
-          type: string
-          format: byte
-        binary:
-          type: string
-          format: binary

--- a/src/test/resources/examples/primitiveTypes/api.yaml
+++ b/src/test/resources/examples/primitiveTypes/api.yaml
@@ -1,0 +1,46 @@
+openapi: "3.0.0"
+info:
+paths:
+components:
+  schemas:
+    Content:
+      type: object
+      properties:
+        integer:
+          type: integer
+        integer32:
+          type: integer
+          format: int32
+        integer64:
+          type: integer
+          format: int64
+        boolean:
+          type: boolean
+        string:
+          type: string
+        stringUuid:
+          type: string
+          format: uuid
+        stringUri:
+          type: string
+          format: uri
+        stringDate:
+          type: string
+          format: date
+        stringDateTime:
+          type: string
+          format: date-time
+        number:
+          type: number
+        numberFloat:
+          type: number
+          format: float
+        numberDouble:
+          type: number
+          format: double
+        base64:
+          type: string
+          format: byte
+        binary:
+          type: string
+          format: binary

--- a/src/test/resources/examples/primitiveTypes/models/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/Content.kt
@@ -7,7 +7,6 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.Boolean
-import kotlin.ByteArray
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -51,10 +50,4 @@ public data class Content(
   @param:JsonProperty("numberDouble")
   @get:JsonProperty("numberDouble")
   public val numberDouble: Double? = null,
-  @param:JsonProperty("base64")
-  @get:JsonProperty("base64")
-  public val base64: ByteArray? = null,
-  @param:JsonProperty("binary")
-  @get:JsonProperty("binary")
-  public val binary: ByteArray? = null,
 )

--- a/src/test/resources/examples/primitiveTypes/models/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/Content.kt
@@ -1,0 +1,60 @@
+package examples.primitiveTypes.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import java.math.BigDecimal
+import java.net.URI
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import kotlin.Boolean
+import kotlin.ByteArray
+import kotlin.Double
+import kotlin.Float
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+
+public data class Content(
+  @param:JsonProperty("integer")
+  @get:JsonProperty("integer")
+  public val integer: Int? = null,
+  @param:JsonProperty("integer32")
+  @get:JsonProperty("integer32")
+  public val integer32: Int? = null,
+  @param:JsonProperty("integer64")
+  @get:JsonProperty("integer64")
+  public val integer64: Long? = null,
+  @param:JsonProperty("boolean")
+  @get:JsonProperty("boolean")
+  public val boolean: Boolean? = null,
+  @param:JsonProperty("string")
+  @get:JsonProperty("string")
+  public val string: String? = null,
+  @param:JsonProperty("stringUuid")
+  @get:JsonProperty("stringUuid")
+  public val stringUuid: UUID? = null,
+  @param:JsonProperty("stringUri")
+  @get:JsonProperty("stringUri")
+  public val stringUri: URI? = null,
+  @param:JsonProperty("stringDate")
+  @get:JsonProperty("stringDate")
+  public val stringDate: LocalDate? = null,
+  @param:JsonProperty("stringDateTime")
+  @get:JsonProperty("stringDateTime")
+  public val stringDateTime: OffsetDateTime? = null,
+  @param:JsonProperty("number")
+  @get:JsonProperty("number")
+  public val number: BigDecimal? = null,
+  @param:JsonProperty("numberFloat")
+  @get:JsonProperty("numberFloat")
+  public val numberFloat: Float? = null,
+  @param:JsonProperty("numberDouble")
+  @get:JsonProperty("numberDouble")
+  public val numberDouble: Double? = null,
+  @param:JsonProperty("base64")
+  @get:JsonProperty("base64")
+  public val base64: ByteArray? = null,
+  @param:JsonProperty("binary")
+  @get:JsonProperty("binary")
+  public val binary: ByteArray? = null,
+)

--- a/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
@@ -40,8 +40,4 @@ public data class Content(
   public val numberFloat: Float? = null,
   @SerialName("numberDouble")
   public val numberDouble: Double? = null,
-  @SerialName("base64")
-  public val base64: String? = null,
-  @SerialName("binary")
-  public val binary: String? = null,
 )

--- a/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
@@ -2,7 +2,6 @@ package examples.primitiveTypes.models
 
 import java.math.BigDecimal
 import kotlin.Boolean
-import kotlin.ByteArray
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -41,10 +40,8 @@ public data class Content(
   public val numberFloat: Float? = null,
   @SerialName("numberDouble")
   public val numberDouble: Double? = null,
-  @Contextual
   @SerialName("base64")
-  public val base64: ByteArray? = null,
-  @Contextual
+  public val base64: String? = null,
   @SerialName("binary")
-  public val binary: ByteArray? = null,
+  public val binary: String? = null,
 )

--- a/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
@@ -1,5 +1,6 @@
 package examples.primitiveTypes.models
 
+import java.math.BigDecimal
 import kotlin.Boolean
 import kotlin.ByteArray
 import kotlin.Double
@@ -9,6 +10,7 @@ import kotlin.Long
 import kotlin.String
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -32,14 +34,17 @@ public data class Content(
   public val stringDate: LocalDate? = null,
   @SerialName("stringDateTime")
   public val stringDateTime: Instant? = null,
+  @Contextual
   @SerialName("number")
-  public val number: Double? = null,
+  public val number: BigDecimal? = null,
   @SerialName("numberFloat")
   public val numberFloat: Float? = null,
   @SerialName("numberDouble")
   public val numberDouble: Double? = null,
+  @Contextual
   @SerialName("base64")
   public val base64: ByteArray? = null,
+  @Contextual
   @SerialName("binary")
   public val binary: ByteArray? = null,
 )

--- a/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
@@ -1,0 +1,45 @@
+package examples.primitiveTypes.models
+
+import kotlin.Boolean
+import kotlin.ByteArray
+import kotlin.Double
+import kotlin.Float
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Content(
+  @SerialName("integer")
+  public val integer: Int? = null,
+  @SerialName("integer32")
+  public val integer32: Int? = null,
+  @SerialName("integer64")
+  public val integer64: Long? = null,
+  @SerialName("boolean")
+  public val boolean: Boolean? = null,
+  @SerialName("string")
+  public val string: String? = null,
+  @SerialName("stringUuid")
+  public val stringUuid: String? = null,
+  @SerialName("stringUri")
+  public val stringUri: String? = null,
+  @SerialName("stringDate")
+  public val stringDate: LocalDate? = null,
+  @SerialName("stringDateTime")
+  public val stringDateTime: Instant? = null,
+  @SerialName("number")
+  public val number: Double? = null,
+  @SerialName("numberFloat")
+  public val numberFloat: Float? = null,
+  @SerialName("numberDouble")
+  public val numberDouble: Double? = null,
+  @SerialName("base64")
+  public val base64: ByteArray? = null,
+  @SerialName("binary")
+  public val binary: ByteArray? = null,
+)


### PR DESCRIPTION
With Jackson we use Java's BigDecimal for numbers without a format keyword, but because Java types are not serializable with Kotlin Serialization we need to use a Kotlin native type instead. ~~I believe the best we can do is Double although it has lower precision than BigDecimal.~~

Alternatively we could allow the user to provide his own custom serializer for BigDecimal (and other Java types like UUID and URI) as [discussed in this issue](https://github.com/cjbooms/fabrikt/issues/362) by annotating the field with `@Contexual`.

**Update:** 

In order to not loose precision we annotate the field with `@Contexual` and leave it to the user to provide a custom serializer. This is aligns with the [recommended approach](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#serializing-large-decimal-numbers) in the documentation. 

We can add the same possibility for string formats (`uuid`, `uri`, `base64`, `binary`), but because no precision is lost we could add it as a configuration option. I prefer to do that in a future PR.