### PR TITLE
Fix oneof mappings issue

### DIFF
--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -78,7 +78,7 @@ class ModelGeneratorTest {
     }
 
     @Test
-    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("inlinedAggregatedObjects")
+    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("discriminatedOneOf")
 
     @ParameterizedTest
     @MethodSource("testCases")

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -35,6 +35,13 @@ components:
           oneOf:
             - "$ref": "#/components/schemas/OneObject"
             - "$ref": "#/components/schemas/TwoObject"
+        inlinedObjectNoMappings:
+          type: object
+          discriminator:
+            propertyName: type
+          oneOf:
+            - "$ref": "#/components/schemas/OneObject"
+            - "$ref": "#/components/schemas/TwoObject"
     State:
       oneOf:
         - $ref: '#/components/schemas/StateA'

--- a/src/test/resources/examples/discriminatedOneOf/models/SomeObj.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/SomeObj.kt
@@ -23,4 +23,8 @@ public data class SomeObj(
   @get:JsonProperty("inlinedObject")
   @get:Valid
   public val inlinedObject: SomeObjInlinedObject? = null,
+  @param:JsonProperty("inlinedObjectNoMappings")
+  @get:JsonProperty("inlinedObjectNoMappings")
+  @get:Valid
+  public val inlinedObjectNoMappings: SomeObjInlinedObjectNoMappings? = null,
 )

--- a/src/test/resources/examples/discriminatedOneOf/models/SomeObjInlinedObjectNoMappings.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/SomeObjInlinedObjectNoMappings.kt
@@ -1,0 +1,14 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  property = "type",
+  visible = true,
+)
+@JsonSubTypes(JsonSubTypes.Type(value = OneObject::class, name =
+    "OneObject"),JsonSubTypes.Type(value = TwoObject::class, name = "TwoObject"))
+public sealed interface SomeObjInlinedObjectNoMappings

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/SomeObj.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/SomeObj.kt
@@ -21,4 +21,7 @@ public data class SomeObj(
   @SerialName("inlinedObject")
   @get:Valid
   public val inlinedObject: SomeObjInlinedObject? = null,
+  @SerialName("inlinedObjectNoMappings")
+  @get:Valid
+  public val inlinedObjectNoMappings: SomeObjInlinedObjectNoMappings? = null,
 )

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/SomeObjInlinedObjectNoMappings.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/SomeObjInlinedObjectNoMappings.kt
@@ -1,0 +1,6 @@
+package examples.discriminatedOneOf.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public sealed interface SomeObjInlinedObjectNoMappings


### PR DESCRIPTION
Improves robustness of polymorphic code generation for oneOf hierarchies. Add function to resolve discriminator mappings with default fallback. Previously we were not falling back to default behaviour and failing hard.

 - Introduced getDiscriminatorMappingsOrDefault to handle oneOf discriminator mappings.
 - Supports both explicit mappings and default name-based matching when mappings are absent.
 - Logs warnings instead of failing hard if referenced schemas are missing.

Closes #404 
