### PR TITLE
RFC: Add Ktor client generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The library currently has support for generating:
 * Clients
   * **OkHttp Client (w/ Jackson Models)** - with the option for a resilience4j fault-tolerance wrapper
   * **OpenFeign** annotated client interfaces
+  * **Ktor Client (w/ Kotlinx.serialization Models)**
 * Controllers
   * **Spring MVC** annotated controller interfaces
   * **Micronaut** HTTP annotated controller interfaces
@@ -201,6 +202,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                               |   `OK_HTTP` - Generate OkHttp client. |
 |                               |   `OPEN_FEIGN` - Generate OpenFeign client. |
 |                               |   `SPRING_HTTP_INTERFACE` - Generate Spring HTTP Interface. |
+|                               |   `KTOR` - Generate Ktor client. |
 |   `--http-controller-opts`    | Select the options for the controllers that you want to be generated. |
 |                               | CHOOSE ANY OF: |
 |                               |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated controller functions |

--- a/end2end-tests/ktor-client-kotlinx/build.gradle.kts
+++ b/end2end-tests/ktor-client-kotlinx/build.gradle.kts
@@ -1,0 +1,92 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+val generationDir = "$buildDir/generated"
+
+sourceSets {
+    main { java.srcDirs("$generationDir/src/main/kotlin") }
+    test { java.srcDirs("$generationDir/src/test/kotlin") }
+}
+
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.serialization") version "2.0.20"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+val junitVersion: String by rootProject.extra
+val ktorVersion: String by rootProject.extra
+val kotlinxDateTimeVersion: String by rootProject.extra
+
+dependencies {
+    // ktor client
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
+    implementation("io.ktor:ktor-client-resources:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion")
+
+    // ktor test
+    testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
+    testImplementation("io.mockk:mockk:1.13.7")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    testImplementation("org.assertj:assertj-core:3.24.2")
+    testImplementation("org.wiremock:wiremock:3.3.1")
+    testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+}
+
+tasks {
+    val generateCode = createGenerateCodeTask(
+        "generateKtorCode",
+        "src/test/resources/examples/ktorClient/api.yaml"
+    )
+
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        compilerOptions {
+            optIn.add("kotlinx.serialization.ExperimentalSerializationApi")
+            optIn.add("kotlin.time.ExperimentalTime")
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+        dependsOn(generateCode)
+    }
+
+    withType<Test> {
+        useJUnitPlatform()
+        jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED")
+        dependsOn(generateCode)
+    }
+}
+
+fun createGenerateCodeTask(name: String, apiFilePath: String, additionalArgs: List<String> = emptyList()) =
+    tasks.create(name, JavaExec::class) {
+    val apiFile = "${rootProject.projectDir}/$apiFilePath"
+    inputs.files(apiFile)
+    outputs.dir(generationDir)
+    outputs.cacheIf { true }
+    classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
+    mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
+    args = listOf(
+        "--output-directory", generationDir,
+        "--base-package", "com.example",
+        "--api-file", apiFile,
+        "--targets", "http_models",
+        "--targets", "client",
+        "--http-client-target", "ktor",
+        "--serialization-library", "kotlinx_serialization",
+        "--validation-library", "no_validation"
+    ).plus(additionalArgs)
+    dependsOn(":jar")
+    dependsOn(":shadowJar")
+}

