### PR TITLE
Add `@Contextual` annotations to array elements for KOTLINX_SERIALIZATION

### DIFF
--- a/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/PrimitiveTypesTest.kt
+++ b/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/PrimitiveTypesTest.kt
@@ -34,7 +34,12 @@ class PrimitiveTypesTest {
         numberFloat = 1.23f,
         numberDouble = 4.56,
         byte = javaClass.getResource("/primitive_types/test.bin")!!.readBytes(),
-        binary = javaClass.getResource("/primitive_types/test.bin")!!.readBytes()
+        binary = javaClass.getResource("/primitive_types/test.bin")!!.readBytes(),
+        arrayOfString = listOf("one", "two", "three"),
+        arrayOfUuid = listOf(
+            UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+            UUID.fromString("123e4567-e89b-12d3-a456-426614174001")
+        ),
     )
 
     @Test

--- a/end2end-tests/models-jackson/src/test/resources/primitive_types/content_valid.json
+++ b/end2end-tests/models-jackson/src/test/resources/primitive_types/content_valid.json
@@ -12,5 +12,7 @@
   "numberFloat" : 1.23,
   "numberDouble" : 4.56,
   "byte" : "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
-  "binary" : "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU="
+  "binary" : "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
+  "arrayOfString" : [ "one", "two", "three" ],
+  "arrayOfUuid" : [ "123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174001" ]
 }

--- a/end2end-tests/models-kotlinx/openapi/api.yaml
+++ b/end2end-tests/models-kotlinx/openapi/api.yaml
@@ -53,6 +53,11 @@ components:
         imageUrl:
           type: string
           format: uri
+        aListOfUuids:
+          type: array
+          items:
+            type: string
+            format: uuid
     Pets:
       type: array
       maxItems: 100

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationPrimitiveTypesTest.kt
@@ -53,7 +53,12 @@ class KotlinxSerializationPrimitiveTypesTest {
         numberFloat = 1.23f,
         numberDouble = 4.56,
         byte = binFileContent,
-        binary = binFileContent
+        binary = binFileContent,
+        arrayOfString = listOf("one", "two", "three"),
+        arrayOfUuid = listOf(
+            UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+            UUID.fromString("123e4567-e89b-12d3-a456-426614174001")
+        )
     )
 
     @Test

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationSimpleTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationSimpleTest.kt
@@ -43,7 +43,7 @@ class KotlinxSerializationSimpleTest {
     @Test
     fun `must deserialize Pet`() {
         val json = """
-            {"id": 1, "name": "Fido", "tag": "dog", "dateOfBirth": "2009-02-13", "lastFedAt": "2011-02-04T10:00:00Z", "earTagUuid": "123e4567-e89b-12d3-a456-426614174000", "imageUrl": "https://example.org/image.jpg"}
+            {"id": 1, "name": "Fido", "tag": "dog", "dateOfBirth": "2009-02-13", "lastFedAt": "2011-02-04T10:00:00Z", "earTagUuid": "123e4567-e89b-12d3-a456-426614174000", "imageUrl": "https://example.org/image.jpg", "aListOfUuids": ["123e4567-e89b-12d3-a456-426614174000", "123e4567-e89b-12d3-a456-426614174001"]}
         """.trimIndent()
         val pet: Pet = jsonWithCustomSerializers.decodeFromString(json)
         assertThat(pet).isEqualTo(
@@ -54,7 +54,11 @@ class KotlinxSerializationSimpleTest {
                 dateOfBirth = LocalDate.parse("2009-02-13"),
                 lastFedAt = Instant.parse("2011-02-04T10:00:00Z"),
                 earTagUuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
-                imageUrl = URI.create("https://example.org/image.jpg")
+                imageUrl = URI.create("https://example.org/image.jpg"),
+                aListOfUuids = listOf(
+                    UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+                    UUID.fromString("123e4567-e89b-12d3-a456-426614174001")
+                )
             )
         )
     }

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationStringFormatTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationStringFormatTest.kt
@@ -30,7 +30,12 @@ class KotlinxSerializationStringFormatTest {
         stringDate = "2020-02-04",
         stringDateTime = "2024-11-04T12:00:00Z",
         byte = "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
-        binary = "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU="
+        binary = "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
+        arrayOfString = listOf("one", "two", "three"),
+        arrayOfUuid = listOf(
+            "123e4567-e89b-12d3-a456-426614174000",
+            "123e4567-e89b-12d3-a456-426614174001"
+        )
     )
 
     @Test

--- a/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid.json
+++ b/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid.json
@@ -12,5 +12,14 @@
     "numberFloat": 1.23,
     "numberDouble": 4.56,
     "byte": "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
-    "binary": "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU="
+    "binary": "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
+    "arrayOfString": [
+        "one",
+        "two",
+        "three"
+    ],
+    "arrayOfUuid": [
+        "123e4567-e89b-12d3-a456-426614174000",
+        "123e4567-e89b-12d3-a456-426614174001"
+    ]
 }

