### PR TITLE
returns Unit when any successful response not exists

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -133,6 +133,8 @@ object GeneratorUtils {
 
     fun Operation.hasMultipleContentMediaTypes(): Boolean? = this.firstResponse()?.hasMultipleContentMediaTypes()
 
+    fun Operation.hasAnySuccessResponseSchemas(): Boolean = getBodySuccessResponses().isNotEmpty()
+
     fun Operation.hasMultipleSuccessResponseSchemas(): Boolean =
             getBodySuccessResponses().flatMap { it.contentMediaTypes.values }.map { it.schema.name }.distinct().size > 1
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -4,6 +4,7 @@ import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaType
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaTypeKey
+import com.cjbooms.fabrikt.generators.GeneratorUtils.hasAnySuccessResponseSchemas
 import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleContentMediaTypes
 import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleSuccessResponseSchemas
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
@@ -37,16 +38,18 @@ object ClientGeneratorUtils {
      * If no response body is found, Unit is returned.
      */
     fun Operation.getReturnType(packages: Packages): TypeName {
-        return if (hasMultipleSuccessResponseSchemas()) {
-                JsonNode::class.asTypeName()
-            } else {
-                this.getPrimaryContentMediaType()?.let {
-                    toModelType(
-                        packages.base,
-                        KotlinTypeInfo.from(it.value.schema)
-                    )
-                } ?: Unit::class.asTypeName()
-            }
+        return if(!hasAnySuccessResponseSchemas()){
+            Unit::class.asTypeName()
+        } else if (hasMultipleSuccessResponseSchemas()) {
+            JsonNode::class.asTypeName()
+        } else {
+            this.getPrimaryContentMediaType()?.let {
+                toModelType(
+                    packages.base,
+                    KotlinTypeInfo.from(it.value.schema)
+                )
+            } ?: Unit::class.asTypeName()
+        }
     }
 
     fun Operation.toClientReturnType(packages: Packages): TypeName {

--- a/src/test/resources/examples/okHttpClient/api.yaml
+++ b/src/test/resources/examples/okHttpClient/api.yaml
@@ -124,6 +124,19 @@ paths:
         204:
           description: "Operation successful"
 
+  /example-path-4/only-failure-response:
+    post:
+      summary: "POST example path 4"
+      responses:
+        204:
+          description: "No Content"
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Failure'
+          description: Bad Request
+
 components:
   parameters:
     PathParam:

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -263,3 +263,38 @@ public class ExamplePath3SubresourceClient(
         return request.execute(client, objectMapper, jacksonTypeRef())
     }
 }
+
+@Suppress("unused")
+public class ExamplePath4OnlyFailureResponseClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val client: OkHttpClient,
+) {
+    /**
+     * POST example path 4
+     */
+    @Throws(ApiException::class)
+    public fun postExamplePath4OnlyFailureResponse(
+        additionalHeaders: Map<String, String> =
+            emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> {
+        val httpUrl: HttpUrl = "$baseUrl/example-path-4/only-failure-response"
+            .toHttpUrl()
+            .newBuilder()
+            .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+            .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request = Request.Builder()
+            .url(httpUrl)
+            .headers(httpHeaders)
+            .post(ByteArray(0).toRequestBody())
+            .build()
+
+        return request.execute(client, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -145,3 +145,33 @@ public class ExamplePath3SubresourceService(
             apiClient.putExamplePath3PathParamSubresource(firstModel, pathParam, ifMatch, csvListQueryParam, additionalHeaders)
         }
 }
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+public class ExamplePath4OnlyFailureResponseService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    client: OkHttpClient,
+) {
+    public var circuitBreakerName: String = "examplePath4OnlyFailureResponseClient"
+
+    private val apiClient: ExamplePath4OnlyFailureResponseClient =
+        ExamplePath4OnlyFailureResponseClient(objectMapper, baseUrl, client)
+
+    @Throws(ApiException::class)
+    public fun postExamplePath4OnlyFailureResponse(
+        additionalHeaders: Map<String, String> =
+            emptyMap(),
+    ): ApiResponse<Unit> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.postExamplePath4OnlyFailureResponse(additionalHeaders)
+        }
+}


### PR DESCRIPTION
In the original implementation, if only 204 No Content and error system responses were defined in the response, the client return value was the model of the error with the response body.

This was considered undesirable behavior, so it has been modified to return Unit if none of the response bodies should be returned in a 2xx.