--- a/end2end-tests/ktor-client-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/routing/ktor/KtorClientKotlinxTest.kt
+++ b/end2end-tests/ktor-client-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/routing/ktor/KtorClientKotlinxTest.kt
@@ -1,0 +1,302 @@
+package com.cjbooms.fabrikt.routing.ktor
+
+import com.example.client.CatalogsItemsAvailabilityClient
+import com.example.client.CatalogsItemsClient
+import com.example.client.CatalogsSearchClient
+import com.example.client.UptimeClient
+import com.example.models.Item
+import com.example.models.SortOrder
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.marcinziolo.kotlin.wiremock.like
+import com.marcinziolo.kotlin.wiremock.post
+import com.marcinziolo.kotlin.wiremock.returns
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.resources.Resources
+import io.ktor.client.plugins.resources.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import io.ktor.resources.href
+import io.ktor.resources.serialization.ResourcesFormat
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.testing.testApplication
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertInstanceOf
+import java.net.ServerSocket
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorClientKotlinxTest {
+
+    private val port: Int = ServerSocket(0).use { socket -> socket.localPort }
+
+    private val wiremock: WireMockServer = WireMockServer(options().port(port).notifier(ConsoleNotifier(true)))
+
+    @BeforeEach
+    fun setUp() {
+        wiremock.start()
+    }
+
+    @Nested
+    inner class Client {
+        @Test
+        fun `client performs post with body`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 201
+                body = """
+                    {
+                        "id": "id-1",
+                        "name": "item-a",
+                        "description": "description-a",
+                        "price": 123.45
+                    }
+                """.trimIndent()
+                header = "Content-Type" to "application/json"
+            }
+
+            val httpClient = HttpClient(CIO) {
+                install(Resources)
+                install(ContentNegotiation) {
+                    json()
+                }
+                defaultRequest {
+                    url(wiremock.baseUrl())
+                }
+            }
+            val client = CatalogsItemsClient(httpClient)
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(
+                        id = "id-1",
+                        name = "item-a",
+                        description = "description-a",
+                        price = 123.45
+                    ),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                when (result) {
+                    is CatalogsItemsClient.CreateItemResult.Success -> {
+                        println("Created item with name: ${result.data.name}. Status code: ${result.response.status}")
+                    }
+
+                    is CatalogsItemsClient.CreateItemResult.Error -> {
+                        fail("Failed to create item.\nStatus code: ${result.response.status}\nBody: ${result.response.bodyAsText()}")
+                    }
+                }
+            }
+        }
+
+        @Test
+        fun `client performs post and gets 404 back`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 404
+                body = "Not found"
+            }
+
+            val httpClient = HttpClient(CIO) {
+                install(Resources)
+                install(ContentNegotiation) {
+                    json()
+                }
+                defaultRequest {
+                    url(wiremock.baseUrl())
+                }
+            }
+            val client = CatalogsItemsClient(httpClient)
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(
+                        id = "id-1",
+                        name = "item-a",
+                        description = "description-a",
+                        price = 123.45
+                    ),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                when (result) {
+                    is CatalogsItemsClient.CreateItemResult.Success -> {
+                        fail("Expected 404 but got success")
+                    }
+
+                    is CatalogsItemsClient.CreateItemResult.Error -> {
+                        println("Failed to create item. Status code: ${result.response.status}")
+                    }
+                }
+            }
+        }
+
+        @Test
+        fun `request can be performed using generated client`() = runBlocking {
+            val capturedCatalogId = slot<String?>()
+            val capturedQuery = slot<String?>()
+            val capturedPage = slot<String?>()
+            val capturedSort = slot<String?>()
+
+            testApplication {
+                routing {
+                    get("/catalogs/{catalogId}/search") {
+                        val catalogId = call.parameters["catalogId"]
+                        val query = call.request.queryParameters["query"]
+                        val page = call.request.queryParameters["page"]
+                        val sort = call.request.queryParameters["sort"]
+
+                        capturedCatalogId.captured = catalogId
+                        capturedQuery.captured = query
+                        capturedPage.captured = page
+                        capturedSort.captured = sort
+
+                        call.response.headers.append("Content-Type", "application/json")
+                        call.respond("""
+                        [
+                            {
+                                "id": "id-1",
+                                "name": "item-a",
+                                "description": "description-a",
+                                "price": 123.45
+                            }
+                        ]
+                    """.trimIndent())
+                    }
+                }
+
+                val httpClient = createClient {
+                    install(Resources)
+                    install(ContentNegotiation) {
+                        json()
+                    }
+                }
+
+                val client = CatalogsSearchClient(httpClient)
+
+                val response = client.searchCatalogItems("catalog-a", "query", 10, SortOrder.DESC)
+
+                assertInstanceOf<CatalogsSearchClient.SearchCatalogItemsResult.Success>(response)
+                assertEquals("catalog-a", capturedCatalogId.captured)
+                assertEquals("query", capturedQuery.captured)
+                assertEquals("10", capturedPage.captured)
+                assertEquals("desc", capturedSort.captured)
+            }
+        }
+    }
+
+    @Nested
+    inner class Resources {
+        @Test
+        fun `should generate URI with required params`() {
+            val resFormat = ResourcesFormat()
+
+            val uri = href(resFormat, CatalogsSearchClient.SearchCatalogItems("catalog-a", "query"))
+
+            assertEquals("/catalogs/catalog-a/search?query=query", uri)
+        }
+
+        @Test
+        fun `should generate URI with all params`() {
+            val resFormat = ResourcesFormat()
+
+            val uri = href(
+                resFormat,
+                CatalogsSearchClient.SearchCatalogItems(
+                    catalogId = "catalog-a",
+                    query = "query",
+                    page = 1,
+                    sort = SortOrder.ASC
+                )
+            )
+
+            assertEquals(
+                "/catalogs/catalog-a/search?query=query&page=1&sort=asc",
+                uri
+            )
+        }
+
+        @Test
+        fun `resource name is generated correctly`() {
+            val resFormat = ResourcesFormat()
+
+            val uri = href(resFormat, CatalogsItemsAvailabilityClient.GetByCatalogIdAndItemId("catalog-a", "item-b"))
+
+            assertEquals("/catalogs/catalog-a/items/item-b/availability", uri)
+        }
+
+        @Test
+        fun `operationId with underscore and dash works`() {
+            val resFormat = ResourcesFormat()
+
+            val uri = href(resFormat, UptimeClient.`Get_System-Uptime`())
+
+            assertEquals("/uptime", uri)
+        }
+
+        @Test
+        fun `request can be performed using Ktor client and the Resources plugin`() = runBlocking {
+            val capturedCatalogId = slot<String?>()
+            val capturedQuery = slot<String?>()
+            val capturedPage = slot<String?>()
+            val capturedSort = slot<String?>()
+
+            testApplication {
+                routing {
+                    get("/catalogs/{catalogId}/search") {
+                        val catalogId = call.parameters["catalogId"]
+                        val query = call.request.queryParameters["query"]
+                        val page = call.request.queryParameters["page"]
+                        val sort = call.request.queryParameters["sort"]
+
+                        capturedCatalogId.captured = catalogId
+                        capturedQuery.captured = query
+                        capturedPage.captured = page
+                        capturedSort.captured = sort
+
+                        call.respond(HttpStatusCode.NoContent)
+                    }
+                }
+
+                val client = createClient {
+                    install(Resources)
+                }
+
+                val httpResponse = client.get(
+                    CatalogsSearchClient.SearchCatalogItems(
+                        catalogId = "catalog-a",
+                        query = "query",
+                        page = 10,
+                        sort = SortOrder.DESC
+                    )
+                )
+
+                assertTrue(httpResponse.status.isSuccess())
+                assertEquals("catalog-a", capturedCatalogId.captured)
+                assertEquals("query", capturedQuery.captured)
+                assertEquals("10", capturedPage.captured)
+                assertEquals("desc", capturedSort.captured)
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     "end2end-tests:okhttp",
     "end2end-tests:openfeign",
     "end2end-tests:ktor",
+    "end2end-tests:ktor-client-kotlinx",
     "end2end-tests:spring-http-interface",
     "end2end-tests:models-jackson",
     "end2end-tests:models-kotlinx",

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -43,6 +43,7 @@ enum class ClientCodeGenTargetType(val description: String) {
     OK_HTTP("Generate OkHttp client."),
     OPEN_FEIGN("Generate OpenFeign client."),
     SPRING_HTTP_INTERFACE("Generate Spring HTTP Interface."),
+    KTOR("Generate Ktor client.")
     ;
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenerator.kt
@@ -12,6 +12,7 @@ import com.cjbooms.fabrikt.generators.client.SpringHttpInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.KtorControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.MicronautControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.SpringControllerInterfaceGenerator
+import com.cjbooms.fabrikt.generators.controller.KtorClientGenerator
 import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.generators.model.QuarkusReflectionModelGenerator
 import com.cjbooms.fabrikt.model.GeneratedFile
@@ -50,6 +51,7 @@ class CodeGenerator(
             ClientCodeGenTargetType.OK_HTTP -> OkHttpClientGenerator(packages, sourceApi, srcPath)
             ClientCodeGenTargetType.OPEN_FEIGN -> OpenFeignInterfaceGenerator(packages, sourceApi)
             ClientCodeGenTargetType.SPRING_HTTP_INTERFACE -> SpringHttpInterfaceGenerator(packages, sourceApi)
+            ClientCodeGenTargetType.KTOR -> KtorClientGenerator(packages, sourceApi)
         }
         val options = MutableSettings.clientOptions
         val clientFiles = clientGenerator.generate(options).files

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -2,8 +2,11 @@ package com.cjbooms.fabrikt.generators
 
 import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.model.PathParam
+import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
@@ -21,6 +24,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 import java.util.function.Predicate
@@ -170,6 +174,7 @@ object GeneratorUtils {
         basePackage: String,
         pathParameters: List<Parameter>,
         extraParameters: List<IncomingParameter>,
+        avoidNameClashes: Boolean = true,
     ): List<IncomingParameter> {
 
         val bodies = requestBody.contentMediaTypes.values
@@ -194,11 +199,20 @@ object GeneratorUtils {
             }
             .sortedBy { it.type.isNullable }
 
-        return detectAndAvoidNameClashes(bodies + parameters + extraParameters)
+        val allParameters = bodies + parameters + extraParameters
+
+        return if (avoidNameClashes) {
+            detectAndAvoidNameClashes(allParameters)
+        } else {
+            allParameters
+        }
     }
 
+    fun List<IncomingParameter>.hasNameClashes(): Boolean =
+        map { it.name }.toSet().size != size
+
     private fun detectAndAvoidNameClashes(parameters: List<IncomingParameter>): List<IncomingParameter> {
-        if (parameters.map { it.name }.toSet().size == parameters.size) {
+        if (!parameters.hasNameClashes()) {
             return parameters
         }
 
@@ -225,6 +239,24 @@ object GeneratorUtils {
                 )
             }
         }
+    }
+
+    data class IncomingParametersByType(
+        val pathParams: List<RequestParameter>,
+        val queryParams: List<RequestParameter>,
+        val headerParams: List<RequestParameter>,
+        val bodyParams: List<BodyParameter>,
+    )
+
+    fun List<IncomingParameter>.splitByType(): IncomingParametersByType {
+        val requestParams = this.filterIsInstance<RequestParameter>()
+
+        return IncomingParametersByType(
+            pathParams = requestParams.filter { it.parameterLocation is PathParam },
+            queryParams = requestParams.filter { it.parameterLocation is QueryParam },
+            headerParams = requestParams.filter { it.parameterLocation is HeaderParam },
+            bodyParams = this.filterIsInstance<BodyParameter>()
+        )
     }
 
     private fun isNullable(parameter: Parameter): Boolean = !parameter.isRequired && parameter.schema.default == null
@@ -257,4 +289,6 @@ object GeneratorUtils {
 
         return objectBuilder.build()
     }
+
+    fun TypeName.isUnit(): Boolean = this == Unit::class.asTypeName()
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
@@ -12,6 +12,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientPa
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.enhancedClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.toClientReturnType
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_IMPORT
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Destinations
 import com.cjbooms.fabrikt.model.GeneratedFile
@@ -126,7 +127,7 @@ class OkHttpEnhancedClientGenerator(
             .addFunctions(funSpecs)
             .build()
 
-        return ClientType(clientType, packages.base)
+        return ClientType(clientType, packages.base, setOf(TYPE_REFERENCE_IMPORT))
     }
 
     fun generateLibrary(options: Set<ClientCodeGenOptionType>): Collection<GeneratedFile> {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -13,6 +13,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingPar
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.toClientReturnType
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_IMPORT
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Destinations
@@ -99,7 +100,7 @@ class OkHttpSimpleClientGenerator(
                 .addFunctions(funcSpecs)
                 .build()
 
-            ClientType(clientType, packages.base)
+            ClientType(clientType, packages.base, setOf(TYPE_REFERENCE_IMPORT))
         }.toSet()
     }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
@@ -1,0 +1,319 @@
+package com.cjbooms.fabrikt.generators.controller
+
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.hasNameClashes
+import com.cjbooms.fabrikt.generators.GeneratorUtils.isUnit
+import com.cjbooms.fabrikt.generators.GeneratorUtils.splitByType
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
+import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
+import com.cjbooms.fabrikt.generators.client.ClientGenerator
+import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
+import com.cjbooms.fabrikt.model.ClientType
+import com.cjbooms.fabrikt.model.Clients
+import com.cjbooms.fabrikt.model.GeneratedFile
+import com.cjbooms.fabrikt.model.IncomingParameter
+import com.cjbooms.fabrikt.model.RequestParameter
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.reprezen.kaizen.oasparser.model3.Operation
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+
+class KtorClientGenerator(
+    private val packages: Packages,
+    private val api: SourceApi,
+) : ClientGenerator {
+    override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
+        val resources: List<TypeSpec> = api.openApi3.routeToPaths().flatMap { (resourceName, paths) ->
+            val resourceContainerBuilder = TypeSpec.objectBuilder(resourceName)
+            val clientClassBuilder = TypeSpec.classBuilder(resourceName + "Client")
+                .addProperty(
+                    PropertySpec.builder("httpClient", ClassName("io.ktor.client", "HttpClient"))
+                        .initializer("httpClient")
+                        .build()
+                )
+                .primaryConstructor(
+                    FunSpec.constructorBuilder()
+                        .addParameter("httpClient", ClassName("io.ktor.client", "HttpClient"))
+                        .build()
+                )
+
+            paths.forEach { path ->
+                path.value.operations.map { (verb, operation) ->
+                    val params = operation.toIncomingParameters(
+                        packages.base, path.value.parameters, emptyList(),
+                        avoidNameClashes = false
+                    )
+                    require(!params.hasNameClashes()) {
+                        """
+                        Operation '${path.value.pathString} > ${verb}' has name clashes in parameters. Ktor type safe 
+                        routing requires parameter names to be unique.
+                    """.trimIndent().replace("\n", "")
+                    }
+
+                    val (pathParams, queryParams, headerParams, bodyParams) = params.splitByType()
+
+                    val resourceClassBuilder =
+                        TypeSpec.classBuilder(resourceClassName(operation, verb, pathParams))
+                            .addAnnotation(
+                                AnnotationSpec.builder(ClassName("io.ktor.resources", "Resource"))
+                                    .addMember("%S", path.value.pathString).build()
+                            )
+
+                    val constructorBuilder = FunSpec.constructorBuilder()
+
+                    // Add path parameters to constructor
+                    pathParams.forEach { param ->
+                        constructorBuilder.addParameter(
+                            ParameterSpec.builder(param.name, param.type.copy(nullable = !param.isRequired))
+                                .build()
+                        )
+                        resourceClassBuilder.addProperty(
+                            PropertySpec.builder(param.name, param.type.copy(nullable = !param.isRequired))
+                                .initializer(param.name)
+                                .build()
+                        )
+                    }
+
+                    // Add query parameters to constructor
+                    queryParams.forEach { param ->
+                        val defaultValue = if (!param.isRequired) "null" else null
+                        constructorBuilder.addParameter(
+                            ParameterSpec.builder(param.name, param.type.copy(nullable = !param.isRequired))
+                                .apply { if (defaultValue != null) defaultValue(defaultValue) }
+                                .build()
+                        )
+                        resourceClassBuilder.addProperty(
+                            PropertySpec.builder(param.name, param.type.copy(nullable = !param.isRequired))
+                                .initializer(param.name)
+                                .build()
+                        )
+                    }
+
+                    resourceClassBuilder.primaryConstructor(constructorBuilder.build())
+                    resourceClassBuilder.addKdoc(buildResourceKdoc(operation, params, verb))
+
+                    // build result sealed class
+                    val resultClassBuilder = TypeSpec.classBuilder(resultClassName(operation, verb, pathParams))
+                        .addModifiers(KModifier.SEALED)
+                    // add success and error
+                    resultClassBuilder.addType(
+                        TypeSpec.classBuilder("Success")
+                            .addModifiers(KModifier.DATA)
+                            .addProperty(
+                                PropertySpec.builder("data", operation.happyPathResponse(packages.base))
+                                    .initializer("data")
+                                    .build()
+                            )
+                            .addProperty(
+                                PropertySpec.builder("response", ClassName("io.ktor.client.statement", "HttpResponse"))
+                                    .initializer("response")
+                                    .build()
+                            )
+                            .primaryConstructor(
+                                FunSpec.constructorBuilder()
+                                    .addParameter("data", operation.happyPathResponse(packages.base))
+                                    .addParameter("response", ClassName("io.ktor.client.statement", "HttpResponse"))
+                                    .build()
+                            )
+                            .superclass(ClassName("", resultClassName(operation, verb, pathParams)))
+                            .build()
+                    )
+                        .addType(
+                            TypeSpec.classBuilder("Error")
+                                .addModifiers(KModifier.DATA)
+                                .addProperty(
+                                    PropertySpec.builder("response", ClassName("io.ktor.client.statement", "HttpResponse"))
+                                        .initializer("response")
+                                        .build()
+                                )
+                                .primaryConstructor(
+                                    FunSpec.constructorBuilder()
+                                        .addParameter("response", ClassName("io.ktor.client.statement", "HttpResponse"))
+                                        .build()
+                                )
+                                .superclass(ClassName("", resultClassName(operation, verb, pathParams)))
+                                .build()
+                        )
+
+                    // build client
+                    val clientFunctionBuilder = FunSpec.builder(clientRequestFunctionName(operation, verb, pathParams))
+                        .addModifiers(KModifier.SUSPEND)
+                        .returns(ClassName("", resultClassName(operation, verb, pathParams)))
+                        .addCode(
+                            CodeBlock.builder()
+                                .addStatement(
+                                    "val response = httpClient.%M(%M(%L)) {",
+                                    MemberName("io.ktor.client.plugins.resources", verb),
+                                    MemberName("", resourceClassName(operation, verb, pathParams)),
+                                    (pathParams + queryParams).joinToString(", ") {
+                                        it.name + " = " + it.name
+                                    }
+                                )
+                                .indent()
+                                .apply {
+                                    addStatement(
+                                        "%M(\"Accept\", \"application/json\")",
+                                        MemberName("io.ktor.client.request", "header")
+                                    )
+                                    if (bodyParams.isNotEmpty()) {
+                                        addStatement(
+                                            "%M(\"Content-Type\", \"application/json\")",
+                                            MemberName("io.ktor.client.request", "header")
+                                        )
+                                        addStatement(
+                                            "%M(%L)",
+                                            MemberName("io.ktor.client.request", "setBody"),
+                                            bodyParams.first().name
+                                        )
+                                    }
+                                    headerParams.forEach {
+                                        addStatement(
+                                            "%M(%S, %L)",
+                                            MemberName("io.ktor.client.request", "header"),
+                                            it.originalName,
+                                            it.name
+                                        )
+                                    }
+                                }
+                                .unindent()
+                                .addStatement("}")
+                                .addStatement(
+                                    "return if (response.status.%M()) {",
+                                    MemberName("io.ktor.http", "isSuccess")
+                                )
+                                .indent()
+                                .apply {
+                                    addStatement(
+                                        "%M.Success(response.%M(), response)",
+                                        MemberName("", resultClassName(operation, verb, pathParams)),
+                                        MemberName("io.ktor.client.call", "body"),
+                                    )
+                                }
+                                .unindent()
+                                .addStatement("} else {")
+                                .indent()
+                                .apply {
+                                    addStatement(
+                                        "%T.Error(response)",
+                                        ClassName("", resultClassName(operation, verb, pathParams))
+                                    )
+                                }
+                                .unindent()
+                                .addStatement("}")
+                                .build()
+                        )
+                    if (bodyParams.isNotEmpty()) {
+                        clientFunctionBuilder.addParameter(
+                            ParameterSpec.builder(bodyParams.first().name, bodyParams.first().type)
+                                .build()
+                        )
+                    }
+                    (pathParams + queryParams + headerParams).forEach { param ->
+                        val defaultValue = if (!param.isRequired) "null" else null
+                        clientFunctionBuilder.addParameter(
+                            ParameterSpec.builder(param.name, param.type.copy(nullable = !param.isRequired))
+                                .apply { if (defaultValue != null) defaultValue(defaultValue) }
+                                .build()
+                        )
+                    }
+
+                    clientClassBuilder.addType(resultClassBuilder.build())
+                    clientClassBuilder.addFunction(clientFunctionBuilder.build())
+
+                    clientClassBuilder.addType(resourceClassBuilder.build())
+                }
+            }
+
+            listOf(resourceContainerBuilder.build(), clientClassBuilder.build())
+        }
+
+        return Clients(resources.map { ClientType(it, packages.base) }.toSet())
+    }
+
+    override fun generateLibrary(options: Set<ClientCodeGenOptionType>): Collection<GeneratedFile> {
+        return emptyList()
+    }
+
+    private fun resourceClassName(op: Operation, verb: String, params: List<RequestParameter>) =
+        if (op.operationId != null) {
+            op.operationId.replaceFirstChar { it.uppercase() }
+        } else {
+            buildString {
+                append(verb.replaceFirstChar { it.uppercase() })
+                append(if (params.isNotEmpty()) "By" + params.joinToString("And") { it -> it.name.replaceFirstChar { it.uppercase() } } else "")
+            }
+        }
+
+    private fun clientRequestFunctionName(op: Operation, verb: String, params: List<RequestParameter>) =
+        if (op.operationId != null) {
+            op.operationId.replaceFirstChar { it.lowercase() }
+        } else {
+            buildString {
+                append(verb.lowercase())
+                append(if (params.isNotEmpty()) "By" + params.joinToString("And") { it -> it.name.replaceFirstChar { it.uppercase() } } else "")
+            }
+        }
+
+    private fun resultClassName(op: Operation, verb: String, params: List<RequestParameter>) =
+        resourceClassName(op, verb, params) + "Result"
+
+    private fun buildResourceKdoc(operation: Operation, parameters: List<IncomingParameter>, verb: String): CodeBlock {
+        val (pathParams, queryParams, headerParams, bodyParams) = parameters.splitByType()
+        val kDoc = CodeBlock.builder()
+
+        // add summary and description
+        val methodDesc = listOf(operation.summary.orEmpty(), operation.description.orEmpty()).filter { it.isNotEmpty() }
+        if (methodDesc.isNotEmpty()) {
+            methodDesc.forEach { kDoc.add("%L\n", it) }
+            kDoc.add("\n")
+        }
+
+        // document method
+        kDoc.add("HTTP method: %L\n\n", verb.uppercase())
+
+        if (bodyParams.isNotEmpty()) {
+            kDoc.add("Request body:\n")
+            bodyParams.forEach {
+                kDoc.add("\t[%L] %L\n\n", it.type, it.description?.trimIndent().orEmpty()).build()
+            }
+        }
+
+        // document the response
+        val happyPathResponse = operation.happyPathResponse(packages.base)
+        kDoc.add("Response:\n")
+        if (happyPathResponse.isUnit()) {
+            kDoc.add("\tA successful request returns an HTTP ${operation.responses.keys.first()} response with an empty body.\n\n")
+        } else {
+            kDoc.add(
+                "\tA successful request returns an HTTP ${operation.responses.keys.first()} response with [%L] in the response body.\n\n",
+                happyPathResponse.toString(),
+            )
+        }
+
+        // document parameters
+        if (headerParams.isNotEmpty()) {
+            kDoc.add("Request headers:\n")
+            headerParams.forEach {
+                kDoc.add("\t\"%L\" (%L) %L\n", it.originalName, if (it.isRequired) "required" else "optional", it.description?.trimIndent().orEmpty()).build()
+            }
+            kDoc.add("\n")
+        }
+        if ((pathParams + queryParams).isNotEmpty()) {
+            kDoc.add("Request parameters:\n")
+            (pathParams + queryParams).forEach {
+                kDoc.add("\t @param %L %L\n", it.name.toKCodeName(), it.description?.trimIndent().orEmpty()).build()
+            }
+        }
+
+        return kDoc.build()
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -2,6 +2,8 @@ package com.cjbooms.fabrikt.generators.controller
 
 import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.isUnit
+import com.cjbooms.fabrikt.generators.GeneratorUtils.splitByType
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.SecuritySupport

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
@@ -1,0 +1,82 @@
+package com.cjbooms.fabrikt.generators
+
+import com.cjbooms.fabrikt.cli.ClientCodeGenTargetType
+import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.cli.SerializationLibrary
+import com.cjbooms.fabrikt.cli.ValidationLibrary
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.controller.KtorClientGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.ModelNameRegistry
+import com.cjbooms.fabrikt.util.FileUtils.toSingleFile
+import com.cjbooms.fabrikt.util.GeneratedCodeAsserter.Companion.assertThatGenerated
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.nio.file.Paths
+import java.util.stream.Stream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorClientGeneratorTest {
+
+    @Suppress("unused")
+    private fun fullApiTestCases(): Stream<String> = Stream.of(
+        "ktorClient",
+    )
+
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(
+            genTypes = setOf(CodeGenerationType.CLIENT),
+            clientTarget = ClientCodeGenTargetType.KTOR,
+            serializationLibrary = SerializationLibrary.KOTLINX_SERIALIZATION,
+            validationLibrary = ValidationLibrary.NO_VALIDATION,
+        )
+        ModelNameRegistry.clear()
+    }
+
+    @ParameterizedTest
+    @MethodSource("fullApiTestCases")
+    fun `correct Ktor routing resources are generated`(testCaseName: String) {
+        val packages = Packages("examples.$testCaseName")
+        val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+
+        val expectedModel = "/examples/$testCaseName/models/ClientModels.kt"
+        val expectedClient = "/examples/$testCaseName/client/KtorClient.kt"
+
+        val models = ModelGenerator(
+            packages,
+            sourceApi
+        ).generate().toSingleFile()
+
+        val clientCode = KtorClientGenerator(
+            packages,
+            sourceApi
+        )
+            .generate(emptySet())
+            .clients
+            .toSingleFile()
+
+        assertThatGenerated(models).isEqualTo(expectedModel)
+        assertThatGenerated(clientCode).isEqualTo(expectedClient)
+    }
+
+    @Test
+    fun `name clashes in parameters causes exception to be thrown`() {
+        val packages = Packages("examples.parameterNameClash")
+        val apiLocation = javaClass.getResource("/examples/parameterNameClash/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            KtorClientGenerator(packages, sourceApi).generate(emptySet())
+        }
+
+        assertEquals("Operation '/example/{b} > get' has name clashes in parameters. Ktor type safe routing requires parameter names to be unique.", exception.message)
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -9,14 +9,13 @@ import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.client.OkHttpEnhancedClientGenerator
 import com.cjbooms.fabrikt.generators.client.OkHttpSimpleClientGenerator
-import com.cjbooms.fabrikt.generators.model.JacksonMetadata
 import com.cjbooms.fabrikt.generators.model.ModelGenerator
 import com.cjbooms.fabrikt.model.ClientType
-import com.cjbooms.fabrikt.model.Models
 import com.cjbooms.fabrikt.model.SimpleFile
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.GeneratedCodeAsserter.Companion.assertThatGenerated
+import com.cjbooms.fabrikt.util.FileUtils.toSingleFile
 import com.cjbooms.fabrikt.util.Linter
+import com.cjbooms.fabrikt.util.GeneratedCodeAsserter.Companion.assertThatGenerated
 import com.cjbooms.fabrikt.util.ModelNameRegistry
 import com.squareup.kotlinpoet.FileSpec
 import org.assertj.core.api.Assertions.assertThat
@@ -163,30 +162,5 @@ class OkHttpClientGeneratorTest {
         assertThatGenerated(models).isEqualTo(expectedModel)
         assertThatGenerated(simpleClientCode).isEqualTo(expectedClient)
         assertThatGenerated(enhancedClientCode).isEqualTo(expectedClientCode)
-    }
-
-    private fun Collection<ClientType>.toSingleFile(): String {
-        val destPackage = if (this.isNotEmpty()) first().destinationPackage else ""
-        val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
-        this.forEach {
-            val builder = singleFileBuilder
-                .addType(it.spec)
-                .addImport(JacksonMetadata.TYPE_REFERENCE_IMPORT.first, JacksonMetadata.TYPE_REFERENCE_IMPORT.second)
-            builder.build()
-        }
-        return Linter.lintString(singleFileBuilder.build().toString())
-    }
-
-    private fun Models.toSingleFile(): String {
-        val destPackage = if (models.isNotEmpty()) models.first().destinationPackage else ""
-        val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
-        models
-            .sortedBy { it.spec.name }
-            .forEach {
-                val builder = singleFileBuilder
-                    .addType(it.spec)
-                builder.build()
-            }
-        return Linter.lintString(singleFileBuilder.build().toString())
     }
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/util/FileUtils.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/util/FileUtils.kt
@@ -1,0 +1,30 @@
+package com.cjbooms.fabrikt.util
+
+import com.cjbooms.fabrikt.model.ClientType
+import com.cjbooms.fabrikt.model.Models
+import com.squareup.kotlinpoet.FileSpec
+
+object FileUtils {
+    fun Collection<ClientType>.toSingleFile(): String {
+        val destPackage = if (this.isNotEmpty()) first().destinationPackage else ""
+        val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
+        this.forEach {
+            singleFileBuilder.addType(it.spec)
+            it.imports.forEach { (pkg, name) -> singleFileBuilder.addImport(pkg, name) }
+        }
+        return Linter.lintString(singleFileBuilder.build().toString())
+    }
+
+    fun Models.toSingleFile(): String {
+        val destPackage = if (models.isNotEmpty()) models.first().destinationPackage else ""
+        val singleFileBuilder = FileSpec.builder(destPackage, "dummyFilename")
+        models
+            .sortedBy { it.spec.name }
+            .forEach {
+                val builder = singleFileBuilder
+                    .addType(it.spec)
+                builder.build()
+            }
+        return Linter.lintString(singleFileBuilder.build().toString())
+    }
+}

--- a/src/test/resources/examples/ktorClient/api.yaml
+++ b/src/test/resources/examples/ktorClient/api.yaml
@@ -1,0 +1,224 @@
+openapi: "3.0.2"
+info:
+  title: Example API
+  version: "1.0"
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /items:
+    get:
+      summary: Retrieve a list of items
+      operationId: getItems
+      parameters:
+        - name: category
+          in: query
+          description: Filter items by category
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of items to return
+          required: false
+          schema:
+            type: integer
+            default: 10
+        - name: priceLimit
+          in: query
+          description: Maximum price of items to return
+          required: false
+          schema:
+            type: number
+            format: double
+      responses:
+        '200':
+          description: A list of items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+  /catalogs/{catalogId}/items:
+    post:
+      summary: Create a new item
+      operationId: createItem
+      parameters:
+        - name: catalogId
+          in: path
+          description: The ID of the catalog
+          required: true
+          schema:
+            type: string
+        - name: X-Request-ID
+          in: header
+          description: Unique identifier for the request
+          required: true
+          schema:
+            type: string
+        - name: X-Tracing-ID
+          in: header
+          description: Unique identifier for the tracing
+          required: false
+          schema:
+            type: string
+        - name: randomNumber
+          in: query
+          description: Just a test query param
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        description: The item to create
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+      responses:
+        '201':
+          description: Item created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+
+  /items/{itemId}/subitems/{subItemId}:
+    get:
+      summary: Retrieve a specific subitem of an item
+      operationId: getSubItem
+      parameters:
+        - name: itemId
+          in: path
+          description: The ID of the item
+          required: true
+          schema:
+            type: string
+        - name: subItemId
+          in: path
+          description: The ID of the subitem
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Subitem details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+        '404':
+          description: Subitem not found
+
+  /catalogs/{catalogId}/search:
+    get:
+      summary: Search for items
+      operationId: searchCatalogItems
+      parameters:
+        - name: catalogId
+          in: path
+          description: The ID of the catalog
+          required: true
+          schema:
+            type: string
+        - name: query
+          in: query
+          description: The search query
+          required: true
+          schema:
+            type: string
+        - name: sort
+          in: query
+          description: Sort order
+          required: false
+          schema:
+            $ref: '#/components/schemas/SortOrder'
+        - name: page
+          in: query
+          description: Page number
+          required: false
+          schema:
+            type: integer
+            default: 1
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+  /catalogs/{catalogId}/items/{itemId}/availability:
+    get:
+      summary: Check item availability
+      # operationId: healthCheck # No operation ID to test name generation
+      parameters:
+        - name: catalogId
+          in: path
+          description: The ID of the catalog
+          required: true
+          schema:
+            type: string
+        - name: itemId
+          in: path
+          description: The ID of the item
+          required: true
+          schema:
+              type: string
+      responses:
+        '204':
+          description: No content
+    put:
+        summary: Update item availability
+        parameters:
+          - name: catalogId
+            in: path
+            description: The ID of the catalog
+            required: true
+            schema:
+              type: string
+          - name: itemId
+            in: path
+            description: The ID of the item
+            required: true
+            schema:
+              type: string
+        responses:
+          '204':
+            description: No content
+  /uptime:
+    get:
+      summary: Get the uptime of the system
+      operationId: Get_System-Uptime # Test operation ID with special characters
+      responses:
+        '200':
+          description: Uptime
+          content:
+            application/json:
+              schema:
+                type: string
+
+components:
+  schemas:
+    SortOrder:
+      type: string
+      enum:
+        - asc
+        - desc
+    Item:
+      type: object
+      required:
+        - id
+        - name
+        - price
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        price:
+          type: number
+          format: double

--- a/src/test/resources/examples/ktorClient/client/KtorClient.kt
+++ b/src/test/resources/examples/ktorClient/client/KtorClient.kt
@@ -1,0 +1,395 @@
+package examples.ktorClient.client
+
+import examples.ktorClient.models.Item
+import examples.ktorClient.models.SortOrder
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.resources.`get`
+import io.ktor.client.plugins.resources.post
+import io.ktor.client.plugins.resources.put
+import io.ktor.client.request.`header`
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.isSuccess
+import io.ktor.resources.Resource
+import kotlin.Double
+import kotlin.Int
+import kotlin.String
+import kotlin.Unit
+import kotlin.collections.List
+
+public object Items
+
+public class ItemsClient(
+    public val httpClient: HttpClient,
+) {
+    public suspend fun getItems(
+        limit: Int? = null,
+        category: String? = null,
+        priceLimit: Double? = null,
+    ): GetItemsResult {
+        val response =
+            httpClient.`get`(
+                GetItems(
+                    limit = limit,
+                    category = category,
+                    priceLimit =
+                    priceLimit,
+                ),
+            ) {
+                `header`("Accept", "application/json")
+            }
+        return if (response.status.isSuccess()) {
+            GetItemsResult.Success(response.body(), response)
+        } else {
+            GetItemsResult.Error(response)
+        }
+    }
+
+    public sealed class GetItemsResult {
+        public data class Success(
+            public val `data`: List<Item>,
+            public val response: HttpResponse,
+        ) : GetItemsResult()
+
+        public data class Error(
+            public val response: HttpResponse,
+        ) : GetItemsResult()
+    }
+
+    /**
+     * Retrieve a list of items
+     *
+     * HTTP method: GET
+     *
+     * Response:
+     * 	A successful request returns an HTTP 200 response with
+     * [kotlin.collections.List<examples.ktorClient.models.Item>] in the response body.
+     *
+     * Request parameters:
+     * 	 @param limit Maximum number of items to return
+     * 	 @param category Filter items by category
+     * 	 @param priceLimit Maximum price of items to return
+     */
+    @Resource("/items")
+    public class GetItems(
+        public val limit: Int? = null,
+        public val category: String? = null,
+        public val priceLimit: Double? = null,
+    )
+}
+
+public object CatalogsItems
+
+public class CatalogsItemsClient(
+    public val httpClient: HttpClient,
+) {
+    public suspend fun createItem(
+        item: Item,
+        catalogId: String,
+        randomNumber: Int,
+        xRequestID: String,
+        xTracingID: String? = null,
+    ): CreateItemResult {
+        val response =
+            httpClient.post(CreateItem(catalogId = catalogId, randomNumber = randomNumber)) {
+                `header`("Accept", "application/json")
+                `header`("Content-Type", "application/json")
+                setBody(item)
+                `header`("X-Request-ID", xRequestID)
+                `header`("X-Tracing-ID", xTracingID)
+            }
+        return if (response.status.isSuccess()) {
+            CreateItemResult.Success(response.body(), response)
+        } else {
+            CreateItemResult.Error(response)
+        }
+    }
+
+    public sealed class CreateItemResult {
+        public data class Success(
+            public val `data`: Item,
+            public val response: HttpResponse,
+        ) : CreateItemResult()
+
+        public data class Error(
+            public val response: HttpResponse,
+        ) : CreateItemResult()
+    }
+
+    /**
+     * Create a new item
+     *
+     * HTTP method: POST
+     *
+     * Request body:
+     * 	[examples.ktorClient.models.Item] The item to create
+     *
+     * Response:
+     * 	A successful request returns an HTTP 201 response with [examples.ktorClient.models.Item] in
+     * the response body.
+     *
+     * Request headers:
+     * 	"X-Request-ID" (required) Unique identifier for the request
+     * 	"X-Tracing-ID" (optional) Unique identifier for the tracing
+     *
+     * Request parameters:
+     * 	 @param catalogId The ID of the catalog
+     * 	 @param randomNumber Just a test query param
+     */
+    @Resource("/catalogs/{catalogId}/items")
+    public class CreateItem(
+        public val catalogId: String,
+        public val randomNumber: Int,
+    )
+}
+
+public object ItemsSubitems
+
+public class ItemsSubitemsClient(
+    public val httpClient: HttpClient,
+) {
+    public suspend fun getSubItem(
+        itemId: String,
+        subItemId: String,
+    ): GetSubItemResult {
+        val response =
+            httpClient.`get`(GetSubItem(itemId = itemId, subItemId = subItemId)) {
+                `header`("Accept", "application/json")
+            }
+        return if (response.status.isSuccess()) {
+            GetSubItemResult.Success(response.body(), response)
+        } else {
+            GetSubItemResult.Error(response)
+        }
+    }
+
+    public sealed class GetSubItemResult {
+        public data class Success(
+            public val `data`: Item,
+            public val response: HttpResponse,
+        ) : GetSubItemResult()
+
+        public data class Error(
+            public val response: HttpResponse,
+        ) : GetSubItemResult()
+    }
+
+    /**
+     * Retrieve a specific subitem of an item
+     *
+     * HTTP method: GET
+     *
+     * Response:
+     * 	A successful request returns an HTTP 200 response with [examples.ktorClient.models.Item] in
+     * the response body.
+     *
+     * Request parameters:
+     * 	 @param itemId The ID of the item
+     * 	 @param subItemId The ID of the subitem
+     */
+    @Resource("/items/{itemId}/subitems/{subItemId}")
+    public class GetSubItem(
+        public val itemId: String,
+        public val subItemId: String,
+    )
+}
+
+public object CatalogsSearch
+
+public class CatalogsSearchClient(
+    public val httpClient: HttpClient,
+) {
+    public suspend fun searchCatalogItems(
+        catalogId: String,
+        query: String,
+        page: Int? = null,
+        sort: SortOrder? = null,
+    ): SearchCatalogItemsResult {
+        val response =
+            httpClient.`get`(
+                SearchCatalogItems(
+                    catalogId = catalogId,
+                    query = query,
+                    page =
+                    page,
+                    sort = sort,
+                ),
+            ) {
+                `header`("Accept", "application/json")
+            }
+        return if (response.status.isSuccess()) {
+            SearchCatalogItemsResult.Success(response.body(), response)
+        } else {
+            SearchCatalogItemsResult.Error(response)
+        }
+    }
+
+    public sealed class SearchCatalogItemsResult {
+        public data class Success(
+            public val `data`: List<Item>,
+            public val response: HttpResponse,
+        ) : SearchCatalogItemsResult()
+
+        public data class Error(
+            public val response: HttpResponse,
+        ) : SearchCatalogItemsResult()
+    }
+
+    /**
+     * Search for items
+     *
+     * HTTP method: GET
+     *
+     * Response:
+     * 	A successful request returns an HTTP 200 response with
+     * [kotlin.collections.List<examples.ktorClient.models.Item>] in the response body.
+     *
+     * Request parameters:
+     * 	 @param catalogId The ID of the catalog
+     * 	 @param query The search query
+     * 	 @param page Page number
+     * 	 @param sort Sort order
+     */
+    @Resource("/catalogs/{catalogId}/search")
+    public class SearchCatalogItems(
+        public val catalogId: String,
+        public val query: String,
+        public val page: Int? = null,
+        public val sort: SortOrder? = null,
+    )
+}
+
+public object CatalogsItemsAvailability
+
+public class CatalogsItemsAvailabilityClient(
+    public val httpClient: HttpClient,
+) {
+    public suspend fun getByCatalogIdAndItemId(
+        catalogId: String,
+        itemId: String,
+    ): GetByCatalogIdAndItemIdResult {
+        val response =
+            httpClient.`get`(GetByCatalogIdAndItemId(catalogId = catalogId, itemId = itemId)) {
+                `header`("Accept", "application/json")
+            }
+        return if (response.status.isSuccess()) {
+            GetByCatalogIdAndItemIdResult.Success(response.body(), response)
+        } else {
+            GetByCatalogIdAndItemIdResult.Error(response)
+        }
+    }
+
+    public suspend fun putByCatalogIdAndItemId(
+        catalogId: String,
+        itemId: String,
+    ): PutByCatalogIdAndItemIdResult {
+        val response =
+            httpClient.put(PutByCatalogIdAndItemId(catalogId = catalogId, itemId = itemId)) {
+                `header`("Accept", "application/json")
+            }
+        return if (response.status.isSuccess()) {
+            PutByCatalogIdAndItemIdResult.Success(response.body(), response)
+        } else {
+            PutByCatalogIdAndItemIdResult.Error(response)
+        }
+    }
+
+    public sealed class GetByCatalogIdAndItemIdResult {
+        public data class Success(
+            public val `data`: Unit,
+            public val response: HttpResponse,
+        ) : GetByCatalogIdAndItemIdResult()
+
+        public data class Error(
+            public val response: HttpResponse,
+        ) : GetByCatalogIdAndItemIdResult()
+    }
+
+    /**
+     * Check item availability
+     *
+     * HTTP method: GET
+     *
+     * Response:
+     * 	A successful request returns an HTTP 204 response with an empty body.
+     *
+     * Request parameters:
+     * 	 @param catalogId The ID of the catalog
+     * 	 @param itemId The ID of the item
+     */
+    @Resource("/catalogs/{catalogId}/items/{itemId}/availability")
+    public class GetByCatalogIdAndItemId(
+        public val catalogId: String,
+        public val itemId: String,
+    )
+
+    public sealed class PutByCatalogIdAndItemIdResult {
+        public data class Success(
+            public val `data`: Unit,
+            public val response: HttpResponse,
+        ) : PutByCatalogIdAndItemIdResult()
+
+        public data class Error(
+            public val response: HttpResponse,
+        ) : PutByCatalogIdAndItemIdResult()
+    }
+
+    /**
+     * Update item availability
+     *
+     * HTTP method: PUT
+     *
+     * Response:
+     * 	A successful request returns an HTTP 204 response with an empty body.
+     *
+     * Request parameters:
+     * 	 @param catalogId The ID of the catalog
+     * 	 @param itemId The ID of the item
+     */
+    @Resource("/catalogs/{catalogId}/items/{itemId}/availability")
+    public class PutByCatalogIdAndItemId(
+        public val catalogId: String,
+        public val itemId: String,
+    )
+}
+
+public object Uptime
+
+public class UptimeClient(
+    public val httpClient: HttpClient,
+) {
+    public suspend fun `get_System-Uptime`(): `Get_System-UptimeResult` {
+        val response =
+            httpClient.`get`(`Get_System-Uptime`()) {
+                `header`("Accept", "application/json")
+            }
+        return if (response.status.isSuccess()) {
+            `Get_System-UptimeResult`.Success(response.body(), response)
+        } else {
+            `Get_System-UptimeResult`.Error(response)
+        }
+    }
+
+    public sealed class `Get_System-UptimeResult` {
+        public data class Success(
+            public val `data`: String,
+            public val response: HttpResponse,
+        ) : `Get_System-UptimeResult`()
+
+        public data class Error(
+            public val response: HttpResponse,
+        ) : `Get_System-UptimeResult`()
+    }
+
+    /**
+     * Get the uptime of the system
+     *
+     * HTTP method: GET
+     *
+     * Response:
+     * 	A successful request returns an HTTP 200 response with [kotlin.String] in the response body.
+     */
+    @Resource("/uptime")
+    public class `Get_System-Uptime`
+}

--- a/src/test/resources/examples/ktorClient/models/ClientModels.kt
+++ b/src/test/resources/examples/ktorClient/models/ClientModels.kt
@@ -1,0 +1,36 @@
+package examples.ktorClient.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.Double
+import kotlin.String
+import kotlin.collections.Map
+
+@Serializable
+public data class Item(
+    @SerialName("id")
+    public val id: String,
+    @SerialName("name")
+    public val name: String,
+    @SerialName("description")
+    public val description: String? = null,
+    @SerialName("price")
+    public val price: Double,
+)
+
+public enum class SortOrder(
+    public val `value`: String,
+) {
+    @SerialName("asc")
+    ASC("asc"),
+
+    @SerialName("desc")
+    DESC("desc"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, SortOrder> = entries.associateBy(SortOrder::value)
+
+        public fun fromValue(`value`: String): SortOrder? = mapping[value]
+    }
+}


### PR DESCRIPTION
## Summary
Implements a new client generator that produces type-safe Ktor client code using Ktor Resources for routing. 

This generator creates client classes with:
- Type-safe resource definitions using @Resource annotations
- Sealed result classes for success/error handling
- KDoc documentation
- Support for path parameters, query parameters, headers, and request bodies

## TODO
- [ ] Gather feedback on API (function naming, result classes, etc.)
- [ ] Test with real specs from real APIs