### PR TITLE
Fix inheritance of array properties

### DIFF
--- a/src/test/resources/examples/polymorphicModels/api.yaml
+++ b/src/test/resources/examples/polymorphicModels/api.yaml
@@ -15,6 +15,7 @@ components:
         - generation
         - first_name
         - last_name
+        - pets
       properties:
         generation:
           type: string
@@ -22,6 +23,10 @@ components:
           type: string
         last_name:
           type: string
+        pets:
+          type: array
+          items:
+            $ref: "#/components/schemas/Pet"
     PolymorphicTypeOne:
       allOf:
         - $ref: "#/components/schemas/PolymorphicSuperType"
@@ -45,3 +50,11 @@ components:
         some_integer_propery:
           type: integer
           format: int32
+
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name

--- a/src/test/resources/examples/polymorphicModels/models/Pet.kt
+++ b/src/test/resources/examples/polymorphicModels/models/Pet.kt
@@ -1,0 +1,12 @@
+package examples.polymorphicModels.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class Pet(
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  @get:NotNull
+  public val name: String,
+)

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicSuperType.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicSuperType.kt
@@ -3,6 +3,7 @@ package examples.polymorphicModels.models
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.collections.List
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -16,6 +17,7 @@ import kotlin.String
 public sealed class PolymorphicSuperType(
   public open val firstName: String,
   public open val lastName: String,
+  public open val pets: List<Pet>,
 ) {
   public abstract val generation: String
 }

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOne.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOne.kt
@@ -1,8 +1,10 @@
 package examples.polymorphicModels.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.String
+import kotlin.collections.List
 
 public data class PolymorphicTypeOne(
   @param:JsonProperty("first_name")
@@ -13,6 +15,11 @@ public data class PolymorphicTypeOne(
   @get:JsonProperty("last_name")
   @get:NotNull
   override val lastName: String,
+  @param:JsonProperty("pets")
+  @get:JsonProperty("pets")
+  @get:NotNull
+  @get:Valid
+  override val pets: List<Pet>,
   @param:JsonProperty("child_one_name")
   @get:JsonProperty("child_one_name")
   public val childOneName: String? = null,
@@ -20,4 +27,4 @@ public data class PolymorphicTypeOne(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "PolymorphicTypeOne",
-) : PolymorphicSuperType(firstName, lastName)
+) : PolymorphicSuperType(firstName, lastName, pets)

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneAnotherRef.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneAnotherRef.kt
@@ -1,8 +1,10 @@
 package examples.polymorphicModels.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.String
+import kotlin.collections.List
 
 public data class PolymorphicTypeOneAnotherRef(
   @param:JsonProperty("first_name")
@@ -13,6 +15,11 @@ public data class PolymorphicTypeOneAnotherRef(
   @get:JsonProperty("last_name")
   @get:NotNull
   override val lastName: String,
+  @param:JsonProperty("pets")
+  @get:JsonProperty("pets")
+  @get:NotNull
+  @get:Valid
+  override val pets: List<Pet>,
   @param:JsonProperty("child_one_name")
   @get:JsonProperty("child_one_name")
   public val childOneName: String? = null,
@@ -20,4 +27,4 @@ public data class PolymorphicTypeOneAnotherRef(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "PolymorphicTypeOne",
-) : PolymorphicSuperType(firstName, lastName)
+) : PolymorphicSuperType(firstName, lastName, pets)

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneRef.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneRef.kt
@@ -1,8 +1,10 @@
 package examples.polymorphicModels.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.String
+import kotlin.collections.List
 
 public data class PolymorphicTypeOneRef(
   @param:JsonProperty("first_name")
@@ -13,6 +15,11 @@ public data class PolymorphicTypeOneRef(
   @get:JsonProperty("last_name")
   @get:NotNull
   override val lastName: String,
+  @param:JsonProperty("pets")
+  @get:JsonProperty("pets")
+  @get:NotNull
+  @get:Valid
+  override val pets: List<Pet>,
   @param:JsonProperty("child_one_name")
   @get:JsonProperty("child_one_name")
   public val childOneName: String? = null,
@@ -20,4 +27,4 @@ public data class PolymorphicTypeOneRef(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "PolymorphicTypeOne",
-) : PolymorphicSuperType(firstName, lastName)
+) : PolymorphicSuperType(firstName, lastName, pets)

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwo.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwo.kt
@@ -1,9 +1,11 @@
 package examples.polymorphicModels.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.Int
 import kotlin.String
+import kotlin.collections.List
 
 public data class PolymorphicTypeTwo(
   @param:JsonProperty("first_name")
@@ -14,6 +16,11 @@ public data class PolymorphicTypeTwo(
   @get:JsonProperty("last_name")
   @get:NotNull
   override val lastName: String,
+  @param:JsonProperty("pets")
+  @get:JsonProperty("pets")
+  @get:NotNull
+  @get:Valid
+  override val pets: List<Pet>,
   @param:JsonProperty("some_integer_propery")
   @get:JsonProperty("some_integer_propery")
   public val someIntegerPropery: Int? = null,
@@ -24,4 +31,4 @@ public data class PolymorphicTypeTwo(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "polymorphic_type_two",
-) : PolymorphicSuperType(firstName, lastName)
+) : PolymorphicSuperType(firstName, lastName, pets)

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwoRef.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwoRef.kt
@@ -1,9 +1,11 @@
 package examples.polymorphicModels.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 import kotlin.Int
 import kotlin.String
+import kotlin.collections.List
 
 public data class PolymorphicTypeTwoRef(
   @param:JsonProperty("first_name")
@@ -14,6 +16,11 @@ public data class PolymorphicTypeTwoRef(
   @get:JsonProperty("last_name")
   @get:NotNull
   override val lastName: String,
+  @param:JsonProperty("pets")
+  @get:JsonProperty("pets")
+  @get:NotNull
+  @get:Valid
+  override val pets: List<Pet>,
   @param:JsonProperty("some_integer_propery")
   @get:JsonProperty("some_integer_propery")
   public val someIntegerPropery: Int? = null,
@@ -24,4 +31,4 @@ public data class PolymorphicTypeTwoRef(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "polymorphic_type_two",
-) : PolymorphicSuperType(firstName, lastName)
+) : PolymorphicSuperType(firstName, lastName, pets)


### PR DESCRIPTION
Properties of the array type that contain non-inlined objects/enums are not inherited correctly in the current implementation - generic parameter is prefixed with the name of the enclosing class, e.g. instead of `List&lt;Pet&gt;` we have `List&lt;EnclosingTypePet&gt;`