--- a/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid_strings.json
+++ b/end2end-tests/models-kotlinx/src/test/resources/primitive_types/content_valid_strings.json
@@ -5,5 +5,14 @@
     "stringDate": "2020-02-04",
     "stringDateTime": "2024-11-04T12:00:00Z",
     "byte": "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
-    "binary": "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU="
+    "binary": "AETdqhOI3C8/jA184vF3FyUNGesJ9x22cn2TqiQLYpFzvy5Moyie3K1MAy8DVy62HxURtRHwP2SjdV7B+HZQzuCwMsJLxhbNj0okOzdV2EOAr2JV3htYH+vNVJE9NHwzyYTkOA5ZuYpEDZMEL+SqjyeSRXaLimqDbkew6hg1QdU=",
+    "arrayOfString": [
+        "one",
+        "two",
+        "three"
+    ],
+    "arrayOfUuid": [
+        "123e4567-e89b-12d3-a456-426614174000",
+        "123e4567-e89b-12d3-a456-426614174001"
+    ]
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
@@ -44,4 +44,7 @@ object JacksonAnnotations : SerializationAnnotations {
 
     override fun addEnumConstantAnnotation(enumSpecBuilder: TypeSpec.Builder, enumValue: String) =
         enumSpecBuilder // not applicable
+
+    override fun annotateArrayElementType(elementType: TypeName, elementTypeInfo: KotlinTypeInfo): TypeName =
+        elementType // Jackson doesn't need array element annotations
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -28,4 +28,5 @@ sealed interface SerializationAnnotations {
     fun addSubtypeMappingAnnotation(typeSpecBuilder: TypeSpec.Builder, mapping: String): TypeSpec.Builder
     fun addEnumPropertyAnnotation(propSpecBuilder: PropertySpec.Builder): PropertySpec.Builder
     fun addEnumConstantAnnotation(enumSpecBuilder: TypeSpec.Builder, enumValue: String): TypeSpec.Builder
+    fun annotateArrayElementType(elementType: TypeName, elementTypeInfo: KotlinTypeInfo): TypeName
 }

--- a/src/test/resources/examples/primitiveTypes/api.yaml
+++ b/src/test/resources/examples/primitiveTypes/api.yaml
@@ -44,3 +44,12 @@ components:
         binary:
           type: string
           format: binary
+        arrayOfString:
+          type: array
+          items:
+            type: string
+        arrayOfUuid:
+          type: array
+          items:
+            type: string
+            format: uuid

--- a/src/test/resources/examples/primitiveTypes/models/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/Content.kt
@@ -13,6 +13,7 @@ import kotlin.Float
 import kotlin.Int
 import kotlin.Long
 import kotlin.String
+import kotlin.collections.List
 
 public data class Content(
   @param:JsonProperty("integer")
@@ -57,4 +58,10 @@ public data class Content(
   @param:JsonProperty("binary")
   @get:JsonProperty("binary")
   public val binary: ByteArray? = null,
+  @param:JsonProperty("arrayOfString")
+  @get:JsonProperty("arrayOfString")
+  public val arrayOfString: List<String>? = null,
+  @param:JsonProperty("arrayOfUuid")
+  @get:JsonProperty("arrayOfUuid")
+  public val arrayOfUuid: List<UUID>? = null,
 )

--- a/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
+++ b/src/test/resources/examples/primitiveTypes/models/kotlinx/Content.kt
@@ -10,6 +10,7 @@ import kotlin.Float
 import kotlin.Int
 import kotlin.Long
 import kotlin.String
+import kotlin.collections.List
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Contextual
@@ -51,4 +52,8 @@ public data class Content(
   @Contextual
   @SerialName("binary")
   public val binary: ByteArray? = null,
+  @SerialName("arrayOfString")
+  public val arrayOfString: List<String>? = null,
+  @SerialName("arrayOfUuid")
+  public val arrayOfUuid: List<@Contextual UUID>? = null,
 )


### PR DESCRIPTION
Types like UUID, URI, BigDecimal, ByteArray, Instant, and LocalDateTime require `@Contextual` annotation with kotlinx.serialization. Previously, these annotations were only added to singular properties, not array elements, causing serialization issues at runtime.

Now generates: `List<@Contextual UUID>` instead of: `List<UUID>` 👌 