### PR TITLE
fix SpringBoot http client parameter names

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -81,19 +81,19 @@ class SpringHttpInterfaceGenerator(
                     when (parameter.parameterLocation) {
                         is QueryParam -> {
                             SpringHttpInterfaceAnnotations.requestParamBuilder()
-                                .addMember("%S", parameter.name)
+                                .addMember("%S", parameter.originalName)
                                 .build()
                         }
 
                         is HeaderParam -> {
                             SpringHttpInterfaceAnnotations.requestHeaderBuilder()
-                                .addMember("%S", parameter.name)
+                                .addMember("%S", parameter.originalName)
                                 .build()
                         }
 
                         is PathParam -> {
                             SpringHttpInterfaceAnnotations.pathVariableBuilder()
-                                .addMember("%S", parameter.name)
+                                .addMember("%S", parameter.originalName)
                                 .build()
                         }
                     }

--- a/src/test/resources/examples/multiMediaType/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/multiMediaType/client/SpringHttpInterfaceClient.kt
@@ -29,9 +29,9 @@ public interface ExamplePath1Client {
         accept = ["application/vnd.custom.media+xml"],
     )
     public fun getExamplePath1(
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("acceptHeader") acceptHeader: String = "application/vnd.custom.media+xml",
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("Accept") acceptHeader: String = "application/vnd.custom.media+xml",
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): QueryResult
@@ -52,9 +52,9 @@ public interface ExamplePath2Client {
         accept = ["application/vnd.custom.media+xml"],
     )
     public fun getExamplePath2(
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("accept") accept: ContentType? = null,
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("Accept") accept: ContentType? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): QueryResult
@@ -73,7 +73,7 @@ public interface MultipleResponseSchemasClient {
         accept = ["application/json"],
     )
     public fun getMultipleResponseSchemas(
-        @RequestHeader("accept") accept: ContentType? = null,
+        @RequestHeader("Accept") accept: ContentType? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): JsonNode

--- a/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
@@ -24,8 +24,8 @@ public interface ExampleClient {
         method = "GET",
     )
     public fun getExampleB(
-        @PathVariable("pathB") pathB: String,
-        @RequestParam("queryB") queryB: String,
+        @PathVariable("b") pathB: String,
+        @RequestParam("b") queryB: String,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )
@@ -42,7 +42,7 @@ public interface ExampleClient {
     )
     public fun postExample(
         @RequestBody bodySomeObject: SomeObject,
-        @RequestParam("querySomeObject") querySomeObject: String,
+        @RequestParam("someObject") querySomeObject: String,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
@@ -32,10 +32,10 @@ public interface ExamplePath1Client {
         accept = ["application/vnd.custom.media+json"],
     )
     public fun getExamplePath1(
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("headerParam1") headerParam1: String? = null,
-        @RequestHeader("headerParam2") headerParam2: String? = null,
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("header_param1") headerParam1: String? = null,
+        @RequestHeader("header_param2") headerParam2: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): QueryResult
@@ -52,7 +52,7 @@ public interface ExamplePath1Client {
     )
     public fun postExamplePath1(
         @RequestBody content: Content,
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )
@@ -74,10 +74,10 @@ public interface ExamplePath2Client {
         accept = ["application/json"],
     )
     public fun getExamplePath2PathParam(
-        @PathVariable("pathParam") pathParam: String,
+        @PathVariable("path_param") pathParam: String,
         @RequestParam("limit") limit: Int = 500,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): Content
@@ -94,9 +94,9 @@ public interface ExamplePath2Client {
         method = "HEAD",
     )
     public fun headOperationIdExample(
-        @PathVariable("pathParam") pathParam: String,
-        @RequestParam("queryParam3") queryParam3: Boolean? = null,
-        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @PathVariable("path_param") pathParam: String,
+        @RequestParam("query_param3") queryParam3: Boolean? = null,
+        @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )
@@ -114,8 +114,8 @@ public interface ExamplePath2Client {
     )
     public fun putExamplePath2PathParam(
         @RequestBody firstModel: FirstModel,
-        @PathVariable("pathParam") pathParam: String,
-        @RequestHeader("ifMatch") ifMatch: String,
+        @PathVariable("path_param") pathParam: String,
+        @RequestHeader("If-Match") ifMatch: String,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )
@@ -137,9 +137,9 @@ public interface ExamplePath3SubresourceClient {
     )
     public fun putExamplePath3PathParamSubresource(
         @RequestBody firstModel: FirstModel,
-        @PathVariable("pathParam") pathParam: String,
-        @RequestHeader("ifMatch") ifMatch: String,
-        @RequestParam("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @PathVariable("path_param") pathParam: String,
+        @RequestHeader("If-Match") ifMatch: String,
+        @RequestParam("csv_list_query_param") csvListQueryParam: List<String>? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
@@ -34,10 +34,10 @@ public interface ExamplePath1Client {
         accept = ["application/vnd.custom.media+json"],
     )
     public fun getExamplePath1(
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("headerParam1") headerParam1: String? = null,
-        @RequestHeader("headerParam2") headerParam2: String? = null,
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("header_param1") headerParam1: String? = null,
+        @RequestHeader("header_param2") headerParam2: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): ResponseEntity<QueryResult>
@@ -54,7 +54,7 @@ public interface ExamplePath1Client {
     )
     public fun postExamplePath1(
         @RequestBody content: Content,
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): ResponseEntity<Unit>
@@ -76,10 +76,10 @@ public interface ExamplePath2Client {
         accept = ["application/json"],
     )
     public fun getExamplePath2PathParam(
-        @PathVariable("pathParam") pathParam: String,
+        @PathVariable("path_param") pathParam: String,
         @RequestParam("limit") limit: Int = 500,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): ResponseEntity<Content>
@@ -96,9 +96,9 @@ public interface ExamplePath2Client {
         method = "HEAD",
     )
     public fun headOperationIdExample(
-        @PathVariable("pathParam") pathParam: String,
-        @RequestParam("queryParam3") queryParam3: Boolean? = null,
-        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @PathVariable("path_param") pathParam: String,
+        @RequestParam("query_param3") queryParam3: Boolean? = null,
+        @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): ResponseEntity<Unit>
@@ -116,8 +116,8 @@ public interface ExamplePath2Client {
     )
     public fun putExamplePath2PathParam(
         @RequestBody firstModel: FirstModel,
-        @PathVariable("pathParam") pathParam: String,
-        @RequestHeader("ifMatch") ifMatch: String,
+        @PathVariable("path_param") pathParam: String,
+        @RequestHeader("If-Match") ifMatch: String,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): ResponseEntity<Unit>
@@ -139,9 +139,9 @@ public interface ExamplePath3SubresourceClient {
     )
     public fun putExamplePath3PathParamSubresource(
         @RequestBody firstModel: FirstModel,
-        @PathVariable("pathParam") pathParam: String,
-        @RequestHeader("ifMatch") ifMatch: String,
-        @RequestParam("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @PathVariable("path_param") pathParam: String,
+        @RequestHeader("If-Match") ifMatch: String,
+        @RequestParam("csv_list_query_param") csvListQueryParam: List<String>? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): ResponseEntity<Unit>

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
@@ -32,10 +32,10 @@ public interface ExamplePath1Client {
         accept = ["application/vnd.custom.media+json"],
     )
     public suspend fun getExamplePath1(
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("headerParam1") headerParam1: String? = null,
-        @RequestHeader("headerParam2") headerParam2: String? = null,
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("header_param1") headerParam1: String? = null,
+        @RequestHeader("header_param2") headerParam2: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): QueryResult
@@ -52,7 +52,7 @@ public interface ExamplePath1Client {
     )
     public suspend fun postExamplePath1(
         @RequestBody content: Content,
-        @RequestParam("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
+        @RequestParam("explode_list_query_param") explodeListQueryParam: List<String>? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )
@@ -74,10 +74,10 @@ public interface ExamplePath2Client {
         accept = ["application/json"],
     )
     public suspend fun getExamplePath2PathParam(
-        @PathVariable("pathParam") pathParam: String,
+        @PathVariable("path_param") pathParam: String,
         @RequestParam("limit") limit: Int = 500,
-        @RequestParam("queryParam2") queryParam2: Int? = null,
-        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @RequestParam("query_param2") queryParam2: Int? = null,
+        @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     ): Content
@@ -94,9 +94,9 @@ public interface ExamplePath2Client {
         method = "HEAD",
     )
     public suspend fun headOperationIdExample(
-        @PathVariable("pathParam") pathParam: String,
-        @RequestParam("queryParam3") queryParam3: Boolean? = null,
-        @RequestHeader("ifNoneMatch") ifNoneMatch: String? = null,
+        @PathVariable("path_param") pathParam: String,
+        @RequestParam("query_param3") queryParam3: Boolean? = null,
+        @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )
@@ -114,8 +114,8 @@ public interface ExamplePath2Client {
     )
     public suspend fun putExamplePath2PathParam(
         @RequestBody firstModel: FirstModel,
-        @PathVariable("pathParam") pathParam: String,
-        @RequestHeader("ifMatch") ifMatch: String,
+        @PathVariable("path_param") pathParam: String,
+        @RequestHeader("If-Match") ifMatch: String,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )
@@ -137,9 +137,9 @@ public interface ExamplePath3SubresourceClient {
     )
     public suspend fun putExamplePath3PathParamSubresource(
         @RequestBody firstModel: FirstModel,
-        @PathVariable("pathParam") pathParam: String,
-        @RequestHeader("ifMatch") ifMatch: String,
-        @RequestParam("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @PathVariable("path_param") pathParam: String,
+        @RequestHeader("If-Match") ifMatch: String,
+        @RequestParam("csv_list_query_param") csvListQueryParam: List<String>? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )


### PR DESCRIPTION
Fixed an issue where the `name` for Kotlin was used for the parameter name of the client generated by SpringBoot Http Client instead of the `originalName`.

I should have realized this when I was writing the test code, sorry.