### PR TITLE
Support long enum values

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -448,7 +448,7 @@ class ModelGenerator(
 
         enum.entries.forEach {
             val enumConstantBuilder = TypeSpec.anonymousClassBuilder()
-                .addSuperclassConstructorParameter(CodeBlock.of("\"$it\""))
+                .addSuperclassConstructorParameter("%S", it)
             serializationAnnotations.addEnumConstantAnnotation(enumConstantBuilder, it)
             classBuilder.addEnumConstant(
                 it.toEnumName(),

--- a/src/test/resources/examples/enumExamples/api.yaml
+++ b/src/test/resources/examples/enumExamples/api.yaml
@@ -45,6 +45,7 @@ components:
         - 4
         - -5
         - _6
+        - really long enum value goes here and it is very descriptive
 
     ExtensibleEnumObject:
       type: string

--- a/src/test/resources/examples/enumExamples/models/EnumObject.kt
+++ b/src/test/resources/examples/enumExamples/models/EnumObject.kt
@@ -14,6 +14,7 @@ public enum class EnumObject(
   `4`("4"),
   _5("-5"),
   _6("_6"),
+  REALLY_LONG_ENUM_VALUE_GOES_HERE_AND_IT_IS_VERY_DESCRIPTIVE("really long enum value goes here and it is very descriptive"),
   ;
 
   public companion object {


### PR DESCRIPTION
Uses [%S format specifier](https://square.github.io/kotlinpoet/s-for-strings/) instead of plain CodeBlock to avoid long enum values being line wrapped.

Fixes #411 