### PR TITLE
add springboot's http interface generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                               | CHOOSE ONE OF: |
 |                               |   `OK_HTTP` - Generate OkHttp client. |
 |                               |   `OPEN_FEIGN` - Generate OpenFeign client. |
+|                               |   `SPRING_HTTP_INTERFACE` - Generate Spring HTTP Interface. |
 |   `--http-controller-opts`    | Select the options for the controllers that you want to be generated. |
 |                               | CHOOSE ANY OF: |
 |                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions |

--- a/end2end-tests/spring-http-interface/build.gradle.kts
+++ b/end2end-tests/spring-http-interface/build.gradle.kts
@@ -1,0 +1,70 @@
+val fabrikt: Configuration by configurations.creating
+
+val generationDir = "$buildDir/generated"
+val apiFile = "${rootProject.projectDir}/src/test/resources/examples/okHttpClient/api.yaml"
+
+sourceSets {
+    main { java.srcDirs("$generationDir/src/main/kotlin") }
+    test { java.srcDirs("$generationDir/src/test/kotlin") }
+}
+
+plugins {
+    kotlin("jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+val jacksonVersion: String by rootProject.extra
+val junitVersion: String by rootProject.extra
+
+dependencies {
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
+    implementation("org.springframework.boot:spring-boot-starter-web:3.4.3")
+    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
+    implementation("javax.validation:validation-api:2.0.1.Final")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    testImplementation("org.assertj:assertj-core:3.24.2")
+    testImplementation("org.wiremock:wiremock:3.3.1")
+    testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+}
+
+tasks {
+    val generateCode by creating(JavaExec::class) {
+        inputs.files(apiFile)
+        outputs.dir(generationDir)
+        outputs.cacheIf { true }
+        classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
+        mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
+        args = listOf(
+            "--output-directory", generationDir,
+            "--base-package", "com.example",
+            "--api-file", apiFile,
+            "--targets", "http_models",
+            "--targets", "client",
+            "--http-client-target", "SPRING_HTTP_INTERFACE",
+        )
+        dependsOn(":jar")
+        dependsOn(":shadowJar")
+    }
+
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+        dependsOn(generateCode)
+    }
+
+
+    withType<Test> {
+        useJUnitPlatform()
+        jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED")
+    }
+}

--- a/end2end-tests/spring-http-interface/src/test/kotlin/com/cjbooms/fabrikt/clients/AdditionalQueryParametersTest.kt
+++ b/end2end-tests/spring-http-interface/src/test/kotlin/com/cjbooms/fabrikt/clients/AdditionalQueryParametersTest.kt
@@ -1,0 +1,67 @@
+package com.cjbooms.fabrikt.clients
+
+import com.example.client.ExamplePath1Client
+import com.example.models.FirstModel
+import com.example.models.QueryResult
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.marcinziolo.kotlin.wiremock.contains
+import com.marcinziolo.kotlin.wiremock.get
+import com.marcinziolo.kotlin.wiremock.like
+import com.marcinziolo.kotlin.wiremock.returns
+import java.net.ServerSocket
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.support.RestClientAdapter
+import org.springframework.web.service.invoker.HttpServiceProxyFactory
+import org.springframework.web.service.invoker.createClient
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AdditionalQueryParametersTest {
+    private val port: Int = ServerSocket(0).use { socket -> socket.localPort }
+    private val wiremock: WireMockServer = WireMockServer(
+        WireMockConfiguration.options().port(port).notifier(ConsoleNotifier(true)))
+    private val mapper = ObjectMapper()
+    private val examplePath1Client: ExamplePath1Client = run {
+        val restClient = RestClient.builder()
+            .baseUrl("http://localhost:$port")
+            .messageConverters(listOf(MappingJackson2HttpMessageConverter(mapper)))
+            .build()
+        val adapter = RestClientAdapter.create(restClient)
+        val factory = HttpServiceProxyFactory.builderFor(adapter).build()
+        factory.createClient()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        wiremock.start()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        wiremock.resetAll()
+        wiremock.stop()
+    }
+
+    @Test
+    fun `additional query parameters are properly appended to requests`() {
+        val expectedResponse = QueryResult(listOf(FirstModel(id = "the parameter was there!")))
+        wiremock.get {
+            urlPath like "/example-path-1"
+            queryParams contains "unspecified_param" like "some_value"
+        } returns {
+            statusCode = 200
+            header = "Content-Type" to "application/json"
+            body = mapper.writeValueAsString(expectedResponse)
+        }
+        val result = examplePath1Client.getExamplePath1(additionalQueryParameters = mapOf("unspecified_param" to "some_value"))
+        Assertions.assertThat(result).isEqualTo(expectedResponse)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     "end2end-tests:okhttp",
     "end2end-tests:openfeign",
     "end2end-tests:ktor",
+    "end2end-tests:spring-http-interface",
     "end2end-tests:models-jackson",
     "end2end-tests:models-kotlinx",
     "playground",

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -4,9 +4,9 @@ import com.cjbooms.fabrikt.generators.JakartaAnnotations
 import com.cjbooms.fabrikt.generators.JavaxValidationAnnotations
 import com.cjbooms.fabrikt.generators.NoValidationAnnotations
 import com.cjbooms.fabrikt.generators.ValidationAnnotations
-import com.cjbooms.fabrikt.model.SerializationAnnotations
 import com.cjbooms.fabrikt.model.JacksonAnnotations
 import com.cjbooms.fabrikt.model.KotlinxSerializationAnnotations
+import com.cjbooms.fabrikt.model.SerializationAnnotations
 
 enum class CodeGenerationType(val description: String) {
     HTTP_MODELS(
@@ -33,6 +33,7 @@ enum class ClientCodeGenOptionType(private val description: String) {
     ;
 
     override fun toString() = "`${super.toString()}` - $description"
+
     companion object {
         const val DEFAULT_OPEN_FEIGN_CLIENT_NAME = "fabrikt-client"
     }
@@ -40,7 +41,9 @@ enum class ClientCodeGenOptionType(private val description: String) {
 
 enum class ClientCodeGenTargetType(val description: String) {
     OK_HTTP("Generate OkHttp client."),
-    OPEN_FEIGN("Generate OpenFeign client.");
+    OPEN_FEIGN("Generate OpenFeign client."),
+    SPRING_HTTP_INTERFACE("Generate Spring HTTP Interface."),
+    ;
 
     override fun toString() = "`${super.toString()}` - $description"
 
@@ -67,6 +70,7 @@ enum class ControllerCodeGenOptionType(val description: String) {
     SUSPEND_MODIFIER("This option adds the suspend modifier to the generated controller functions"),
     AUTHENTICATION("This option adds the authentication parameter to the generated controller functions"),
     COMPLETION_STAGE("This option makes generated controller functions have Type CompletionStage<T> (works only with Spring Controller generator)");
+
     override fun toString() = "`${super.toString()}` - $description"
 }
 
@@ -92,13 +96,18 @@ enum class CodeGenTypeOverride(val description: String) {
     DATE_AS_STRING("Ignore string format `date` and use `String` as the type"),
     DATETIME_AS_STRING("Ignore string format `date-time` and use `String` as the type"),
     BYTEARRAY_AS_INPUTSTREAM("Use `InputStream` as ByteArray type. Defaults to `ByteArray`");
+
     override fun toString() = "`${super.toString()}` - $description"
 }
 
 enum class ValidationLibrary(val description: String, val annotations: ValidationAnnotations) {
-    JAVAX_VALIDATION("Use `javax.validation` annotations in generated model classes (default)", JavaxValidationAnnotations),
+    JAVAX_VALIDATION(
+        "Use `javax.validation` annotations in generated model classes (default)",
+        JavaxValidationAnnotations
+    ),
     JAKARTA_VALIDATION("Use `jakarta.validation` annotations in generated model classes", JakartaAnnotations),
     NO_VALIDATION("Use no validation annotations in generated model classes", NoValidationAnnotations);
+
     override fun toString() = "`${super.toString()}` - $description"
 
     companion object {
@@ -119,7 +128,10 @@ enum class ExternalReferencesResolutionMode(val description: String) {
 
 enum class SerializationLibrary(val description: String, val serializationAnnotations: SerializationAnnotations) {
     JACKSON("Use Jackson for serialization and deserialization", JacksonAnnotations),
-    KOTLINX_SERIALIZATION("Use kotlinx.serialization for serialization and deserialization", KotlinxSerializationAnnotations);
+    KOTLINX_SERIALIZATION(
+        "Use kotlinx.serialization for serialization and deserialization",
+        KotlinxSerializationAnnotations
+    );
 
     override fun toString() = "`${super.toString()}` - $description"
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -8,6 +8,7 @@ import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.generators.client.OkHttpClientGenerator
 import com.cjbooms.fabrikt.generators.client.OpenFeignInterfaceGenerator
+import com.cjbooms.fabrikt.generators.client.SpringHttpInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.KtorControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.MicronautControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.SpringControllerInterfaceGenerator
@@ -48,6 +49,7 @@ class CodeGenerator(
         val clientGenerator = when (MutableSettings.clientTarget()) {
             ClientCodeGenTargetType.OK_HTTP -> OkHttpClientGenerator(packages, sourceApi, srcPath)
             ClientCodeGenTargetType.OPEN_FEIGN -> OpenFeignInterfaceGenerator(packages, sourceApi)
+            ClientCodeGenTargetType.SPRING_HTTP_INTERFACE -> SpringHttpInterfaceGenerator(packages, sourceApi)
         }
         val options = MutableSettings.clientOptions()
         val clientFiles = clientGenerator.generate(options).files

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -125,7 +125,7 @@ object ClientGeneratorUtils {
     }
 
     /**
-     * Adds suspend as modified to the func spec so that i can be used with CoroutineFeign
+     * Add suspend as modified to method definitions on supported clients, ex. CoroutineFeign, Spring HTTP Interface.
      */
     fun FunSpec.Builder.addSuspendModifier(options: Set<ClientCodeGenOptionType>): FunSpec.Builder {
         if (options.contains(ClientCodeGenOptionType.SUSPEND_MODIFIER)) {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators.client
 
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaType
@@ -10,7 +11,9 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleSuccessResponseS
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.OasDefault
+import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports.RESPONSE_ENTITY
 import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
+import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
@@ -21,6 +24,7 @@ import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
@@ -28,6 +32,7 @@ import com.squareup.kotlinpoet.asTypeName
 object ClientGeneratorUtils {
     const val ACCEPT_HEADER_NAME = "Accept"
     const val ACCEPT_HEADER_VARIABLE_NAME = "acceptHeader"
+    const val CONTENT_TYPE_HEADER_NAME = "Content-Type"
     const val ADDITIONAL_HEADERS_PARAMETER_NAME = "additionalHeaders"
     const val ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME = "additionalQueryParameters"
 
@@ -63,7 +68,12 @@ object ClientGeneratorUtils {
     fun deriveClientParameters(path: Path, operation: Operation, basePackage: String): List<IncomingParameter> {
         fun needsAcceptHeaderParameter(path: Path, operation: Operation): Boolean {
             val hasAcceptParameter = GeneratorUtils.mergeParameters(path.parameters, operation.parameters)
-                .any { parameter -> parameter.`in` == "header" && parameter.name.equals(ACCEPT_HEADER_NAME, ignoreCase = true) }
+                .any { parameter ->
+                    parameter.`in` == "header" && parameter.name.equals(
+                        ACCEPT_HEADER_NAME,
+                        ignoreCase = true
+                    )
+                }
             return operation.hasMultipleContentMediaTypes() == true && !hasAcceptParameter
         }
 
@@ -91,7 +101,8 @@ object ClientGeneratorUtils {
 
     fun FunSpec.Builder.addIncomingParameters(
         parameters: List<IncomingParameter>,
-        annotateRequestParameterWith: ((parameter: RequestParameter) -> AnnotationSpec?)? = null
+        annotateRequestParameterWith: ((parameter: RequestParameter) -> AnnotationSpec?)? = null,
+        annotateBodyParameterWith: ((parameter: BodyParameter) -> AnnotationSpec?)? = null,
     ): FunSpec.Builder {
         val specs = parameters.map {
             val builder = it.toParameterSpecBuilder()
@@ -103,8 +114,33 @@ object ClientGeneratorUtils {
                     builder.addAnnotation(annotationSpec)
                 }
             }
+            if (it is BodyParameter) {
+                annotateBodyParameterWith?.invoke(it)?.let { annotationSpec ->
+                    builder.addAnnotation(annotationSpec)
+                }
+            }
             builder.build()
         }
         return this.addParameters(specs)
+    }
+
+    /**
+     * Adds suspend as modified to the func spec so that i can be used with CoroutineFeign
+     */
+    fun FunSpec.Builder.addSuspendModifier(options: Set<ClientCodeGenOptionType>): FunSpec.Builder {
+        if (options.contains(ClientCodeGenOptionType.SUSPEND_MODIFIER)) {
+            this.addModifiers(KModifier.SUSPEND)
+        }
+        return this
+    }
+
+    /**
+     * Adds a ResponseEntity around the returned object so that we can get headers and statuscodes
+     */
+    fun TypeName.optionallyParameterizeWithResponseEntity(options: Set<ClientCodeGenOptionType>): TypeName {
+        if (options.contains(ClientCodeGenOptionType.SPRING_RESPONSE_ENTITY_WRAPPER)) {
+            return RESPONSE_ENTITY.parameterizedBy(this)
+        }
+        return this
     }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
@@ -10,11 +10,12 @@ import com.cjbooms.fabrikt.generators.TypeFactory
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ADDITIONAL_HEADERS_PARAMETER_NAME
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingParameters
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addSuspendModifier
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.getReturnType
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.optionallyParameterizeWithResponseEntity
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.metadata.OpenFeignAnnotations
-import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports.RESPONSE_ENTITY
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Clients
 import com.cjbooms.fabrikt.model.GeneratedFile
@@ -34,11 +35,8 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.buildCodeBlock
-
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 
 class OpenFeignInterfaceGenerator(
     private val packages: Packages,
@@ -160,7 +158,7 @@ class OpenFeignInterfaceGenerator(
         }
 
         private fun List<IncomingParameter>.getPathAndQueryParameters():
-            Pair<List<RequestParameter>, List<RequestParameter>> {
+                Pair<List<RequestParameter>, List<RequestParameter>> {
             val queryParameters = mutableListOf<RequestParameter>()
             val pathVariables = mutableListOf<RequestParameter>()
             for (parameter in this) {
@@ -286,25 +284,5 @@ class OpenFeignInterfaceGenerator(
                 }.toString()
             }
         }
-    }
-
-    /**
-     * Adds suspend as modified to the func spec so that i can be used with CoroutineFeign
-     */
-    private fun FunSpec.Builder.addSuspendModifier(options: Set<ClientCodeGenOptionType>): FunSpec.Builder {
-        if (options.contains(ClientCodeGenOptionType.SUSPEND_MODIFIER)) {
-            this.addModifiers(KModifier.SUSPEND)
-        }
-        return this
-    }
-
-    /**
-     * Adds a ResponseEntity around the returned object so that we can get headers and statuscodes
-     */
-    private fun TypeName.optionallyParameterizeWithResponseEntity(options: Set<ClientCodeGenOptionType>): TypeName {
-        if (options.contains(ClientCodeGenOptionType.SPRING_RESPONSE_ENTITY_WRAPPER)) {
-            return RESPONSE_ENTITY.parameterizedBy(this)
-        }
-        return this
     }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -1,0 +1,273 @@
+package com.cjbooms.fabrikt.generators.client
+
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.functionName
+import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaType
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
+import com.cjbooms.fabrikt.generators.TypeFactory
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ADDITIONAL_HEADERS_PARAMETER_NAME
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingParameters
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addSuspendModifier
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.getReturnType
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.optionallyParameterizeWithResponseEntity
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
+import com.cjbooms.fabrikt.generators.client.metadata.SpringHttpInterfaceAnnotations
+import com.cjbooms.fabrikt.model.ClientType
+import com.cjbooms.fabrikt.model.Clients
+import com.cjbooms.fabrikt.model.Destinations
+import com.cjbooms.fabrikt.model.GeneratedFile
+import com.cjbooms.fabrikt.model.HeaderParam
+import com.cjbooms.fabrikt.model.IncomingParameter
+import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.model.PathParam
+import com.cjbooms.fabrikt.model.QueryParam
+import com.cjbooms.fabrikt.model.RequestParameter
+import com.cjbooms.fabrikt.model.SimpleFile
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.github.javaparser.utils.CodeGenerationUtils
+import com.reprezen.kaizen.oasparser.model3.Operation
+import com.reprezen.kaizen.oasparser.model3.Path
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.buildCodeBlock
+
+class SpringHttpInterfaceGenerator(
+    private val packages: Packages,
+    private val api: SourceApi,
+    private val srcPath: java.nio.file.Path = Destinations.MAIN_KT_SOURCE
+) : ClientGenerator {
+    override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
+        val clientTypes = api.openApi3.routeToPaths().map { (resourceName, paths) ->
+            val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
+                path.operations.map { (verb, operation) ->
+                    buildFunction(path, resource, operation, verb, options)
+                }
+            }
+
+            val clientType = TypeSpec.interfaceBuilder(simpleClientName(resourceName))
+                .addAnnotation(generatedAnnotationSpec())
+                .addAnnotation(AnnotationSpec.builder(Suppress::class).addMember("%S", "unused").build())
+                .addFunctions(funcSpecs)
+                .build()
+
+            ClientType(clientType, packages.base)
+        }.toSet()
+
+        return Clients(clientTypes)
+    }
+
+    private fun buildFunction(
+        path: Path,
+        resource: String,
+        operation: Operation,
+        verb: String,
+        options: Set<ClientCodeGenOptionType>,
+    ): FunSpec {
+        val parameters = deriveClientParameters(path, operation, packages.base)
+        return FunSpec
+            .builder(functionName(operation, resource, verb))
+            .addModifiers(KModifier.ABSTRACT)
+            .addKdoc(operation.toKdoc(parameters))
+            .addHttpExchangeAnnotation(operation, resource, parameters, verb)
+            .addSuspendModifier(options)
+            .addIncomingParameters(
+                parameters,
+                annotateRequestParameterWith = { parameter ->
+                    when (parameter.parameterLocation) {
+                        is QueryParam -> {
+                            SpringHttpInterfaceAnnotations.requestParamBuilder()
+                                .addMember("%S", parameter.name)
+                                .build()
+                        }
+
+                        is HeaderParam -> {
+                            SpringHttpInterfaceAnnotations.requestHeaderBuilder()
+                                .addMember("%S", parameter.name)
+                                .build()
+                        }
+
+                        is PathParam -> {
+                            SpringHttpInterfaceAnnotations.pathVariableBuilder()
+                                .addMember("%S", parameter.name)
+                                .build()
+                        }
+                    }
+                },
+                annotateBodyParameterWith = { _ ->
+                    SpringHttpInterfaceAnnotations.requestBodyBuilder()
+                        .build()
+                }
+            )
+            .addParameter(
+                ParameterSpec.builder(
+                    ADDITIONAL_HEADERS_PARAMETER_NAME,
+                    TypeFactory.createMapOfStringToNonNullType(Any::class.asTypeName()),
+                )
+                    .addAnnotation(SpringHttpInterfaceAnnotations.requestHeaderBuilder().build())
+                    .defaultValue("emptyMap()")
+                    .build(),
+            )
+            .addParameter(
+                ParameterSpec.builder(
+                    ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME,
+                    TypeFactory.createMapOfStringToNonNullType(Any::class.asTypeName()),
+                )
+                    .addAnnotation(SpringHttpInterfaceAnnotations.requestParamBuilder().build())
+                    .defaultValue("emptyMap()")
+                    .build(),
+            )
+            .returns(
+                operation
+                    .getReturnType(packages)
+                    .optionallyParameterizeWithResponseEntity(options)
+            )
+            .build()
+    }
+
+    private fun FunSpec.Builder.addHttpExchangeAnnotation(
+        operation: Operation,
+        resource: String,
+        parameters: List<IncomingParameter>,
+        verb: String,
+    ): FunSpec.Builder = apply {
+        val annotation = HttpExchangeAnnotationBuilder(operation, resource, parameters, verb).build()
+        addAnnotation(annotation)
+    }
+
+    private class HttpExchangeAnnotationBuilder(
+        private val operation: Operation,
+        private val resource: String,
+        private val parameters: List<IncomingParameter>,
+        private val verb: String,
+    ) {
+        fun build(): AnnotationSpec {
+            val headerParams = parameters.getHeaderParameters()
+
+            return SpringHttpInterfaceAnnotations.httpExchangeBuilder()
+                .addUrl()
+                .addMember("method=%S", verb.uppercase())
+                .addContentType(headerParams)
+                .addAccepts(headerParams)
+                .addHeaders(headerParams)
+                .build()
+        }
+
+        private fun AnnotationSpec.Builder.addUrl(): AnnotationSpec.Builder = apply {
+            val pathParameters = parameters.getPathParameters()
+            val resolvedResource = resourceWithDeduplicatedParamNames(resource, pathParameters)
+
+            addMember("url=%S", resolvedResource)
+        }
+
+        private fun AnnotationSpec.Builder.addContentType(
+            headerParams: List<RequestParameter>
+        ): AnnotationSpec.Builder = apply {
+            val contentType = headerParams.filter { header ->
+                header.typeInfo is KotlinTypeInfo.Enum && header.typeInfo.entries.size == 1
+            }.singleOrNull { header ->
+                header.name == ClientGeneratorUtils.CONTENT_TYPE_HEADER_NAME
+            }
+
+            if (contentType != null) {
+                contentType.typeInfo as KotlinTypeInfo.Enum
+                addMember("contentType=%S", contentType.typeInfo.entries.first())
+            }
+        }
+
+        private fun AnnotationSpec.Builder.addAccepts(
+            headerParams: List<RequestParameter>,
+        ): AnnotationSpec.Builder = apply {
+            val acceptHeaders = headerParams.filter { header ->
+                header.typeInfo is KotlinTypeInfo.Enum && header.typeInfo.entries.size == 1
+            }.filter { header ->
+                header.name == ClientGeneratorUtils.ACCEPT_HEADER_NAME
+            }.map { header ->
+                header.typeInfo as KotlinTypeInfo.Enum
+                buildCodeBlock {
+                    add("%S", header.typeInfo.entries.first())
+                }
+            }.takeIf { it.isNotEmpty() }
+                ?: run {
+                    // Add default accept header
+                    val block = operation.getPrimaryContentMediaType()?.key?.let { mediaType ->
+                        buildCodeBlock {
+                            add("%S", mediaType)
+                        }
+                    }
+                    listOfNotNull(block)
+                }
+
+            if (acceptHeaders.isNotEmpty()) {
+                addMember("accept=%L", acceptHeaders)
+            }
+        }
+
+        private fun AnnotationSpec.Builder.addHeaders(
+            headerParams: List<RequestParameter>,
+        ): AnnotationSpec.Builder = apply {
+            val headerValues = headerParams.filter { header ->
+                header.typeInfo is KotlinTypeInfo.Enum && header.typeInfo.entries.size == 1
+            }.filterNot { header ->
+                header.name == ClientGeneratorUtils.ACCEPT_HEADER_NAME
+            }.map { header ->
+                header.typeInfo as KotlinTypeInfo.Enum
+                buildCodeBlock {
+                    add("%S=%S", header.originalName, header.typeInfo.entries.first())
+                }
+            }
+
+            if (headerValues.isNotEmpty()) {
+                addMember("headers=%L", headerValues)
+            }
+        }
+
+        private fun List<IncomingParameter>.getHeaderParameters(): List<RequestParameter> =
+            filterIsInstance<RequestParameter>()
+                .filter { it.parameterLocation is HeaderParam }
+
+        private fun List<IncomingParameter>.getPathParameters(): List<RequestParameter> =
+            filterIsInstance<RequestParameter>()
+                .filter { it.parameterLocation is PathParam }
+
+        private fun resourceWithDeduplicatedParamNames(
+            resource: String,
+            pathParameters: List<RequestParameter>,
+        ): String {
+            var resolvedResource = resource
+            pathParameters.forEach { parameter ->
+                if (parameter.originalName != parameter.name) {
+                    resolvedResource = resolvedResource.replace("{${parameter.originalName}}", "{${parameter.name}}")
+                }
+            }
+            return resolvedResource
+        }
+    }
+
+    override fun generateLibrary(options: Set<ClientCodeGenOptionType>): Collection<GeneratedFile> = setOf(
+        generatedAnnotationFile()
+    )
+
+    private fun generatedAnnotationFile(): SimpleFile {
+        val destFile = srcPath.resolve(CodeGenerationUtils.packageToPath(packages.client))
+            .resolve("GeneratedClient.kt")
+        val annotationTypeSpec = TypeSpec.annotationBuilder(
+            ClassName(packages.client, "GeneratedClient")
+        ).build()
+        val fileSpec = FileSpec.builder(packages.client, "GeneratedClient").addType(annotationTypeSpec).build()
+        return SimpleFile(destFile, fileSpec.toString())
+    }
+
+    private fun generatedAnnotationSpec(): AnnotationSpec = AnnotationSpec.builder(
+        ClassName(packages.client, "GeneratedClient")
+    ).build()
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -25,15 +25,11 @@ import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
-import com.cjbooms.fabrikt.model.SimpleFile
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
-import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
 import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
@@ -55,7 +51,6 @@ class SpringHttpInterfaceGenerator(
             }
 
             val clientType = TypeSpec.interfaceBuilder(simpleClientName(resourceName))
-                .addAnnotation(generatedAnnotationSpec())
                 .addAnnotation(AnnotationSpec.builder(Suppress::class).addMember("%S", "unused").build())
                 .addFunctions(funcSpecs)
                 .build()
@@ -253,21 +248,5 @@ class SpringHttpInterfaceGenerator(
         }
     }
 
-    override fun generateLibrary(options: Set<ClientCodeGenOptionType>): Collection<GeneratedFile> = setOf(
-        generatedAnnotationFile()
-    )
-
-    private fun generatedAnnotationFile(): SimpleFile {
-        val destFile = srcPath.resolve(CodeGenerationUtils.packageToPath(packages.client))
-            .resolve("GeneratedClient.kt")
-        val annotationTypeSpec = TypeSpec.annotationBuilder(
-            ClassName(packages.client, "GeneratedClient")
-        ).build()
-        val fileSpec = FileSpec.builder(packages.client, "GeneratedClient").addType(annotationTypeSpec).build()
-        return SimpleFile(destFile, fileSpec.toString())
-    }
-
-    private fun generatedAnnotationSpec(): AnnotationSpec = AnnotationSpec.builder(
-        ClassName(packages.client, "GeneratedClient")
-    ).build()
+    override fun generateLibrary(options: Set<ClientCodeGenOptionType>): Collection<GeneratedFile> = setOf()
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/SpringHttpInterface.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/SpringHttpInterface.kt
@@ -1,0 +1,35 @@
+package com.cjbooms.fabrikt.generators.client.metadata
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+
+object SpringHttpInterfaceImports {
+    object Packages {
+        const val BIND_ANNOTATION = "org.springframework.web.bind.annotation"
+        const val SERVICE_ANNOTATION = "org.springframework.web.service.annotation"
+    }
+
+    val REQUEST_PARAM = ClassName(Packages.BIND_ANNOTATION, "RequestParam")
+    val REQUEST_HEADER = ClassName(Packages.BIND_ANNOTATION, "RequestHeader")
+    val REQUEST_BODY = ClassName(Packages.BIND_ANNOTATION, "RequestBody")
+    val PATH_VARIABLE = ClassName(Packages.BIND_ANNOTATION, "PathVariable")
+
+    val HTTP_EXCHANGE = ClassName(Packages.SERVICE_ANNOTATION, "HttpExchange")
+}
+
+object SpringHttpInterfaceAnnotations {
+    fun requestParamBuilder(): AnnotationSpec.Builder = AnnotationSpec
+        .builder(SpringHttpInterfaceImports.REQUEST_PARAM)
+
+    fun requestHeaderBuilder(): AnnotationSpec.Builder = AnnotationSpec
+        .builder(SpringHttpInterfaceImports.REQUEST_HEADER)
+
+    fun requestBodyBuilder(): AnnotationSpec.Builder = AnnotationSpec
+        .builder(SpringHttpInterfaceImports.REQUEST_BODY)
+
+    fun pathVariableBuilder(): AnnotationSpec.Builder = AnnotationSpec
+        .builder(SpringHttpInterfaceImports.PATH_VARIABLE)
+
+    fun httpExchangeBuilder(): AnnotationSpec.Builder = AnnotationSpec
+        .builder(SpringHttpInterfaceImports.HTTP_EXCHANGE)
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
@@ -1,0 +1,121 @@
+package com.cjbooms.fabrikt.generators
+
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
+import com.cjbooms.fabrikt.cli.ClientCodeGenTargetType
+import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.client.SpringHttpInterfaceGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
+import com.cjbooms.fabrikt.model.ClientType
+import com.cjbooms.fabrikt.model.Models
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.Linter
+import com.cjbooms.fabrikt.util.ModelNameRegistry
+import com.cjbooms.fabrikt.util.ResourceHelper.readTextResource
+import com.squareup.kotlinpoet.FileSpec
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SpringHttpInterfaceGeneratorTest {
+    @Suppress("unused")
+    private fun fullApiTestCases(): Stream<String> = Stream.of(
+        "springHttpInterfaceClient",
+        "multiMediaType",
+        "pathLevelParameters",
+        "parameterNameClash",
+    )
+
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(
+            genTypes = setOf(CodeGenerationType.CLIENT),
+            clientTarget = ClientCodeGenTargetType.SPRING_HTTP_INTERFACE,
+            modelOptions = setOf(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS),
+        )
+        ModelNameRegistry.clear()
+    }
+
+    @ParameterizedTest
+    @MethodSource("fullApiTestCases")
+    fun `correct Spring HTTP Interface clients are generated from a full API definition`(testCaseName: String) {
+        runTestCase(testCaseName)
+    }
+
+    @Test
+    fun `correct Spring HTTP Interface clients are generated with suspend modifier`() {
+        runTestCase(
+            "springHttpInterfaceClient",
+            clientFileName = "SuspendableSpringHttpInterfaceClient.kt",
+            options = setOf(ClientCodeGenOptionType.SUSPEND_MODIFIER),
+        )
+    }
+
+    @Test
+    fun `correct Spring HTTP Interface clients are generated with response entity wrapper and spring annotation`() {
+        runTestCase(
+            "springHttpInterfaceClient",
+            clientFileName = "SpringHttpInterfaceClientWithResponseEntity.kt",
+            options = setOf(
+                ClientCodeGenOptionType.SPRING_RESPONSE_ENTITY_WRAPPER,
+            )
+        )
+    }
+
+    private fun runTestCase(
+        testCaseName: String,
+        clientFileName: String = "SpringHttpInterfaceClient.kt",
+        options: Set<ClientCodeGenOptionType> = emptySet(),
+    ) {
+        val packages = Packages("examples.$testCaseName")
+        val sourceApi = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
+
+        val expectedModel = readTextResource("/examples/$testCaseName/models/ClientModels.kt")
+        val expectedClient = readTextResource("/examples/$testCaseName/client/$clientFileName")
+
+        val models = ModelGenerator(
+            packages,
+            sourceApi,
+        ).generate().toSingleFile()
+        val clientCode = SpringHttpInterfaceGenerator(
+            packages,
+            sourceApi,
+        )
+            .generate(options)
+            .clients
+            .toSingleFile()
+
+        assertThat(clientCode).isEqualTo(expectedClient)
+        assertThat(models).isEqualTo(expectedModel)
+    }
+
+    private fun Collection<ClientType>.toSingleFile(): String {
+        val destPackage = if (this.isNotEmpty()) first().destinationPackage else ""
+        val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
+        this.forEach {
+            val builder = singleFileBuilder
+                .addType(it.spec)
+            builder.build()
+        }
+        return Linter.lintString(singleFileBuilder.build().toString())
+    }
+
+    private fun Models.toSingleFile(): String {
+        val destPackage = if (models.isNotEmpty()) models.first().destinationPackage else ""
+        val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
+        models
+            .sortedBy { it.spec.name }
+            .forEach {
+                val builder = singleFileBuilder
+                    .addType(it.spec)
+                builder.build()
+            }
+        return Linter.lintString(singleFileBuilder.build().toString())
+    }
+}

--- a/src/test/resources/examples/multiMediaType/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/multiMediaType/client/SpringHttpInterfaceClient.kt
@@ -14,7 +14,6 @@ import kotlin.Suppress
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath1Client {
     /**
@@ -38,7 +37,6 @@ public interface ExamplePath1Client {
     ): QueryResult
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath2Client {
     /**
@@ -62,7 +60,6 @@ public interface ExamplePath2Client {
     ): QueryResult
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface MultipleResponseSchemasClient {
     /**
@@ -82,7 +79,6 @@ public interface MultipleResponseSchemasClient {
     ): JsonNode
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface DifferentSuccessAndErrorResponseSchemaClient {
     /**

--- a/src/test/resources/examples/multiMediaType/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/multiMediaType/client/SpringHttpInterfaceClient.kt
@@ -1,0 +1,102 @@
+package examples.multiMediaType.client
+
+import com.fasterxml.jackson.databind.JsonNode
+import examples.multiMediaType.models.ContentType
+import examples.multiMediaType.models.QueryResult
+import examples.multiMediaType.models.SuccessResponse
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath1Client {
+    /**
+     * GET example path 1
+     *
+     * @param explodeListQueryParam
+     * @param queryParam2
+     * @param acceptHeader
+     */
+    @HttpExchange(
+        url = "/example-path-1",
+        method = "GET",
+        accept = ["application/vnd.custom.media+xml"],
+    )
+    public fun getExamplePath1(
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("acceptHeader") acceptHeader: String = "application/vnd.custom.media+xml",
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): QueryResult
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath2Client {
+    /**
+     * GET example path 1
+     *
+     * @param explodeListQueryParam
+     * @param queryParam2
+     * @param accept the content type accepted by the client
+     */
+    @HttpExchange(
+        url = "/example-path-2",
+        method = "GET",
+        accept = ["application/vnd.custom.media+xml"],
+    )
+    public fun getExamplePath2(
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("accept") accept: ContentType? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): QueryResult
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface MultipleResponseSchemasClient {
+    /**
+     * GET with multiple response content schemas
+     *
+     * @param accept the content type accepted by the client
+     */
+    @HttpExchange(
+        url = "/multiple-response-schemas",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun getMultipleResponseSchemas(
+        @RequestHeader("accept") accept: ContentType? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): JsonNode
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface DifferentSuccessAndErrorResponseSchemaClient {
+    /**
+     *
+     */
+    @HttpExchange(
+        url = "/different-success-and-error-response-schema",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun getDifferentSuccessAndErrorResponseSchema(
+        @RequestHeader
+        additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam
+        additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): SuccessResponse
+}

--- a/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
@@ -1,0 +1,50 @@
+package examples.parameterNameClash.client
+
+import examples.parameterNameClash.models.SomeObject
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.Map
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExampleClient {
+    /**
+     *
+     *
+     * @param pathB
+     * @param queryB
+     */
+    @HttpExchange(
+        url = "/example/{pathB}",
+        method = "GET",
+    )
+    public fun getExampleB(
+        @PathVariable("pathB") pathB: String,
+        @RequestParam("queryB") queryB: String,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+
+    /**
+     *
+     *
+     * @param bodySomeObject example
+     * @param querySomeObject
+     */
+    @HttpExchange(
+        url = "/example",
+        method = "POST",
+    )
+    public fun postExample(
+        @RequestBody bodySomeObject: SomeObject,
+        @RequestParam("querySomeObject") querySomeObject: String,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}

--- a/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
@@ -11,7 +11,6 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.Map
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExampleClient {
     /**

--- a/src/test/resources/examples/pathLevelParameters/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/SpringHttpInterfaceClient.kt
@@ -8,7 +8,6 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.Map
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExampleClient {
     /**

--- a/src/test/resources/examples/pathLevelParameters/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/SpringHttpInterfaceClient.kt
@@ -1,0 +1,30 @@
+package examples.pathLevelParameters.client
+
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.Map
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExampleClient {
+    /**
+     *
+     *
+     * @param a
+     * @param b
+     */
+    @HttpExchange(
+        url = "/example",
+        method = "GET",
+    )
+    public fun getExample(
+        @RequestParam("a") a: String,
+        @RequestParam("b") b: String,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}

--- a/src/test/resources/examples/springHttpInterfaceClient/api.yaml
+++ b/src/test/resources/examples/springHttpInterfaceClient/api.yaml
@@ -1,0 +1,325 @@
+openapi: "3.0.0"
+info:
+  title: "API Example"
+  version: "1.0"
+paths:
+  /example-path-1:
+    get:
+      summary: "GET example path 1"
+      parameters:
+        - $ref: "#/components/parameters/ListQueryParamExploded"
+        - $ref: "#/components/parameters/QueryParam2"
+        - $ref: "#/components/parameters/HeaderParam1"
+        - $ref: "#/components/parameters/HeaderParam2"
+      responses:
+        200:
+          description: "successful operation"
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+          content:
+            application/vnd.custom.media+json:
+              schema:
+                $ref: "#/components/schemas/QueryResult"
+
+    post:
+      summary: "POST example path 1"
+      parameters:
+        - $ref: "#/components/parameters/ListQueryParamExploded"
+      requestBody:
+        $ref: "#/components/requestBodies/PostBody"
+      responses:
+        201:
+          headers:
+            Location:
+              $ref: "#/components/headers/Location"
+          description: "Successful operation"
+
+  /example-path-2/{path_param}:
+    get:
+      summary: "GET example path 2"
+      parameters:
+        - $ref: "#/components/parameters/PathParam"
+        - $ref: "#/components/parameters/QueryParam2"
+        - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/PaginationLimitParam"
+      responses:
+        200:
+          description: "successful operation"
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+          content:
+            application/json:
+              schema:
+                discriminator:
+                  propertyName: "model_type"
+                oneOf:
+                  - $ref: "#/components/schemas/FirstModel"
+                  - $ref: "#/components/schemas/SecondModel"
+                  - $ref: "#/components/schemas/ThirdModel"
+        304:
+          description: "Returned in conjunction with use of the If-None-Match header.\
+            \ Indicates that the resource as described by the passed etag value has\
+            \ not changed"
+    head:
+      operationId: headOperationIdExample
+      summary: "HEAD example path 2"
+      parameters:
+        - $ref: "#/components/parameters/PathParam"
+        - $ref: "#/components/parameters/QueryParam3"
+        - $ref: "#/components/parameters/IfNoneMatch"
+      responses:
+        200:
+          description: "Record Exists"
+        304:
+          description: "Returned in conjunction with use of the If-None-Match header.\
+            \ Indicates that the resource as described by the passed etag value has\
+            \ not changed"
+
+    put:
+      summary: "PUT example path 2"
+      parameters:
+        - $ref: "#/components/parameters/PathParam"
+        - $ref: "#/components/parameters/IfMatch"
+      requestBody:
+        $ref: "#/components/requestBodies/PutBody"
+      responses:
+        204:
+          description: "Operation successful"
+
+  /example-path-3/{path_param}/subresource:
+    put:
+      summary: "PUT example path 3"
+      parameters:
+        - $ref: "#/components/parameters/ListQueryParamCsv"
+        - $ref: "#/components/parameters/PathParam"
+        - $ref: "#/components/parameters/IfMatch"
+      requestBody:
+        $ref: "#/components/requestBodies/PutBody"
+      responses:
+        204:
+          description: "Operation successful"
+
+components:
+  parameters:
+    PathParam:
+      name: "path_param"
+      description: "The resource id"
+      in: "path"
+      required: true
+      schema:
+        type: "string"
+
+    IfMatch:
+      name: "If-Match"
+      description: "The RFC7232 If-Match header field"
+      in: "header"
+      schema:
+        type: "string"
+      required: true
+
+    IfNoneMatch:
+      name: "If-None-Match"
+      description: "The RFC7232 If-None-Match header field"
+      in: "header"
+      schema:
+        type: "string"
+      required: false
+
+    ListQueryParamExploded:
+      name: "explode_list_query_param"
+      in: "query"
+      schema:
+        type: "array"
+        items:
+          type: "string"
+      required: false
+      allowEmptyValue: false
+
+    ListQueryParamCsv:
+      name: "csv_list_query_param"
+      in: "query"
+      explode: false
+      schema:
+        type: "array"
+        items:
+          type: "string"
+      required: false
+      allowEmptyValue: false
+
+    PaginationLimitParam:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 500
+      required: false
+
+    QueryParam2:
+      name: "query_param2"
+      in: "query"
+      schema:
+        type: integer
+      required: false
+
+    QueryParam3:
+      name: "query_param3"
+      in: "query"
+      schema:
+        type: boolean
+      required: false
+    HeaderParam1:
+      name: "header_param1"
+      in: "header"
+      schema:
+        type: string
+      required: false
+    HeaderParam2:
+      name: "header_param2"
+      in: "header"
+      schema:
+        type: string
+      required: false
+
+
+  headers:
+    Location:
+      description: "The Location header indicates the URL of a newly created resource"
+      schema:
+        type: "string"
+
+    CacheControl:
+      description: "The RFC7234 Cache Control header"
+      schema:
+        type: "string"
+      example: "must-revalidate, max-age=5"
+
+  requestBodies:
+    PostBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            discriminator:
+              propertyName: "model_type"
+            oneOf:
+              - $ref: "#/components/schemas/FirstModel"
+              - $ref: "#/components/schemas/SecondModel"
+              - $ref: "#/components/schemas/ThirdModel"
+    PutBody:
+      required: false
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FirstModel"
+
+
+  schemas:
+    QueryResult:
+      type: "object"
+      required:
+        - "items"
+      properties:
+        items:
+          type: "array"
+          minItems: 0
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/FirstModel"
+              - $ref: "#/components/schemas/SecondModel"
+              - $ref: "#/components/schemas/ThirdModel"
+    Content:
+      type: "object"
+      required:
+        - "id"
+        - "attr_1"
+        - "attr_2"
+        - "attr_3"
+        - "etag"
+        - "model_type"
+      properties:
+        id:
+          description: "The unique resource id"
+          type: "string"
+          readOnly: true
+        first_attr:
+          description: "The attribute 1"
+          type: "string"
+          format: "date-time"
+          example: "2016-01-27T10:52:46.406Z"
+          readOnly: true
+        second_attr:
+          description: "The attribute 2"
+          type: "string"
+          readOnly: true
+        third_attr:
+          type: "string"
+          enum:
+            - "enum_type_1"
+            - "enum_type_2"
+          description: "Enum types for attribute 3"
+          example: "enum_type_2"
+        etag:
+          type: "string"
+          description: "Etag value to be used in conjunction with If-Match headers for optimistic locking purposes"
+          readOnly: true
+        model_type:
+          type: "string"
+          description: "The model discrimination type"
+          enum:
+            - "first_model"
+            - "second_model"
+            - "third_model"
+          example: "third_model"
+      discriminator:
+        propertyName: "model_type"
+        mapping:
+          first_model: "#/components/schemas/FirstModel"
+          second_model: "#/components/schemas/SecondModel"
+          third_model: "#/components/schemas/ThirdModel"
+
+    FirstModel:
+      allOf:
+        - $ref: "#/components/schemas/Content"
+        - type: "object"
+          properties:
+            extra_first_attr:
+              description: "The attribute 1 for model 1"
+              type: array
+              items:
+                type: "string"
+                minItems: 1
+                maxItems: 10
+              readOnly: true
+    SecondModel:
+      allOf:
+        - $ref: "#/components/schemas/Content"
+        - type: "object"
+          properties:
+            extra_first_attr:
+              description: "The attribute 1 for model 2"
+              type: "string"
+              readOnly: true
+            extra_second_attr:
+              description: "The attribute 2 for model 2"
+              type: boolean
+              readOnly: true
+
+    ThirdModel:
+      allOf:
+        - $ref: "#/components/schemas/Content"
+        - type: "object"
+          properties:
+            extra_first_attr:
+              description: "The attribute 1 for model 3"
+              type: "string"
+              format: "date-time"
+              example: "2016-01-27T10:52:46.406Z"
+              readOnly: true
+            extra_second_attr:
+              description: "The attribute 2 for model 3"
+              type: integer
+              readOnly: true

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
@@ -1,0 +1,149 @@
+package examples.springHttpInterfaceClient.client
+
+import examples.springHttpInterfaceClient.models.Content
+import examples.springHttpInterfaceClient.models.FirstModel
+import examples.springHttpInterfaceClient.models.QueryResult
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath1Client {
+    /**
+     * GET example path 1
+     *
+     * @param explodeListQueryParam
+     * @param queryParam2
+     * @param headerParam1
+     * @param headerParam2
+     */
+    @HttpExchange(
+        url = "/example-path-1",
+        method = "GET",
+        accept = ["application/vnd.custom.media+json"],
+    )
+    public fun getExamplePath1(
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("headerParam1") headerParam1: String? = null,
+        @RequestHeader("headerParam2") headerParam2: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): QueryResult
+
+    /**
+     * POST example path 1
+     *
+     * @param content
+     * @param explodeListQueryParam
+     */
+    @HttpExchange(
+        url = "/example-path-1",
+        method = "POST",
+    )
+    public fun postExamplePath1(
+        @RequestBody content: Content,
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath2Client {
+    /**
+     * GET example path 2
+     *
+     * @param pathParam The resource id
+     * @param limit
+     * @param queryParam2
+     * @param ifNoneMatch The RFC7232 If-None-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun getExamplePath2PathParam(
+        @PathVariable("pathParam") pathParam: String,
+        @RequestParam("limit") limit: Int = 500,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): Content
+
+    /**
+     * HEAD example path 2
+     *
+     * @param pathParam The resource id
+     * @param queryParam3
+     * @param ifNoneMatch The RFC7232 If-None-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "HEAD",
+    )
+    public fun headOperationIdExample(
+        @PathVariable("pathParam") pathParam: String,
+        @RequestParam("queryParam3") queryParam3: Boolean? = null,
+        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+
+    /**
+     * PUT example path 2
+     *
+     * @param firstModel
+     * @param pathParam The resource id
+     * @param ifMatch The RFC7232 If-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "PUT",
+    )
+    public fun putExamplePath2PathParam(
+        @RequestBody firstModel: FirstModel,
+        @PathVariable("pathParam") pathParam: String,
+        @RequestHeader("ifMatch") ifMatch: String,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath3SubresourceClient {
+    /**
+     * PUT example path 3
+     *
+     * @param firstModel
+     * @param pathParam The resource id
+     * @param ifMatch The RFC7232 If-Match header field
+     * @param csvListQueryParam
+     */
+    @HttpExchange(
+        url = "/example-path-3/{pathParam}/subresource",
+        method = "PUT",
+    )
+    public fun putExamplePath3PathParamSubresource(
+        @RequestBody firstModel: FirstModel,
+        @PathVariable("pathParam") pathParam: String,
+        @RequestHeader("ifMatch") ifMatch: String,
+        @RequestParam("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
@@ -16,7 +16,6 @@ import kotlin.Suppress
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath1Client {
     /**
@@ -59,7 +58,6 @@ public interface ExamplePath1Client {
     )
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath2Client {
     /**
@@ -123,7 +121,6 @@ public interface ExamplePath2Client {
     )
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath3SubresourceClient {
     /**

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
@@ -18,7 +18,6 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath1Client {
     /**
@@ -61,7 +60,6 @@ public interface ExamplePath1Client {
     ): ResponseEntity<Unit>
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath2Client {
     /**
@@ -125,7 +123,6 @@ public interface ExamplePath2Client {
     ): ResponseEntity<Unit>
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath3SubresourceClient {
     /**

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
@@ -1,0 +1,151 @@
+package examples.springHttpInterfaceClient.client
+
+import examples.springHttpInterfaceClient.models.Content
+import examples.springHttpInterfaceClient.models.FirstModel
+import examples.springHttpInterfaceClient.models.QueryResult
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath1Client {
+    /**
+     * GET example path 1
+     *
+     * @param explodeListQueryParam
+     * @param queryParam2
+     * @param headerParam1
+     * @param headerParam2
+     */
+    @HttpExchange(
+        url = "/example-path-1",
+        method = "GET",
+        accept = ["application/vnd.custom.media+json"],
+    )
+    public fun getExamplePath1(
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("headerParam1") headerParam1: String? = null,
+        @RequestHeader("headerParam2") headerParam2: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): ResponseEntity<QueryResult>
+
+    /**
+     * POST example path 1
+     *
+     * @param content
+     * @param explodeListQueryParam
+     */
+    @HttpExchange(
+        url = "/example-path-1",
+        method = "POST",
+    )
+    public fun postExamplePath1(
+        @RequestBody content: Content,
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): ResponseEntity<Unit>
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath2Client {
+    /**
+     * GET example path 2
+     *
+     * @param pathParam The resource id
+     * @param limit
+     * @param queryParam2
+     * @param ifNoneMatch The RFC7232 If-None-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun getExamplePath2PathParam(
+        @PathVariable("pathParam") pathParam: String,
+        @RequestParam("limit") limit: Int = 500,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): ResponseEntity<Content>
+
+    /**
+     * HEAD example path 2
+     *
+     * @param pathParam The resource id
+     * @param queryParam3
+     * @param ifNoneMatch The RFC7232 If-None-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "HEAD",
+    )
+    public fun headOperationIdExample(
+        @PathVariable("pathParam") pathParam: String,
+        @RequestParam("queryParam3") queryParam3: Boolean? = null,
+        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): ResponseEntity<Unit>
+
+    /**
+     * PUT example path 2
+     *
+     * @param firstModel
+     * @param pathParam The resource id
+     * @param ifMatch The RFC7232 If-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "PUT",
+    )
+    public fun putExamplePath2PathParam(
+        @RequestBody firstModel: FirstModel,
+        @PathVariable("pathParam") pathParam: String,
+        @RequestHeader("ifMatch") ifMatch: String,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): ResponseEntity<Unit>
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath3SubresourceClient {
+    /**
+     * PUT example path 3
+     *
+     * @param firstModel
+     * @param pathParam The resource id
+     * @param ifMatch The RFC7232 If-Match header field
+     * @param csvListQueryParam
+     */
+    @HttpExchange(
+        url = "/example-path-3/{pathParam}/subresource",
+        method = "PUT",
+    )
+    public fun putExamplePath3PathParamSubresource(
+        @RequestBody firstModel: FirstModel,
+        @PathVariable("pathParam") pathParam: String,
+        @RequestHeader("ifMatch") ifMatch: String,
+        @RequestParam("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): ResponseEntity<Unit>
+}

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
@@ -16,7 +16,6 @@ import kotlin.Suppress
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath1Client {
     /**
@@ -59,7 +58,6 @@ public interface ExamplePath1Client {
     )
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath2Client {
     /**
@@ -123,7 +121,6 @@ public interface ExamplePath2Client {
     )
 }
 
-@GeneratedClient
 @Suppress("unused")
 public interface ExamplePath3SubresourceClient {
     /**

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
@@ -1,0 +1,149 @@
+package examples.springHttpInterfaceClient.client
+
+import examples.springHttpInterfaceClient.models.Content
+import examples.springHttpInterfaceClient.models.FirstModel
+import examples.springHttpInterfaceClient.models.QueryResult
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath1Client {
+    /**
+     * GET example path 1
+     *
+     * @param explodeListQueryParam
+     * @param queryParam2
+     * @param headerParam1
+     * @param headerParam2
+     */
+    @HttpExchange(
+        url = "/example-path-1",
+        method = "GET",
+        accept = ["application/vnd.custom.media+json"],
+    )
+    public suspend fun getExamplePath1(
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("headerParam1") headerParam1: String? = null,
+        @RequestHeader("headerParam2") headerParam2: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): QueryResult
+
+    /**
+     * POST example path 1
+     *
+     * @param content
+     * @param explodeListQueryParam
+     */
+    @HttpExchange(
+        url = "/example-path-1",
+        method = "POST",
+    )
+    public suspend fun postExamplePath1(
+        @RequestBody content: Content,
+        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath2Client {
+    /**
+     * GET example path 2
+     *
+     * @param pathParam The resource id
+     * @param limit
+     * @param queryParam2
+     * @param ifNoneMatch The RFC7232 If-None-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public suspend fun getExamplePath2PathParam(
+        @PathVariable("pathParam") pathParam: String,
+        @RequestParam("limit") limit: Int = 500,
+        @RequestParam("queryParam2") queryParam2: Int? = null,
+        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): Content
+
+    /**
+     * HEAD example path 2
+     *
+     * @param pathParam The resource id
+     * @param queryParam3
+     * @param ifNoneMatch The RFC7232 If-None-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "HEAD",
+    )
+    public suspend fun headOperationIdExample(
+        @PathVariable("pathParam") pathParam: String,
+        @RequestParam("queryParam3") queryParam3: Boolean? = null,
+        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+
+    /**
+     * PUT example path 2
+     *
+     * @param firstModel
+     * @param pathParam The resource id
+     * @param ifMatch The RFC7232 If-Match header field
+     */
+    @HttpExchange(
+        url = "/example-path-2/{pathParam}",
+        method = "PUT",
+    )
+    public suspend fun putExamplePath2PathParam(
+        @RequestBody firstModel: FirstModel,
+        @PathVariable("pathParam") pathParam: String,
+        @RequestHeader("ifMatch") ifMatch: String,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}
+
+@GeneratedClient
+@Suppress("unused")
+public interface ExamplePath3SubresourceClient {
+    /**
+     * PUT example path 3
+     *
+     * @param firstModel
+     * @param pathParam The resource id
+     * @param ifMatch The RFC7232 If-Match header field
+     * @param csvListQueryParam
+     */
+    @HttpExchange(
+        url = "/example-path-3/{pathParam}/subresource",
+        method = "PUT",
+    )
+    public suspend fun putExamplePath3PathParamSubresource(
+        @RequestBody firstModel: FirstModel,
+        @PathVariable("pathParam") pathParam: String,
+        @RequestHeader("ifMatch") ifMatch: String,
+        @RequestParam("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}

--- a/src/test/resources/examples/springHttpInterfaceClient/models/ClientModels.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/models/ClientModels.kt
@@ -1,0 +1,167 @@
+package examples.springHttpInterfaceClient.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.`annotation`.JsonValue
+import java.time.OffsetDateTime
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "model_type",
+    visible = true,
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(
+        value = FirstModel::class,
+        name =
+        "first_model",
+    ),
+    JsonSubTypes.Type(
+        value = SecondModel::class,
+        name =
+        "second_model",
+    ),
+    JsonSubTypes.Type(value = ThirdModel::class, name = "third_model"),
+)
+public sealed class Content(
+    public open val id: String? = null,
+    public open val firstAttr: OffsetDateTime? = null,
+    public open val secondAttr: String? = null,
+    public open val thirdAttr: ContentThirdAttr? = null,
+    public open val etag: String? = null,
+) {
+    public abstract val modelType: ContentModelType
+}
+
+public enum class ContentModelType(
+    @JsonValue
+    public val `value`: String,
+) {
+    FIRST_MODEL("first_model"),
+    SECOND_MODEL("second_model"),
+    THIRD_MODEL("third_model"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, ContentModelType> =
+            entries.associateBy(ContentModelType::value)
+
+        public fun fromValue(`value`: String): ContentModelType? = mapping[value]
+    }
+}
+
+public enum class ContentThirdAttr(
+    @JsonValue
+    public val `value`: String,
+) {
+    ENUM_TYPE_1("enum_type_1"),
+    ENUM_TYPE_2("enum_type_2"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, ContentThirdAttr> =
+            entries.associateBy(ContentThirdAttr::value)
+
+        public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
+    }
+}
+
+public data class FirstModel(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    public val extraFirstAttr: List<String>? = null,
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    @param:JsonProperty("model_type")
+    override val modelType: ContentModelType = ContentModelType.FIRST_MODEL,
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag)
+
+public data class QueryResult(
+    @param:JsonProperty("items")
+    @get:JsonProperty("items")
+    @get:NotNull
+    @get:Size(min = 0)
+    @get:Valid
+    public val items: List<Content>,
+)
+
+public data class SecondModel(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    public val extraFirstAttr: String? = null,
+    @param:JsonProperty("extra_second_attr")
+    @get:JsonProperty("extra_second_attr")
+    public val extraSecondAttr: Boolean? = null,
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    @param:JsonProperty("model_type")
+    override val modelType: ContentModelType = ContentModelType.SECOND_MODEL,
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag)
+
+public data class ThirdModel(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    public val extraFirstAttr: OffsetDateTime? = null,
+    @param:JsonProperty("extra_second_attr")
+    @get:JsonProperty("extra_second_attr")
+    public val extraSecondAttr: Int? = null,
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    @param:JsonProperty("model_type")
+    override val modelType: ContentModelType = ContentModelType.THIRD_MODEL,
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag)


### PR DESCRIPTION
SpringBoot's HTTP Interface is a declarative http client like Retrofit or OpenFeign.
https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-http-interface

Since SpringBoot has now removed OpenFeign from the official project and seems to be focusing on this HTTP Interface, we thought it reasonable to add support for it and implemented it.

This client supports ResponseEntity and suspend methods, so we move the relevant code to ClientGeneratorUtils and so on.