### PR TITLE
playground eclipse temurin

### DIFF
--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Switch to `eclipse-temurin:17-jdk-alpine` for playground as `openjdk:17-jdk-slim` is `410 Gone` 🕳️ 