### PR TITLE
Fix NPE on empty type.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/model/OasType.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/OasType.kt
@@ -74,7 +74,7 @@ sealed class OasType(
                     if (candidates.size > 1) candidates.find { it.format == format }
                     else candidates.firstOrNull()
                 } ?: throw IllegalStateException(
-                "Unknown OAS type: ${safeType()} and format: $format and specialization: ${getSpecialization(oasKey)}"
+                "Unknown OAS type: ${safeType()} and format: $format and specialization: ${getSpecialization(oasKey)} for key: $oasKey"
             )
 
         private fun values(clazz: KClass<OasType>) =


### PR DESCRIPTION
The spec file provided in issue #390 has the following blank type that causes the kaizen parser to crash, so I have added a little function to fix this:
```
    Model:
      type:
      title: Model
```

Also improving the handling of 3.1 nullable definitions, by expanding support to include anyOf definitions. This was a further stumbling block with the API provided in #390