### PR TITLE
Fix Missing marker interface for oneOf.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -188,7 +188,7 @@ class ModelGenerator(
 
     private fun createModels(api: OpenApi3, schemas: List<SchemaInfo>) = schemas
         .filterNot { it.schema.isSimpleType() }
-        .filterNot { it.schema.isOneOfPolymorphicTypes() }
+        .filterNot { it.schema.isOneOfPolymorphicTypes() && SEALED_INTERFACES_FOR_ONE_OF !in options }
         .flatMap { schemaInfo ->
             val properties = schemaInfo.schema.topLevelProperties(HTTP_SETTINGS, api, schemaInfo.schema)
             when {

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -290,11 +290,16 @@ object KaizenParserExtensions {
     fun Schema.isOneOfPolymorphicTypes() =
         this.oneOfSchemas?.firstOrNull()?.allOfSchemas?.firstOrNull() != null
 
-    fun Schema.isInlinedOneOfSuperInterface() = isOneOfSuperInterface() && isInlinedPropertySchema()
+    fun Schema.isInlinedOneOfSuperInterface() = isOneOfSuperInterfaceOnly() && isInlinedPropertySchema()
+
+    // Not part of any other aggregations
+    fun Schema.isOneOfSuperInterfaceOnly() =
+        oneOfSchemas.isNotEmpty() && allOfSchemas.isEmpty() && anyOfSchemas.isEmpty() && properties.isEmpty() &&
+            oneOfSchemas.all { it.isObjectType() }
 
     fun Schema.isOneOfSuperInterface() =
         oneOfSchemas.isNotEmpty() && allOfSchemas.isEmpty() && anyOfSchemas.isEmpty() && properties.isEmpty() &&
-            oneOfSchemas.all { it.isObjectType() }
+            oneOfSchemas.all { it.isObjectType() || it.isAggregatedObject() }
 
     fun Schema.isOneOfSuperInterfaceWithDiscriminator() =
         discriminator != null && discriminator.propertyName != null && isOneOfSuperInterface()

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -90,7 +90,7 @@ class ModelGeneratorTest {
         if (testCaseName == "instantDateTime") {
             MutableSettings.addOption(CodeGenTypeOverride.DATETIME_AS_INSTANT)
         }
-        if (testCaseName == "discriminatedOneOf" || testCaseName == "oneOfMarkerInterface") {
+        if (testCaseName == "discriminatedOneOf" || testCaseName == "oneOfMarkerInterface" || testCaseName == "polymorphicModels") {
             MutableSettings.addOption(ModelCodeGenOptionType.SEALED_INTERFACES_FOR_ONE_OF)
         }
         if (testCaseName == "mapExamplesNonNullValues") {

--- a/src/test/resources/examples/polymorphicModels/api.yaml
+++ b/src/test/resources/examples/polymorphicModels/api.yaml
@@ -1,6 +1,13 @@
 openapi: 3.0.0
 components:
   schemas:
+    PolymorphicType:
+      discriminator:
+        propertyName: generation
+      oneOf:
+        - $ref: "#/components/schemas/PolymorphicTypeOne"
+        - $ref: "#/components/schemas/polymorphic_type_two"
+
     PolymorphicTypeOneRef:
       $ref: "#/components/schemas/PolymorphicTypeOne"
     PolymorphicTypeOneAnotherRef:

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicType.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicType.kt
@@ -1,0 +1,15 @@
+package examples.polymorphicModels.models
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  property = "generation",
+  visible = true,
+)
+@JsonSubTypes(JsonSubTypes.Type(value = PolymorphicTypeOne::class, name =
+    "PolymorphicTypeOne"),JsonSubTypes.Type(value = PolymorphicTypeTwo::class, name =
+    "polymorphic_type_two"))
+public sealed interface PolymorphicType

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOne.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOne.kt
@@ -27,4 +27,4 @@ public data class PolymorphicTypeOne(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "PolymorphicTypeOne",
-) : PolymorphicSuperType(firstName, lastName, pets)
+) : PolymorphicSuperType(firstName, lastName, pets), PolymorphicType

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneAnotherRef.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneAnotherRef.kt
@@ -27,4 +27,4 @@ public data class PolymorphicTypeOneAnotherRef(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "PolymorphicTypeOne",
-) : PolymorphicSuperType(firstName, lastName, pets)
+) : PolymorphicSuperType(firstName, lastName, pets), PolymorphicType

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneRef.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeOneRef.kt
@@ -27,4 +27,4 @@ public data class PolymorphicTypeOneRef(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "PolymorphicTypeOne",
-) : PolymorphicSuperType(firstName, lastName, pets)
+) : PolymorphicSuperType(firstName, lastName, pets), PolymorphicType

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwo.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwo.kt
@@ -31,4 +31,4 @@ public data class PolymorphicTypeTwo(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "polymorphic_type_two",
-) : PolymorphicSuperType(firstName, lastName, pets)
+) : PolymorphicSuperType(firstName, lastName, pets), PolymorphicType

--- a/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwoRef.kt
+++ b/src/test/resources/examples/polymorphicModels/models/PolymorphicTypeTwoRef.kt
@@ -31,4 +31,4 @@ public data class PolymorphicTypeTwoRef(
   @get:NotNull
   @param:JsonProperty("generation")
   override val generation: String = "polymorphic_type_two",
-) : PolymorphicSuperType(firstName, lastName, pets)
+) : PolymorphicSuperType(firstName, lastName, pets), PolymorphicType


### PR DESCRIPTION
When making use of both oneOf and allOf, with sealed interfaces for oneOf, the marker interface for the oneOf was not getting generated.

Cleanup PR extracted to #451 , which should be merged first