### PR TITLE
Option to add Serdeable to generated models

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                               |   `QUARKUS_REFLECTION` - This option adds @RegisterForReflection to the generated models. Requires dependency "'io.quarkus:quarkus-core:+" |
 |                               |   `MICRONAUT_INTROSPECTION` - This option adds @Introspected to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
 |                               |   `MICRONAUT_REFLECTION` - This option adds @ReflectiveAccess to the generated models. Requires dependency "'io.micronaut:micronaut-core:+" |
+|                               |   `MICRONAUT_SERDEABLE` - This option adds @Serdeable to the generated models. Requires dependency "'io.micronaut.serde:micronaut-serde-jackson:+" |
 |                               |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
 |                               |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
 |                               |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -59,6 +59,7 @@ enum class ModelCodeGenOptionType(val description: String) {
     QUARKUS_REFLECTION("This option adds @RegisterForReflection to the generated models. Requires dependency \"'io.quarkus:quarkus-core:+\""),
     MICRONAUT_INTROSPECTION("This option adds @Introspected to the generated models. Requires dependency \"'io.micronaut:micronaut-core:+\""),
     MICRONAUT_REFLECTION("This option adds @ReflectiveAccess to the generated models. Requires dependency \"'io.micronaut:micronaut-core:+\""),
+    MICRONAUT_SERDEABLE("This option adds @Serdeable to the generated models. Requires dependency \"'io.micronaut.serde:micronaut-serde-jackson:+\""),
     INCLUDE_COMPANION_OBJECT("This option adds a companion object to the generated models."),
     SEALED_INTERFACES_FOR_ONE_OF("This option enables the generation of interfaces for discriminated oneOf types"),
     NON_NULL_MAP_VALUES("This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable"),

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
@@ -12,6 +12,8 @@ import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.cli.OutputOptionType
 import com.cjbooms.fabrikt.cli.SerializationLibrary
 import com.cjbooms.fabrikt.cli.ValidationLibrary
+import com.cjbooms.fabrikt.model.MicronautSerdeAnnotations
+import com.cjbooms.fabrikt.model.SerializationAnnotations
 
 object MutableSettings {
     var generationTypes: Set<CodeGenerationType> = mutableSetOf()
@@ -42,6 +44,18 @@ object MutableSettings {
         private set
     var outputOptions: Set<OutputOptionType> = mutableSetOf()
         private set
+
+    /**
+     * Returns the effective serialization annotations to use.
+     * If MICRONAUT_SERDEABLE option is enabled, uses MicronautSerdeAnnotations.
+     * Otherwise, uses the serialization annotations from the configured serialization library.
+     */
+    val effectiveSerializationAnnotations: SerializationAnnotations
+        get() = if (ModelCodeGenOptionType.MICRONAUT_SERDEABLE in modelOptions) {
+            MicronautSerdeAnnotations
+        } else {
+            serializationLibrary.serializationAnnotations
+        }
 
     fun updateSettings(
         genTypes: Set<CodeGenerationType> = emptySet(),

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/MicronautSerdeAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/MicronautSerdeAnnotations.kt
@@ -1,0 +1,23 @@
+package com.cjbooms.fabrikt.model
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+
+/**
+ * Serialization annotations for Micronaut Serialization.
+ * Delegates to JacksonAnnotations for most behavior due to compatibility with Jackson annotations.
+ */
+object MicronautSerdeAnnotations : SerializationAnnotations by JacksonAnnotations {
+    private val SERDEABLE = ClassName("io.micronaut.serde.annotation", "Serdeable")
+
+    override fun addClassAnnotation(typeSpecBuilder: TypeSpec.Builder) =
+        typeSpecBuilder.addAnnotation(SERDEABLE)
+
+    /**
+     * Micronaut Serde has built-in enum serialization and does not require @JsonValue annotation.
+     * Returning the builder as-is (no-op).
+     */
+    override fun addEnumPropertyAnnotation(propSpecBuilder: PropertySpec.Builder) =
+        propSpecBuilder
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -323,6 +323,25 @@ class ModelGeneratorTest {
     }
 
     @Test
+    fun `micronaut serde models are generated from a full API definition when the micronaut-serde option is set`() {
+        val basePackage = "examples.micronautSerdeModels"
+        val spec = readTextResource("/examples/micronautSerdeModels/api.yaml")
+        val expectedModels = "/examples/micronautSerdeModels/models/Models.kt"
+        MutableSettings.updateSettings(
+            modelOptions = setOf(ModelCodeGenOptionType.MICRONAUT_SERDEABLE),
+        )
+
+        val models = ModelGenerator(
+            Packages(basePackage),
+            SourceApi(spec),
+        )
+            .generate()
+            .toSingleFile()
+
+        assertThatGenerated(models).isEqualTo(expectedModels)
+    }
+
+    @Test
     fun `micronaut reflection models are generated from a full API definition when the micronaut-reflection option is set`() {
         val basePackage = "examples.micronautReflectionModels"
         val spec = readTextResource("/examples/micronautReflectionModels/api.yaml")

--- a/src/test/resources/examples/micronautSerdeModels/api.yaml
+++ b/src/test/resources/examples/micronautSerdeModels/api.yaml
@@ -1,0 +1,110 @@
+openapi: "3.0.0"
+info:
+paths:
+components:
+  schemas:
+    QueryResult:
+      type: "object"
+      required:
+        - "items"
+      properties:
+        items:
+          type: "array"
+          minItems: 0
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/FirstModel"
+              - $ref: "#/components/schemas/SecondModel"
+              - $ref: "#/components/schemas/ThirdModel"
+    Content:
+      type: "object"
+      required:
+        - "id"
+        - "attr_1"
+        - "attr_2"
+        - "attr_3"
+        - "etag"
+        - "model_type"
+      properties:
+        id:
+          description: "The unique resource id"
+          type: "string"
+          readOnly: true
+        first_attr:
+          description: "The attribute 1"
+          type: "string"
+          format: "date-time"
+          example: "2016-01-27T10:52:46.406Z"
+          readOnly: true
+        second_attr:
+          description: "The attribute 2"
+          type: "string"
+          readOnly: true
+        third_attr:
+          type: "string"
+          enum:
+            - "enum_type_1"
+            - "enum_type_2"
+          description: "Enum types for attribute 3"
+          example: "enum_type_2"
+        etag:
+          type: "string"
+          description: "Etag value to be used in conjunction with If-Match headers for optimistic locking purposes"
+          readOnly: true
+        model_type:
+          type: "string"
+          description: "The model discrimination type"
+          enum:
+            - "first_model"
+            - "second_model"
+            - "third_model"
+          example: "third_model"
+      discriminator:
+        propertyName: "model_type"
+        mapping:
+          first_model: "#/components/schemas/FirstModel"
+          second_model: "#/components/schemas/SecondModel"
+          third_model: "#/components/schemas/ThirdModel"
+
+    FirstModel:
+      allOf:
+        - $ref: "#/components/schemas/Content"
+        - type: "object"
+          properties:
+            extra_first_attr:
+              description: "The attribute 1 for model 1"
+              type: array
+              items:
+                type: "string"
+                minItems: 1
+                maxItems: 10
+              readOnly: true
+    SecondModel:
+      allOf:
+        - $ref: "#/components/schemas/Content"
+        - type: "object"
+          properties:
+            extra_first_attr:
+              description: "The attribute 1 for model 2"
+              type: "string"
+              readOnly: true
+            extra_second_attr:
+              description: "The attribute 2 for model 2"
+              type: boolean
+              readOnly: true
+
+    ThirdModel:
+      allOf:
+        - $ref: "#/components/schemas/Content"
+        - type: "object"
+          properties:
+            extra_first_attr:
+              description: "The attribute 1 for model 3"
+              type: "string"
+              format: "date-time"
+              example: "2016-01-27T10:52:46.406Z"
+              readOnly: true
+            extra_second_attr:
+              description: "The attribute 2 for model 3"
+              type: integer
+              readOnly: true

--- a/src/test/resources/examples/micronautSerdeModels/models/Models.kt
+++ b/src/test/resources/examples/micronautSerdeModels/models/Models.kt
@@ -1,0 +1,269 @@
+package examples.micronautSerdeModels.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import io.micronaut.serde.`annotation`.Serdeable
+import java.time.OffsetDateTime
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "model_type",
+    visible = true,
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(
+        value = FirstModel::class,
+        name =
+            "first_model",
+    ),
+    JsonSubTypes.Type(
+        value = SecondModel::class,
+        name =
+            "second_model",
+    ),
+    JsonSubTypes.Type(value = ThirdModel::class, name = "third_model"),
+)
+@Serdeable
+public sealed class Content(
+    /**
+     * The unique resource id
+     */
+    public open val id: String? = null,
+    /**
+     * The attribute 1
+     */
+    public open val firstAttr: OffsetDateTime? = null,
+    /**
+     * The attribute 2
+     */
+    public open val secondAttr: String? = null,
+    /**
+     * Enum types for attribute 3
+     */
+    public open val thirdAttr: ContentThirdAttr? = null,
+    /**
+     * Etag value to be used in conjunction with If-Match headers for optimistic locking purposes
+     */
+    public open val etag: String? = null,
+) {
+    /**
+     * The model discrimination type
+     */
+    public abstract val modelType: ContentModelType
+}
+
+/**
+ * The model discrimination type
+ */
+@Serdeable
+public enum class ContentModelType(
+    public val `value`: String,
+) {
+    FIRST_MODEL("first_model"),
+    SECOND_MODEL("second_model"),
+    THIRD_MODEL("third_model"),
+    ;
+
+    override fun toString(): String = value
+
+    public companion object {
+        private val mapping: Map<String, ContentModelType> =
+            entries.associateBy(ContentModelType::value)
+
+        public fun fromValue(`value`: String): ContentModelType? = mapping[value]
+    }
+}
+
+/**
+ * Enum types for attribute 3
+ */
+@Serdeable
+public enum class ContentThirdAttr(
+    public val `value`: String,
+) {
+    ENUM_TYPE_1("enum_type_1"),
+    ENUM_TYPE_2("enum_type_2"),
+    ;
+
+    override fun toString(): String = value
+
+    public companion object {
+        private val mapping: Map<String, ContentThirdAttr> =
+            entries.associateBy(ContentThirdAttr::value)
+
+        public fun fromValue(`value`: String): ContentThirdAttr? = mapping[value]
+    }
+}
+
+@Serdeable
+public data class FirstModel(
+    /**
+     * The unique resource id
+     */
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    /**
+     * The attribute 1
+     */
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    /**
+     * The attribute 2
+     */
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    /**
+     * Enum types for attribute 3
+     */
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    /**
+     * Etag value to be used in conjunction with If-Match headers for optimistic locking purposes
+     */
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    /**
+     * The attribute 1 for model 1
+     */
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    public val extraFirstAttr: List<String>? = null,
+    /**
+     * The model discrimination type
+     */
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    @param:JsonProperty("model_type")
+    override val modelType: ContentModelType = ContentModelType.FIRST_MODEL,
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag)
+
+@Serdeable
+public data class QueryResult(
+    @param:JsonProperty("items")
+    @get:JsonProperty("items")
+    @get:NotNull
+    @get:Size(min = 0)
+    @get:Valid
+    public val items: List<Content>,
+)
+
+@Serdeable
+public data class SecondModel(
+    /**
+     * The unique resource id
+     */
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    /**
+     * The attribute 1
+     */
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    /**
+     * The attribute 2
+     */
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    /**
+     * Enum types for attribute 3
+     */
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    /**
+     * Etag value to be used in conjunction with If-Match headers for optimistic locking purposes
+     */
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    /**
+     * The attribute 1 for model 2
+     */
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    public val extraFirstAttr: String? = null,
+    /**
+     * The attribute 2 for model 2
+     */
+    @param:JsonProperty("extra_second_attr")
+    @get:JsonProperty("extra_second_attr")
+    public val extraSecondAttr: Boolean? = null,
+    /**
+     * The model discrimination type
+     */
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    @param:JsonProperty("model_type")
+    override val modelType: ContentModelType = ContentModelType.SECOND_MODEL,
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag)
+
+@Serdeable
+public data class ThirdModel(
+    /**
+     * The unique resource id
+     */
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    override val id: String? = null,
+    /**
+     * The attribute 1
+     */
+    @param:JsonProperty("first_attr")
+    @get:JsonProperty("first_attr")
+    override val firstAttr: OffsetDateTime? = null,
+    /**
+     * The attribute 2
+     */
+    @param:JsonProperty("second_attr")
+    @get:JsonProperty("second_attr")
+    override val secondAttr: String? = null,
+    /**
+     * Enum types for attribute 3
+     */
+    @param:JsonProperty("third_attr")
+    @get:JsonProperty("third_attr")
+    override val thirdAttr: ContentThirdAttr? = null,
+    /**
+     * Etag value to be used in conjunction with If-Match headers for optimistic locking purposes
+     */
+    @param:JsonProperty("etag")
+    @get:JsonProperty("etag")
+    override val etag: String? = null,
+    /**
+     * The attribute 1 for model 3
+     */
+    @param:JsonProperty("extra_first_attr")
+    @get:JsonProperty("extra_first_attr")
+    public val extraFirstAttr: OffsetDateTime? = null,
+    /**
+     * The attribute 2 for model 3
+     */
+    @param:JsonProperty("extra_second_attr")
+    @get:JsonProperty("extra_second_attr")
+    public val extraSecondAttr: Int? = null,
+    /**
+     * The model discrimination type
+     */
+    @get:JsonProperty("model_type")
+    @get:NotNull
+    @param:JsonProperty("model_type")
+    override val modelType: ContentModelType = ContentModelType.THIRD_MODEL,
+) : Content(id, firstAttr, secondAttr, thirdAttr, etag)


### PR DESCRIPTION
Useful when using [Micronaut Serialization](https://micronaut-projects.github.io/micronaut-serialization/latest/guide/). 

Means models will automatically work with Micronaut Serialization without having to perform [`@SerdeImport`](https://micronaut-projects.github.io/micronaut-serialization/latest/guide/#serdeImport) for each and every model class.

Enable with `--http-model-opts MICRONAUT_SERDEABLE`.