### PR TITLE
Change AnyType header to String in generated client code.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -43,7 +43,7 @@ object ClientGeneratorUtils {
      * If no response body is found, Unit is returned.
      */
     fun Operation.getReturnType(packages: Packages): TypeName {
-        return if(!hasAnySuccessResponseSchemas()){
+        return if (!hasAnySuccessResponseSchemas()) {
             Unit::class.asTypeName()
         } else if (hasMultipleSuccessResponseSchemas()) {
             JsonNode::class.asTypeName()
@@ -105,7 +105,7 @@ object ClientGeneratorUtils {
         annotateBodyParameterWith: ((parameter: BodyParameter) -> AnnotationSpec?)? = null,
     ): FunSpec.Builder {
         val specs = parameters.map {
-            val builder = it.toParameterSpecBuilder()
+            val builder = it.toParameterSpecBuilder(treatAnyTypeHeadersAsStrings = true)
             if (it is RequestParameter) {
                 if (it.defaultValue != null) OasDefault.from(it.typeInfo, it.type, it.defaultValue)
                     ?.let { t -> builder.defaultValue(t.getDefault()) }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -12,6 +12,7 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asTypeName
 
 sealed class GeneratedType(val spec: TypeSpec, val destinationPackage: String) {
     val className = ClassName(destinationPackage, spec.name!!)
@@ -68,7 +69,7 @@ fun <T : GeneratedType> Collection<T>.toFileSpec(): Collection<FileSpec> = this
  */
 sealed class IncomingParameter(val oasName: String, val description: String?, val type: TypeName) {
     val name: String = oasName.toKotlinParameterName()
-    open fun toParameterSpecBuilder(): ParameterSpec.Builder =
+    open fun toParameterSpecBuilder(treatAnyTypeHeadersAsStrings: Boolean = false): ParameterSpec.Builder =
         ParameterSpec.builder(name, type)
 }
 
@@ -101,4 +102,12 @@ class RequestParameter(
         explode = parameter.explode,
         defaultValue = parameter.schema.default
     )
+
+    override fun toParameterSpecBuilder(treatAnyTypeHeadersAsStrings: Boolean): ParameterSpec.Builder =
+        if (treatAnyTypeHeadersAsStrings && parameterLocation == HeaderParam && typeInfo == KotlinTypeInfo.AnyType) {
+            ParameterSpec.builder(
+                name = name,
+                type = if (isRequired) String::class.asTypeName() else String::class.asTypeName().copy(nullable = true)
+            )
+        } else super.toParameterSpecBuilder(treatAnyTypeHeadersAsStrings)
 }

--- a/src/test/resources/examples/okHttpClient/api.yaml
+++ b/src/test/resources/examples/okHttpClient/api.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: "3.1.0"
 info:
   title: "API Example"
   version: "1.0"
@@ -10,6 +10,7 @@ paths:
         - $ref: "#/components/parameters/ListQueryParamExploded"
         - $ref: "#/components/parameters/QueryParam2"
         - $ref: "#/components/parameters/ListQueryParamInt"
+        - $ref: "#/components/parameters/JsonEncodedHeaderParam"
       responses:
         200:
           description: "successful operation"
@@ -217,6 +218,20 @@ components:
         type: boolean
       required: false
 
+    JsonEncodedHeaderParam:
+      name: X-Json-Encoded-Header
+      in: header
+      description: Json Encoded header
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/JsonEncodedHeader"
+            example:
+              headerProp1: value
+              headerProp2: anotherValue
+              nestedProp:
+                nestedProp1: nestedValue
+
   headers:
     Location:
       description: "The Location header indicates the URL of a newly created resource"
@@ -371,4 +386,12 @@ components:
         error:
           type: string
         subType:
+          type: string
+
+    JsonEncodedHeader:
+      type: "object"
+      properties:
+        headerProp1:
+          type: string
+        headerProp2:
           type: string

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -33,12 +33,14 @@ public class ExamplePath1Client(
      * @param explodeListQueryParam
      * @param queryParam2
      * @param intListQueryParam
+     * @param xJsonEncodedHeader Json Encoded header
      */
     @Throws(ApiException::class)
     public fun getExamplePath1(
         explodeListQueryParam: List<String>? = null,
         queryParam2: Int? = null,
         intListQueryParam: List<Int>? = null,
+        xJsonEncodedHeader: String? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
         additionalQueryParameters: Map<String, String> = emptyMap(),
     ): ApiResponse<QueryResult> {
@@ -52,7 +54,10 @@ public class ExamplePath1Client(
                 .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
                 .build()
 
-        val headerBuilder = Headers.Builder()
+        val headerBuilder =
+            Headers
+                .Builder()
+                .`header`("X-Json-Encoded-Header", xJsonEncodedHeader)
         additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
         val httpHeaders: Headers = headerBuilder.build()
 

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -45,10 +45,11 @@ public class ExamplePath1Service(
         explodeListQueryParam: List<String>? = null,
         queryParam2: Int? = null,
         intListQueryParam: List<Int>? = null,
+        xJsonEncodedHeader: String? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
     ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.getExamplePath1(explodeListQueryParam, queryParam2, intListQueryParam, additionalHeaders)
+            apiClient.getExamplePath1(explodeListQueryParam, queryParam2, intListQueryParam, xJsonEncodedHeader, additionalHeaders)
         }
 
     @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClient/models/ClientModels.kt
+++ b/src/test/resources/examples/okHttpClient/models/ClientModels.kt
@@ -165,6 +165,15 @@ public data class FirstModel(
     override val modelType: ContentModelType = ContentModelType.FIRST_MODEL,
 ) : Content(id, firstAttr, secondAttr, thirdAttr, etag)
 
+public data class JsonEncodedHeader(
+    @param:JsonProperty("headerProp1")
+    @get:JsonProperty("headerProp1")
+    public val headerProp1: String? = null,
+    @param:JsonProperty("headerProp2")
+    @get:JsonProperty("headerProp2")
+    public val headerProp2: String? = null,
+)
+
 public data class QueryResult(
     @param:JsonProperty("items")
     @get:JsonProperty("items")

--- a/src/test/resources/examples/pathLevelParameters/api.yaml
+++ b/src/test/resources/examples/pathLevelParameters/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   version: '1'
   title: pathLevelParameters
@@ -10,6 +10,18 @@ paths:
         required: true
         schema:
           type: string
+      - name: X-Json-Encoded-Header
+        in: header
+        description: Json Encoded header
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JsonEncodedHeader"
+              example:
+                headerProp1: value
+                headerProp2: anotherValue
+                nestedProp:
+                  nestedProp1: nestedValue
     get:
       parameters:
         - in: query
@@ -20,3 +32,13 @@ paths:
       responses:
         '204':
           description: example
+
+components:
+  schemas:
+    JsonEncodedHeader:
+      type: "object"
+      properties:
+        headerProp1:
+          type: string
+        headerProp2:
+          type: string

--- a/src/test/resources/examples/pathLevelParameters/client/ApiClient.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiClient.kt
@@ -24,11 +24,13 @@ public class ExampleClient(
      *
      * @param a
      * @param b
+     * @param xJsonEncodedHeader Json Encoded header
      */
     @Throws(ApiException::class)
     public fun getExample(
         a: String,
         b: String,
+        xJsonEncodedHeader: String? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
         additionalQueryParameters: Map<String, String> = emptyMap(),
     ): ApiResponse<Unit> {
@@ -41,7 +43,10 @@ public class ExampleClient(
                 .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
                 .build()
 
-        val headerBuilder = Headers.Builder()
+        val headerBuilder =
+            Headers
+                .Builder()
+                .`header`("X-Json-Encoded-Header", xJsonEncodedHeader)
         additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
         val httpHeaders: Headers = headerBuilder.build()
 

--- a/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/ApiService.kt
@@ -33,9 +33,10 @@ public class ExampleService(
     public fun getExample(
         a: String,
         b: String,
+        xJsonEncodedHeader: String? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
     ): ApiResponse<Unit> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.getExample(a, b, additionalHeaders)
+            apiClient.getExample(a, b, xJsonEncodedHeader, additionalHeaders)
         }
 }

--- a/src/test/resources/examples/pathLevelParameters/client/OpenFeignClient.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/OpenFeignClient.kt
@@ -1,6 +1,7 @@
 package examples.pathLevelParameters.client
 
 import feign.HeaderMap
+import feign.Headers
 import feign.Param
 import feign.QueryMap
 import feign.RequestLine
@@ -15,11 +16,14 @@ public interface ExampleClient {
      *
      * @param a
      * @param b
+     * @param xJsonEncodedHeader Json Encoded header
      */
     @RequestLine("GET /example?a={a}&b={b}")
+    @Headers("X-Json-Encoded-Header: {xJsonEncodedHeader}")
     public fun getExample(
         @Param("a") a: String,
         @Param("b") b: String,
+        @Param("xJsonEncodedHeader") xJsonEncodedHeader: String? = null,
         @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
         @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
     )

--- a/src/test/resources/examples/pathLevelParameters/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/SpringHttpInterfaceClient.kt
@@ -15,6 +15,7 @@ public interface ExampleClient {
      *
      * @param a
      * @param b
+     * @param xJsonEncodedHeader Json Encoded header
      */
     @HttpExchange(
         url = "/example",
@@ -23,6 +24,7 @@ public interface ExampleClient {
     public fun getExample(
         @RequestParam("a") a: String,
         @RequestParam("b") b: String,
+        @RequestHeader("X-Json-Encoded-Header") xJsonEncodedHeader: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
         @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
     )

--- a/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/ktor/Controllers.kt
@@ -25,9 +25,11 @@ public interface ExampleController {
      *
      * @param a
      * @param b
+     * @param xJsonEncodedHeader Json Encoded header
      * @param call The Ktor application call
      */
     public suspend fun `get`(
+        xJsonEncodedHeader: String?,
         a: String,
         b: String,
         call: ApplicationCall,
@@ -41,9 +43,10 @@ public interface ExampleController {
          */
         public fun Route.exampleRoutes(controller: ExampleController) {
             `get`("/example") {
+                val xJsonEncodedHeader = call.request.headers["X-Json-Encoded-Header"]
                 val a = call.request.queryParameters.getTypedOrFail<kotlin.String>("a")
                 val b = call.request.queryParameters.getTypedOrFail<kotlin.String>("b")
-                controller.get(a, b, call)
+                controller.get(xJsonEncodedHeader, a, b, call)
             }
         }
 

--- a/src/test/resources/examples/pathLevelParameters/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/micronaut/Controllers.kt
@@ -3,8 +3,10 @@ package examples.pathLevelParameters.controllers
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.`annotation`.Controller
 import io.micronaut.http.`annotation`.Get
+import io.micronaut.http.`annotation`.Header
 import io.micronaut.http.`annotation`.QueryValue
 import io.micronaut.security.rules.SecurityRule
+import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 
@@ -15,10 +17,12 @@ public interface ExampleController {
      *
      * @param a
      * @param b
+     * @param xJsonEncodedHeader Json Encoded header
      */
     @Get(uri = "/example")
     public fun `get`(
         @QueryValue(value = "a") a: String,
         @QueryValue(value = "b") b: String,
+        @Header(value = "X-Json-Encoded-Header") xJsonEncodedHeader: Any?,
     ): HttpResponse<Unit>
 }

--- a/src/test/resources/examples/pathLevelParameters/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/pathLevelParameters/controllers/spring/Controllers.kt
@@ -4,9 +4,11 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestHeader
 import org.springframework.web.bind.`annotation`.RequestMapping
 import org.springframework.web.bind.`annotation`.RequestMethod
 import org.springframework.web.bind.`annotation`.RequestParam
+import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 
@@ -19,6 +21,7 @@ public interface ExampleController {
      *
      * @param a
      * @param b
+     * @param xJsonEncodedHeader Json Encoded header
      */
     @RequestMapping(
         value = ["/example"],
@@ -27,9 +30,7 @@ public interface ExampleController {
     )
     public fun `get`(
         @RequestParam(value = "a", required = true) a: String,
-        @RequestParam(
-            value = "b",
-            required = true,
-        ) b: String,
+        @RequestParam(value = "b", required = true) b: String,
+        @RequestHeader(value = "X-Json-Encoded-Header", required = false) xJsonEncodedHeader: Any?,
     ): ResponseEntity<Unit>
 }

--- a/src/test/resources/examples/pathLevelParameters/models/ClientModels.kt
+++ b/src/test/resources/examples/pathLevelParameters/models/ClientModels.kt
@@ -1,0 +1,13 @@
+package examples.pathLevelParameters.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class JsonEncodedHeader(
+    @param:JsonProperty("headerProp1")
+    @get:JsonProperty("headerProp1")
+    public val headerProp1: String? = null,
+    @param:JsonProperty("headerProp2")
+    @get:JsonProperty("headerProp2")
+    public val headerProp2: String? = null,
+)


### PR DESCRIPTION
The Okhttp client code does not compile when a AnyType is used as a header value