### PR TITLE
Make polymorphic allOf detection more targeted.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -287,8 +287,13 @@ object KaizenParserExtensions {
     private fun List<Schema>?.hasAnyDefinedProperties(): Boolean =
         this?.any { it.properties?.isNotEmpty() == true } == true
 
-    fun Schema.isOneOfPolymorphicTypes() =
-        this.oneOfSchemas?.firstOrNull()?.allOfSchemas?.firstOrNull() != null
+    fun Schema.isOneOfPolymorphicTypes(): Boolean {
+        val maybeAllOfInFirstOneOf = this.oneOfSchemas?.firstOrNull()?.allOfSchemas?.firstOrNull()
+        return if (maybeAllOfInFirstOneOf != null) {
+            this.oneOfSchemas.all { it.allOfSchemas.contains(maybeAllOfInFirstOneOf) }
+        } else false
+    }
+
 
     fun Schema.isInlinedOneOfSuperInterface() = isOneOfSuperInterfaceOnly() && isInlinedPropertySchema()
 

--- a/src/test/resources/examples/inlinedAggregatedObjects/api.yaml
+++ b/src/test/resources/examples/inlinedAggregatedObjects/api.yaml
@@ -38,6 +38,28 @@ components:
                   id:
                     type: string
                     description: The identifier of the chat message.
+        arrayWithOneOf:
+          type: array
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/BModel"
+              - $ref: "#/components/schemas/CModel"
+
+    BModel:
+      type: object
+      allOf:
+        - type: object
+          properties:
+            b:
+              title: "<redacted>"
+              type: number
+
+    CModel:
+      type: object
+      properties:
+        c:
+          type: number
+
     SimpleObjOne:
       type: object
       required:

--- a/src/test/resources/examples/inlinedAggregatedObjects/models/BModel.kt
+++ b/src/test/resources/examples/inlinedAggregatedObjects/models/BModel.kt
@@ -1,0 +1,10 @@
+package examples.inlinedAggregatedObjects.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import java.math.BigDecimal
+
+public data class BModel(
+  @param:JsonProperty("b")
+  @get:JsonProperty("b")
+  public val b: BigDecimal? = null,
+)

--- a/src/test/resources/examples/inlinedAggregatedObjects/models/CModel.kt
+++ b/src/test/resources/examples/inlinedAggregatedObjects/models/CModel.kt
@@ -1,0 +1,10 @@
+package examples.inlinedAggregatedObjects.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import java.math.BigDecimal
+
+public data class CModel(
+  @param:JsonProperty("c")
+  @get:JsonProperty("c")
+  public val c: BigDecimal? = null,
+)

--- a/src/test/resources/examples/inlinedAggregatedObjects/models/Container.kt
+++ b/src/test/resources/examples/inlinedAggregatedObjects/models/Container.kt
@@ -2,6 +2,7 @@ package examples.inlinedAggregatedObjects.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import javax.validation.Valid
+import kotlin.Any
 import kotlin.collections.List
 
 public data class Container(
@@ -23,4 +24,7 @@ public data class Container(
   @get:Valid
   public val arrayWithAnyOfAggregationOfMany: List<ContainerArrayWithAnyOfAggregationOfMany>? =
       null,
+  @param:JsonProperty("arrayWithOneOf")
+  @get:JsonProperty("arrayWithOneOf")
+  public val arrayWithOneOf: List<Any>? = null,
 )


### PR DESCRIPTION
We cannot just assume that if the first schema in a oneOf contains an allOf, that all the oneOf schemas will also contain that same allOf schema. This logic is a hangover from the very first attempts by fabrikt to handle polymorphism, long before the recommendation to use discriminated oneOf.

We're still not 100% bullet-proof with this logic, but this improves it by ensuring its firing is much more targeted.

Closes #475 