### PR TITLE
fix: remove property from 'required' if it's a nullable ref

### DIFF
--- a/src/test/resources/examples/openapi310/api.yaml
+++ b/src/test/resources/examples/openapi310/api.yaml
@@ -5,6 +5,8 @@ components:
       type: object
       required:
         - simpleNullable
+        - requiredNullableRef
+        - singleRequiredFieldNullableRef
       properties:
         simpleNullable:
           type:
@@ -15,6 +17,14 @@ components:
           oneOf:
             - type: 'null'
             - $ref: '#/components/schemas/OneObject'
+        requiredNullableRef:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/OneObject'
+        singleRequiredFieldNullableRef:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/SingleRequiredFieldNullableObject'
         complexNullable:
           anyOf:
             - items:
@@ -40,3 +50,11 @@ components:
       properties:
         type:
           type: string
+    SingleRequiredFieldNullableObject:
+      required:
+        - requiredNullableRef
+      properties:
+        requiredNullableRef:
+          oneOf:
+            - "$ref": "#/components/schemas/OneObject"
+            - type: 'null'

--- a/src/test/resources/examples/openapi310/models/NewNullableFormat.kt
+++ b/src/test/resources/examples/openapi310/models/NewNullableFormat.kt
@@ -17,6 +17,14 @@ public data class NewNullableFormat(
   @get:JsonProperty("objectNullable")
   @get:Valid
   public val objectNullable: OneObject? = null,
+  @param:JsonProperty("requiredNullableRef")
+  @get:JsonProperty("requiredNullableRef")
+  @get:Valid
+  public val requiredNullableRef: OneObject? = null,
+  @param:JsonProperty("singleRequiredFieldNullableRef")
+  @get:JsonProperty("singleRequiredFieldNullableRef")
+  @get:Valid
+  public val singleRequiredFieldNullableRef: SingleRequiredFieldNullableObject? = null,
   @param:JsonProperty("complexNullable")
   @get:JsonProperty("complexNullable")
   public val complexNullable: List<Any>? = null,

--- a/src/test/resources/examples/openapi310/models/SingleRequiredFieldNullableObject.kt
+++ b/src/test/resources/examples/openapi310/models/SingleRequiredFieldNullableObject.kt
@@ -1,0 +1,11 @@
+package examples.openapi310.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+
+public data class SingleRequiredFieldNullableObject(
+  @param:JsonProperty("requiredNullableRef")
+  @get:JsonProperty("requiredNullableRef")
+  @get:Valid
+  public val requiredNullableRef: OneObject? = null,
+)

--- a/src/test/resources/examples/requiredReadOnly/api.yaml
+++ b/src/test/resources/examples/requiredReadOnly/api.yaml
@@ -6,10 +6,15 @@ components:
       required:
         - user_name
         - created
+        - created_by
       properties:
         user_name:
           type: string
         created:
           type: string
           format: date-time
+          readOnly: true
+        created_by:
+          type: string
+          nullable: true
           readOnly: true

--- a/src/test/resources/examples/requiredReadOnly/models/RequiredReadOnly.kt
+++ b/src/test/resources/examples/requiredReadOnly/models/RequiredReadOnly.kt
@@ -13,4 +13,7 @@ public data class RequiredReadOnly(
   @param:JsonProperty("created")
   @get:JsonProperty("created")
   public val created: OffsetDateTime? = null,
+  @param:JsonProperty("created_by")
+  @get:JsonProperty("created_by")
+  public val createdBy: String? = null,
 )


### PR DESCRIPTION
In OAS v3.1 with the `oneOf` syntax, nullable required `$ref` properties were being generated as non-nullable kotlin types. This PR works around the issue by removing the property from the `required` list if it's a nullable ref.

The following openapi
```yaml
openapi: 3.1.0
components:
  schemas:
    NewNullableFormat:
      type: object
      required:
        - requiredNullableRef
      properties:
        requiredNullableRef:
          oneOf:
            - type: 'null'
            - $ref: '#/components/schemas/OneObject'
```
will be downgraded to the equivalent OAS 3.0
```yaml
openapi: 3.1.0
components:
  schemas:
    NewNullableFormat:
      type: object
      properties:
        requiredNullableRef:
          $ref: '#/components/schemas/OneObject'
          nullable: true  # will be ignored
```
Fixes #424