### PR TITLE
feat: support http status code ranges

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
@@ -32,7 +32,7 @@ object ControllerGeneratorUtils {
         val toResponseMapping: Map<Int, Response> = responses
             .filter { it.key != "default" }
             .map { (code, body) ->
-                code.toInt() to body
+                code.replace('X','0').toInt() to body
             }.toMap()
 
         // Happy path, just pull out the http code with the lowest value. Later we may have conditional responses

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -41,6 +41,7 @@ class SpringControllerGeneratorTest {
         "jakartaValidationAnnotations",
         "modelSuffix",
         "unsupportedInlinedDefinitions",
+        "httpStatusCodeRangeDefinition"
     )
 
     private fun setupGithubApiTestEnv(annotations: ValidationAnnotations = JavaxValidationAnnotations) {

--- a/src/test/resources/examples/httpStatusCodeRangeDefinition/api.yaml
+++ b/src/test/resources/examples/httpStatusCodeRangeDefinition/api.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+info:
+  version: '1'
+  title: httpStatusCodeRangeDefinition
+paths:
+  /example:
+    get:
+      responses:
+        '2XX':  # https://swagger.io/docs/specification/v3_0/describing-responses/#http-status-codes
+          description: example

--- a/src/test/resources/examples/httpStatusCodeRangeDefinition/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/httpStatusCodeRangeDefinition/controllers/spring/Controllers.kt
@@ -1,0 +1,23 @@
+package examples.httpStatusCodeRangeDefinition.controllers
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import kotlin.Unit
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface ExampleController {
+    /**
+     *
+     */
+    @RequestMapping(
+        value = ["/example"],
+        produces = [],
+        method = [RequestMethod.GET],
+    )
+    public fun `get`(): ResponseEntity<Unit>
+}


### PR DESCRIPTION
add support for code ranges:
" To define a range of response codes, you may use the following range definitions: 1XX, 2XX, 3XX, 4XX, and 5XX"
https://swagger.io/docs/specification/v3_0/describing-responses/#http-status-codes