### PR TITLE
fix spring http interface path param name

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -158,10 +158,7 @@ class SpringHttpInterfaceGenerator(
         }
 
         private fun AnnotationSpec.Builder.addUrl(): AnnotationSpec.Builder = apply {
-            val pathParameters = parameters.getPathParameters()
-            val resolvedResource = resourceWithDeduplicatedParamNames(resource, pathParameters)
-
-            addMember("url=%S", resolvedResource)
+            addMember("url=%S", resource)
         }
 
         private fun AnnotationSpec.Builder.addContentType(
@@ -233,19 +230,6 @@ class SpringHttpInterfaceGenerator(
         private fun List<IncomingParameter>.getPathParameters(): List<RequestParameter> =
             filterIsInstance<RequestParameter>()
                 .filter { it.parameterLocation is PathParam }
-
-        private fun resourceWithDeduplicatedParamNames(
-            resource: String,
-            pathParameters: List<RequestParameter>,
-        ): String {
-            var resolvedResource = resource
-            pathParameters.forEach { parameter ->
-                if (parameter.originalName != parameter.name) {
-                    resolvedResource = resolvedResource.replace("{${parameter.originalName}}", "{${parameter.name}}")
-                }
-            }
-            return resolvedResource
-        }
     }
 
     override fun generateLibrary(options: Set<ClientCodeGenOptionType>): Collection<GeneratedFile> = setOf()

--- a/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/parameterNameClash/client/SpringHttpInterfaceClient.kt
@@ -20,7 +20,7 @@ public interface ExampleClient {
      * @param queryB
      */
     @HttpExchange(
-        url = "/example/{pathB}",
+        url = "/example/{b}",
         method = "GET",
     )
     public fun getExampleB(

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
@@ -69,7 +69,7 @@ public interface ExamplePath2Client {
      * @param ifNoneMatch The RFC7232 If-None-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "GET",
         accept = ["application/json"],
     )
@@ -90,7 +90,7 @@ public interface ExamplePath2Client {
      * @param ifNoneMatch The RFC7232 If-None-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "HEAD",
     )
     public fun headOperationIdExample(
@@ -109,7 +109,7 @@ public interface ExamplePath2Client {
      * @param ifMatch The RFC7232 If-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "PUT",
     )
     public fun putExamplePath2PathParam(
@@ -132,7 +132,7 @@ public interface ExamplePath3SubresourceClient {
      * @param csvListQueryParam
      */
     @HttpExchange(
-        url = "/example-path-3/{pathParam}/subresource",
+        url = "/example-path-3/{path_param}/subresource",
         method = "PUT",
     )
     public fun putExamplePath3PathParamSubresource(

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
@@ -71,7 +71,7 @@ public interface ExamplePath2Client {
      * @param ifNoneMatch The RFC7232 If-None-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "GET",
         accept = ["application/json"],
     )
@@ -92,7 +92,7 @@ public interface ExamplePath2Client {
      * @param ifNoneMatch The RFC7232 If-None-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "HEAD",
     )
     public fun headOperationIdExample(
@@ -111,7 +111,7 @@ public interface ExamplePath2Client {
      * @param ifMatch The RFC7232 If-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "PUT",
     )
     public fun putExamplePath2PathParam(
@@ -134,7 +134,7 @@ public interface ExamplePath3SubresourceClient {
      * @param csvListQueryParam
      */
     @HttpExchange(
-        url = "/example-path-3/{pathParam}/subresource",
+        url = "/example-path-3/{path_param}/subresource",
         method = "PUT",
     )
     public fun putExamplePath3PathParamSubresource(

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
@@ -69,7 +69,7 @@ public interface ExamplePath2Client {
      * @param ifNoneMatch The RFC7232 If-None-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "GET",
         accept = ["application/json"],
     )
@@ -90,7 +90,7 @@ public interface ExamplePath2Client {
      * @param ifNoneMatch The RFC7232 If-None-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "HEAD",
     )
     public suspend fun headOperationIdExample(
@@ -109,7 +109,7 @@ public interface ExamplePath2Client {
      * @param ifMatch The RFC7232 If-Match header field
      */
     @HttpExchange(
-        url = "/example-path-2/{pathParam}",
+        url = "/example-path-2/{path_param}",
         method = "PUT",
     )
     public suspend fun putExamplePath2PathParam(
@@ -132,7 +132,7 @@ public interface ExamplePath3SubresourceClient {
      * @param csvListQueryParam
      */
     @HttpExchange(
-        url = "/example-path-3/{pathParam}/subresource",
+        url = "/example-path-3/{path_param}/subresource",
         method = "PUT",
     )
     public suspend fun putExamplePath3PathParamSubresource(


### PR DESCRIPTION
Fixed a problem where `@PathVariable` argument and `@HttpExchange` argument did not match in name