### PR TITLE
Clients: Test enum as query param

### DIFF
--- a/end2end-tests/okhttp/src/test/kotlin/com/cjbooms/fabrikt/clients/Okio3Test.kt
+++ b/end2end-tests/okhttp/src/test/kotlin/com/cjbooms/fabrikt/clients/Okio3Test.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.clients.okio3
 
 import com.example.client.*
+import com.example.models.EnumQueryParam
 import com.example.models.Failure
 import com.example.models.FirstModel
 import com.example.models.QueryResult
@@ -107,6 +108,23 @@ class Okio3Test {
                 listOf(FirstModel(id = testInfo.displayName))
             )
         )
+    }
+
+    @Test
+    fun `adds enum_query_param to the query`(testInfo: TestInfo) {
+        wiremock.get {
+            urlPath like "/example-path-1"
+            queryParams contains "enum_query_param" like "ENUM_VALUE_1"
+        } returns {
+            statusCode = 200
+            body = mapper.writeValueAsString(
+                QueryResult(
+                    emptyList()
+                )
+            )
+        }
+
+        examplePath1Client.getExamplePath1(enumQueryParam = EnumQueryParam.ENUM_VALUE_1)
     }
 
     @Test

--- a/end2end-tests/spring-http-interface/src/test/kotlin/com/cjbooms/fabrikt/clients/AdditionalQueryParametersTest.kt
+++ b/end2end-tests/spring-http-interface/src/test/kotlin/com/cjbooms/fabrikt/clients/AdditionalQueryParametersTest.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.clients
 
 import com.example.client.ExamplePath1Client
+import com.example.models.EnumQueryParam
 import com.example.models.FirstModel
 import com.example.models.QueryResult
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -62,6 +63,21 @@ class AdditionalQueryParametersTest {
             body = mapper.writeValueAsString(expectedResponse)
         }
         val result = examplePath1Client.getExamplePath1(additionalQueryParameters = mapOf("unspecified_param" to "some_value"))
+        Assertions.assertThat(result).isEqualTo(expectedResponse)
+    }
+
+    @Test
+    fun `enum query parameters are properly appended to requests`() {
+        val expectedResponse = QueryResult(listOf(FirstModel(id = "the parameter was there!")))
+        wiremock.get {
+            urlPath like "/example-path-1"
+            queryParams contains "enum_query_param" like "ENUM_VALUE_1"
+        } returns {
+            statusCode = 200
+            header = "Content-Type" to "application/json"
+            body = mapper.writeValueAsString(expectedResponse)
+        }
+        val result = examplePath1Client.getExamplePath1(enumQueryParam = EnumQueryParam.ENUM_VALUE_1)
         Assertions.assertThat(result).isEqualTo(expectedResponse)
     }
 }

--- a/src/test/resources/examples/okHttpClient/api.yaml
+++ b/src/test/resources/examples/okHttpClient/api.yaml
@@ -11,6 +11,7 @@ paths:
         - $ref: "#/components/parameters/QueryParam2"
         - $ref: "#/components/parameters/ListQueryParamInt"
         - $ref: "#/components/parameters/JsonEncodedHeaderParam"
+        - $ref: "#/components/parameters/EnumQueryParam"
       responses:
         200:
           description: "successful operation"
@@ -231,6 +232,16 @@ components:
               headerProp2: anotherValue
               nestedProp:
                 nestedProp1: nestedValue
+    EnumQueryParam:
+        name: enum_query_param
+        in: query
+        schema:
+            type: string
+            enum:
+            - "enum_value_1"
+            - "enum_value_2"
+            - "enum_value_3"
+        required: false
 
   headers:
     Location:

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -3,6 +3,7 @@ package examples.okHttpClient.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import examples.okHttpClient.models.Content
+import examples.okHttpClient.models.EnumQueryParam
 import examples.okHttpClient.models.FirstModel
 import examples.okHttpClient.models.QueryResult
 import okhttp3.Headers
@@ -34,6 +35,7 @@ public class ExamplePath1Client(
      * @param queryParam2
      * @param intListQueryParam
      * @param xJsonEncodedHeader Json Encoded header
+     * @param enumQueryParam
      */
     @Throws(ApiException::class)
     public fun getExamplePath1(
@@ -41,6 +43,7 @@ public class ExamplePath1Client(
         queryParam2: Int? = null,
         intListQueryParam: List<Int>? = null,
         xJsonEncodedHeader: String? = null,
+        enumQueryParam: EnumQueryParam? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
         additionalQueryParameters: Map<String, String> = emptyMap(),
     ): ApiResponse<QueryResult> {
@@ -51,6 +54,7 @@ public class ExamplePath1Client(
                 .queryParam("explode_list_query_param", explodeListQueryParam, true)
                 .queryParam("query_param2", queryParam2)
                 .queryParam("int_list_query_param", intListQueryParam, true)
+                .queryParam("enum_query_param", enumQueryParam)
                 .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
                 .build()
 

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -3,6 +3,7 @@ package examples.okHttpClient.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import examples.okHttpClient.models.Content
+import examples.okHttpClient.models.EnumQueryParam
 import examples.okHttpClient.models.FirstModel
 import examples.okHttpClient.models.QueryResult
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
@@ -46,10 +47,18 @@ public class ExamplePath1Service(
         queryParam2: Int? = null,
         intListQueryParam: List<Int>? = null,
         xJsonEncodedHeader: String? = null,
+        enumQueryParam: EnumQueryParam? = null,
         additionalHeaders: Map<String, String> = emptyMap(),
     ): ApiResponse<QueryResult> =
         withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
-            apiClient.getExamplePath1(explodeListQueryParam, queryParam2, intListQueryParam, xJsonEncodedHeader, additionalHeaders)
+            apiClient.getExamplePath1(
+                explodeListQueryParam,
+                queryParam2,
+                intListQueryParam,
+                xJsonEncodedHeader,
+                enumQueryParam,
+                additionalHeaders,
+            )
         }
 
     @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClient/models/ClientModels.kt
+++ b/src/test/resources/examples/okHttpClient/models/ClientModels.kt
@@ -101,6 +101,22 @@ public enum class ContentThirdAttr(
     }
 }
 
+public enum class EnumQueryParam(
+    @JsonValue
+    public val `value`: String,
+) {
+    ENUM_VALUE_1("enum_value_1"),
+    ENUM_VALUE_2("enum_value_2"),
+    ENUM_VALUE_3("enum_value_3"),
+    ;
+
+    public companion object {
+        private val mapping: Map<String, EnumQueryParam> = entries.associateBy(EnumQueryParam::value)
+
+        public fun fromValue(`value`: String): EnumQueryParam? = mapping[value]
+    }
+}
+
 public data class Failure(
     @param:JsonProperty("traceId")
     @get:JsonProperty("traceId")


### PR DESCRIPTION
This test simply asserts the current enum behavior for generated clients.

It relates to #459, which raises the question of whether we are currently handling enums correctly in the clients.