### PR TITLE
Support additionalProperties: false

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -101,7 +101,7 @@ object KaizenParserExtensions {
             ?.filterNot { it.isBlank() } ?: emptyList()
     }
 
-    fun Schema.hasAdditionalProperties(): Boolean = Overlay.of(additionalPropertiesSchema).isPresent
+    fun Schema.hasAdditionalProperties(): Boolean = Overlay.of(additionalPropertiesSchema).isPresent && additionalProperties != false
 
     fun Schema.isUnknownAdditionalProperties(oasKey: String) = type == null &&
         (getSchemaNameInParent() ?: oasKey) == "additionalProperties" && properties?.isEmpty() == true

--- a/src/test/resources/examples/additionalProperties/api.yaml
+++ b/src/test/resources/examples/additionalProperties/api.yaml
@@ -9,4 +9,13 @@ components:
       properties:
         message:
           type: string
-      additionalProperties: true
+      additionalProperties: true # allow additional properties of any type
+    ResultWithoutAdditionalProperties:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+      additionalProperties: false # explicitly disallow additional properties
+    # ... we could add more examples here for additionalProperties with a schema

--- a/src/test/resources/examples/additionalProperties/models/ResultWithoutAdditionalProperties.kt
+++ b/src/test/resources/examples/additionalProperties/models/ResultWithoutAdditionalProperties.kt
@@ -1,0 +1,12 @@
+package examples.additionalProperties.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class ResultWithoutAdditionalProperties(
+  @param:JsonProperty("message")
+  @get:JsonProperty("message")
+  @get:NotNull
+  public val message: String,
+)

--- a/src/test/resources/examples/mapExamples/models/ContainsReferenceToPolymorphicMap.kt
+++ b/src/test/resources/examples/mapExamples/models/ContainsReferenceToPolymorphicMap.kt
@@ -1,26 +1,12 @@
 package examples.mapExamples.models
 
-import com.fasterxml.jackson.`annotation`.JsonAnyGetter
-import com.fasterxml.jackson.`annotation`.JsonAnySetter
-import com.fasterxml.jackson.`annotation`.JsonIgnore
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import kotlin.Any
 import kotlin.String
 import kotlin.collections.Map
-import kotlin.collections.MutableMap
 
 public data class ContainsReferenceToPolymorphicMap(
   @param:JsonProperty("attributes")
   @get:JsonProperty("attributes")
   public val attributes: Map<String, Any?>?,
-  @get:JsonIgnore
-  public val properties: MutableMap<String, Any?> = mutableMapOf(),
-) {
-  @JsonAnyGetter
-  public fun `get`(): Map<String, Any?> = properties
-
-  @JsonAnySetter
-  public fun `set`(name: String, `value`: Any?) {
-    properties[name] = value
-  }
-}
+)


### PR DESCRIPTION
This PR adds support for explicitly disabling additional properties with `additionalProperties: false`.

Some tools adds this to signal that additional properties are not supported.
