### PR TITLE
Fix #408 by doing distinct on body parameters by schema

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -175,6 +175,7 @@ object GeneratorUtils {
                     it.schema
                 )
             }
+            .distinctBy { it.schema.safeName().toKotlinParameterName().ifEmpty { it.schema.toVarName() } }
 
         val parameters = mergeParameters(pathParameters, parameters)
             .map {


### PR DESCRIPTION
This should fix the problem mentioned in issue #408. 

It's probably really an issue of bad API definition. But it makes sense for a tool like this to be rather flexible where the spec isn't hard.