### PR TITLE
Fix issue with inlined oneOf generation under arrays.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -38,6 +38,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.getSuperType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isComplexTypedAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedTypedAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfPolymorphicTypes
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
@@ -383,7 +384,7 @@ class ModelGenerator(
                         ),
                     )
 
-                items.isOneOfSuperInterface() && SEALED_INTERFACES_FOR_ONE_OF in options ->
+                items.isInlinedOneOfSuperInterface() && SEALED_INTERFACES_FOR_ONE_OF in options ->
                     setOf(
                         oneOfSuperInterface(
                             modelName = ModelNameRegistry.getOrRegister(schema, enclosingSchema),

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -8,6 +8,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInLinedObjectUnderAllOf
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isRequired
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
@@ -224,7 +225,7 @@ sealed class PropertyInfo {
         private fun isInlined(): Boolean =
             schema
                 .itemsSchema
-                .let { it.isInlinedObjectDefinition() || it.isInlinedEnumDefinition() || it.isInlinedArrayDefinition() || it.isOneOfSuperInterface()}
+                .let { it.isInlinedObjectDefinition() || it.isInlinedEnumDefinition() || it.isInlinedArrayDefinition() || it.isInlinedOneOfSuperInterface()}
     }
 
     data class MapField(

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -307,20 +307,17 @@ object KaizenParserExtensions {
         (allOfSchemas ?: emptyList()) + (anyOfSchemas ?: emptyList())
 
     /**
-     * The `pathFromRoot` of a property schema ends with
-     * `/properties/<name of property>`, so we check if the
-     * penultimate segment is `properties`.
-     */
+    * Recognises two inlining patterns:
+    * - A direct property schema:              /properties/<name>
+    * - An array item schema under a property: /properties/<name>/items
+    */
     private fun Schema.isInlinedPropertySchema(): Boolean {
         val path = Overlay.of(this).pathFromRoot
 
-        // Case 1: /properties/<property>
-        val directPropertyMatch = Regex(".*/properties/[^/]+$")
+        val isDirectProperty = Regex(".*/properties/[^/]+$").matches(path)
+        val isArrayItem = Regex(".*/properties/[^/]+/items$").matches(path)
 
-        // Case 2: /properties/<property>/items
-        val itemsPropertyMatch = Regex(".*/properties/[^/]+/items$")
-
-        return directPropertyMatch.matches(path) || itemsPropertyMatch.matches(path)
+        return isDirectProperty || isArrayItem
     }
 
     fun OpenApi3.basePath(): String =

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -10,6 +10,10 @@ components:
       properties:
         state:
           $ref: '#/components/schemas/State'
+        arrayOfStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/State'
         inlinedArray:
           type: array
           items:

--- a/src/test/resources/examples/discriminatedOneOf/models/SomeObj.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/SomeObj.kt
@@ -11,6 +11,10 @@ public data class SomeObj(
   @get:NotNull
   @get:Valid
   public val state: State,
+  @param:JsonProperty("arrayOfStates")
+  @get:JsonProperty("arrayOfStates")
+  @get:Valid
+  public val arrayOfStates: List<State>? = null,
   @param:JsonProperty("inlinedArray")
   @get:JsonProperty("inlinedArray")
   @get:Valid

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/SomeObj.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/SomeObj.kt
@@ -12,6 +12,9 @@ public data class SomeObj(
   @get:NotNull
   @get:Valid
   public val state: State,
+  @SerialName("arrayOfStates")
+  @get:Valid
+  public val arrayOfStates: List<State>? = null,
   @SerialName("inlinedArray")
   @get:Valid
   public val inlinedArray: List<SomeObjInlinedArray>? = null,


### PR DESCRIPTION
When dealing with arrays, we must also check that the items schema is inlined before generating a class for it. 

Closes Issue #400 