### PR TITLE
Update version of fabrikt-gradle-plugin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Latest version of the plugin: [![Gradle Plugin Portal Version](https://img.shiel
 ```kotlin
 plugins {
     // find latest version: https://github.com/acanda/fabrikt-gradle-plugin/releases
-    id("ch.acanda.gradle.fabrikt") version "1.13.0"
+    id("ch.acanda.gradle.fabrikt") version "1.14.0"
 }
 
 fabrikt {


### PR DESCRIPTION
I finally added support for the new String override types from Fabrikt 21.2.