### PR TITLE
Tag based grouping for controllers

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -71,6 +71,7 @@ enum class ModelCodeGenOptionType(val description: String) {
 enum class ControllerCodeGenOptionType(val description: String) {
     SUSPEND_MODIFIER("This option adds the suspend modifier to the generated controller functions"),
     AUTHENTICATION("This option adds the authentication parameter to the generated controller functions"),
+    TAG_GROUPING("This option groups controllers based on the first tag rather than paths"),
     COMPLETION_STAGE("This option makes generated controller functions have Type CompletionStage<T> (works only with Spring Controller generator)");
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -71,7 +71,7 @@ enum class ModelCodeGenOptionType(val description: String) {
 enum class ControllerCodeGenOptionType(val description: String) {
     SUSPEND_MODIFIER("This option adds the suspend modifier to the generated controller functions"),
     AUTHENTICATION("This option adds the authentication parameter to the generated controller functions"),
-    TAG_GROUPING("This option groups controllers based on the first tag rather than paths"),
+    GROUP_BY_TAG("This option groups controllers based on the first tag rather than paths"),
     COMPLETION_STAGE("This option makes generated controller functions have Type CompletionStage<T> (works only with Spring Controller generator)");
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
+import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.HeaderParam
@@ -8,6 +9,7 @@ import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
+import com.cjbooms.fabrikt.util.GroupingStrategy
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
 import com.cjbooms.fabrikt.util.NormalisedString.toKotlinParameterName
@@ -284,4 +286,11 @@ object GeneratorUtils {
     }
 
     fun TypeName.isUnit(): Boolean = this == Unit::class.asTypeName()
+
+    fun groupingStrategyFrom(options: Set<ControllerCodeGenOptionType>): GroupingStrategy =
+        if (ControllerCodeGenOptionType.GROUP_BY_TAG in options) {
+            GroupingStrategy.BY_FIRST_TAG
+        } else {
+            GroupingStrategy.BY_FIRST_PATH_SEGMENT
+        }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
@@ -20,7 +20,7 @@ import com.cjbooms.fabrikt.model.HandlebarsTemplates
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.SimpleFile
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
@@ -46,7 +46,7 @@ class OkHttpEnhancedClientGenerator(
         }
 
     private fun generateResilience4jClientCode(): Collection<ClientType> {
-        return api.openApi3.routeToPaths().map { (resourceName, paths) ->
+        return api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
             val funSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     val parameters = deriveClientParameters(path, operation, packages.base)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -27,7 +27,7 @@ import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
@@ -41,7 +41,6 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 import java.nio.file.Path
 import com.cjbooms.fabrikt.util.toUpperCase
-import com.squareup.kotlinpoet.TypeName
 
 class OkHttpSimpleClientGenerator(
     private val packages: Packages,
@@ -49,7 +48,7 @@ class OkHttpSimpleClientGenerator(
     private val srcPath: Path = Destinations.MAIN_KT_SOURCE
 ) {
     fun generateDynamicClientCode(): Collection<ClientType> {
-        return api.openApi3.routeToPaths().map { (resourceName, paths) ->
+        return api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
             val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     val parameters = deriveClientParameters(path, operation, packages.base)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
@@ -26,7 +26,7 @@ import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.cjbooms.fabrikt.util.toUpperCase
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
@@ -43,7 +43,7 @@ class OpenFeignInterfaceGenerator(
     private val api: SourceApi,
 ) : ClientGenerator {
     override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
-        val clientTypes = api.openApi3.routeToPaths().map { (resourceName, paths) ->
+        val clientTypes = api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
             val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     buildFunction(path, resource, operation, verb, options)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -26,7 +26,7 @@ import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -43,7 +43,7 @@ class SpringHttpInterfaceGenerator(
     private val srcPath: java.nio.file.Path = Destinations.MAIN_KT_SOURCE
 ) : ClientGenerator {
     override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
-        val clientTypes = api.openApi3.routeToPaths().map { (resourceName, paths) ->
+        val clientTypes = api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
             val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     buildFunction(path, resource, operation, verb, options)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
@@ -17,8 +17,8 @@ import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
 import com.github.javaparser.utils.CodeGenerationUtils
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -41,7 +41,7 @@ class KtorClientGenerator(
     private val networkErrorClassName = ClassName(packages.client, "NetworkError")
 
     override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
-        val resources: List<TypeSpec> = api.openApi3.routeToPaths().flatMap { (resourceName, paths) ->
+        val resources: List<TypeSpec> = api.openApi3.groupByPathSegment().flatMap { (resourceName, paths) ->
             val clientClassBuilder = TypeSpec.classBuilder(resourceName + "Client")
                 .addProperty(
                     PropertySpec.builder("httpClient", ClassName("io.ktor.client", "HttpClient"))

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -2,6 +2,7 @@ package com.cjbooms.fabrikt.generators.controller
 
 import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.groupingStrategyFrom
 import com.cjbooms.fabrikt.generators.GeneratorUtils.isUnit
 import com.cjbooms.fabrikt.generators.GeneratorUtils.splitByType
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
@@ -21,8 +22,9 @@ import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.FileUtils.addFileDisclaimer
+import com.cjbooms.fabrikt.util.GroupingStrategy
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSingleResource
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupedPaths
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
 import com.cjbooms.fabrikt.util.toUpperCase
 import com.reprezen.kaizen.oasparser.model3.Operation
@@ -60,11 +62,11 @@ class KtorControllerInterfaceGenerator(
     private val api: SourceApi,
     private val options: Set<ControllerCodeGenOptionType> = emptySet(),
 ) : ControllerInterfaceGenerator {
-    private val useTagBasedGrouping: Boolean
-        get() = options.any { it == ControllerCodeGenOptionType.TAG_GROUPING }
+    private val groupingStrategy: GroupingStrategy
+        get() = groupingStrategyFrom(options)
 
     override fun generate(): KtorControllers {
-        val controllerInterfaces = api.openApi3.routeToPaths(useTagBasedGrouping).map { (resourceName, paths) ->
+        val controllerInterfaces = api.openApi3.groupedPaths(groupingStrategy).map { (resourceName, paths) ->
             val controllerBuilder = TypeSpec.interfaceBuilder(ControllerGeneratorUtils.controllerName(resourceName))
 
             val routeFunBuilder = FunSpec.builder("${resourceName.camelCase()}Routes")

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -60,8 +60,11 @@ class KtorControllerInterfaceGenerator(
     private val api: SourceApi,
     private val options: Set<ControllerCodeGenOptionType> = emptySet(),
 ) : ControllerInterfaceGenerator {
+    private val useTagBasedGrouping: Boolean
+        get() = options.any { it == ControllerCodeGenOptionType.TAG_GROUPING }
+
     override fun generate(): KtorControllers {
-        val controllerInterfaces = api.openApi3.routeToPaths().map { (resourceName, paths) ->
+        val controllerInterfaces = api.openApi3.routeToPaths(useTagBasedGrouping).map { (resourceName, paths) ->
             val controllerBuilder = TypeSpec.interfaceBuilder(ControllerGeneratorUtils.controllerName(resourceName))
 
             val routeFunBuilder = FunSpec.builder("${resourceName.camelCase()}Routes")

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -47,9 +47,12 @@ class MicronautControllerInterfaceGenerator(
     private val addAuthenticationParameter: Boolean
         get() = options.any { it == ControllerCodeGenOptionType.AUTHENTICATION }
 
+    private val useTagBasedGrouping: Boolean
+        get() = options.any { it == ControllerCodeGenOptionType.TAG_GROUPING }
+
     override fun generate(): MicronautControllers =
         MicronautControllers(
-            api.openApi3.routeToPaths().map { (resourceName, paths) ->
+            api.openApi3.routeToPaths(useTagBasedGrouping).map { (resourceName, paths) ->
                 buildController(resourceName, paths.values)
             }.toSet(),
             addAuthenticationParameter,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -2,6 +2,7 @@ package com.cjbooms.fabrikt.generators.controller
 
 import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.groupingStrategyFrom
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.ValidationAnnotations
@@ -22,8 +23,9 @@ import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.FileUtils.addFileDisclaimer
+import com.cjbooms.fabrikt.util.GroupingStrategy
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSingleResource
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupedPaths
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -47,12 +49,12 @@ class MicronautControllerInterfaceGenerator(
     private val addAuthenticationParameter: Boolean
         get() = options.any { it == ControllerCodeGenOptionType.AUTHENTICATION }
 
-    private val useTagBasedGrouping: Boolean
-        get() = options.any { it == ControllerCodeGenOptionType.TAG_GROUPING }
+    private val groupingStrategy: GroupingStrategy
+        get() = groupingStrategyFrom(options)
 
     override fun generate(): MicronautControllers =
         MicronautControllers(
-            api.openApi3.routeToPaths(useTagBasedGrouping).map { (resourceName, paths) ->
+            api.openApi3.groupedPaths(groupingStrategy).map { (resourceName, paths) ->
                 buildController(resourceName, paths.values)
             }.toSet(),
             addAuthenticationParameter,

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -2,6 +2,7 @@ package com.cjbooms.fabrikt.generators.controller
 
 import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.GeneratorUtils.groupingStrategyFrom
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKdoc
 import com.cjbooms.fabrikt.generators.ValidationAnnotations
@@ -21,8 +22,9 @@ import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.FileUtils.addFileDisclaimer
+import com.cjbooms.fabrikt.util.GroupingStrategy
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSingleResource
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPaths
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupedPaths
 import com.cjbooms.fabrikt.util.toUpperCase
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
@@ -43,12 +45,12 @@ class SpringControllerInterfaceGenerator(
     private val EXTENSION_ASYNC_SUPPORT = "x-async-support"
     private val addAuthenticationParameter: Boolean
         get() = options.any { it == ControllerCodeGenOptionType.AUTHENTICATION }
-    private val useTagBasedGrouping: Boolean
-        get() = options.any { it == ControllerCodeGenOptionType.TAG_GROUPING }
+    private val groupingStrategy: GroupingStrategy
+        get() = groupingStrategyFrom(options)
 
     override fun generate(): SpringControllers =
         SpringControllers(
-            api.openApi3.routeToPaths(useTagBasedGrouping).map { (resourceName, paths) ->
+            api.openApi3.groupedPaths(groupingStrategy).map { (resourceName, paths) ->
                 buildController(resourceName, paths.values)
             }.toSet(),
         )

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -43,10 +43,12 @@ class SpringControllerInterfaceGenerator(
     private val EXTENSION_ASYNC_SUPPORT = "x-async-support"
     private val addAuthenticationParameter: Boolean
         get() = options.any { it == ControllerCodeGenOptionType.AUTHENTICATION }
+    private val useTagBasedGrouping: Boolean
+        get() = options.any { it == ControllerCodeGenOptionType.TAG_GROUPING }
 
     override fun generate(): SpringControllers =
         SpringControllers(
-            api.openApi3.routeToPaths().map { (resourceName, paths) ->
+            api.openApi3.routeToPaths(useTagBasedGrouping).map { (resourceName, paths) ->
                 buildController(resourceName, paths.values)
             }.toSet(),
         )

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -271,7 +271,7 @@ class KtorControllerInterfaceGeneratorTest {
         val controllers = KtorControllerInterfaceGenerator(
             Packages(basePackage),
             api,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(4)
@@ -309,7 +309,7 @@ class KtorControllerInterfaceGeneratorTest {
         val controllers = KtorControllerInterfaceGenerator(
             Packages(basePackage),
             api,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         // /organisations/{parent-id}/contributors has tags [organisation, contributor]
@@ -343,7 +343,7 @@ class KtorControllerInterfaceGeneratorTest {
 
         val tagBased = KtorControllerInterfaceGenerator(
             Packages(basePackage), api,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         fun countOps(c: KtorControllerInterfaceGenerator.KtorControllers) = c.files
@@ -361,7 +361,7 @@ class KtorControllerInterfaceGeneratorTest {
         val controllers = KtorControllerInterfaceGenerator(
             Packages(basePackage),
             api,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(1)
@@ -374,7 +374,7 @@ class KtorControllerInterfaceGeneratorTest {
         val controllers = KtorControllerInterfaceGenerator(
             Packages(basePackage),
             api,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(1)

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
@@ -284,7 +284,7 @@ class MicronautControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(4)
@@ -323,7 +323,7 @@ class MicronautControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         // /organisations/{parent-id}/contributors has tags [organisation, contributor]
@@ -357,7 +357,7 @@ class MicronautControllerGeneratorTest {
 
         val tagBased = MicronautControllerInterfaceGenerator(
             Packages(basePackage), api, JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         fun countOps(c: MicronautControllers) = c.files
@@ -376,7 +376,7 @@ class MicronautControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(1)
@@ -390,7 +390,7 @@ class MicronautControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(1)

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
@@ -276,4 +276,124 @@ class MicronautControllerGeneratorTest {
 
         assertThatGenerated(controllers.trim()).isEqualTo(expectedControllers)
     }
+
+    @Test
+    fun `ensure TAG_GROUPING produces controllers grouped by first tag`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+        val controllers = MicronautControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        assertThat(controllers.files).size().isEqualTo(4)
+        assertThat(controllers.files.map { it.name }).containsExactlyInAnyOrder(
+            "EventsController",
+            "ContributorController",
+            "OrganisationController",
+            "RepositoryController",
+        )
+
+        // OrganisationController should contain 8 operations from both /organisations
+        // and /organisations/{parent-id}/contributors (first tag is "organisation")
+        val organisationFunctionNames = controllers.files
+            .filter { it.name == "OrganisationController" }
+            .flatMap { it.members }
+            .flatMap { (it as TypeSpec).funSpecs.map { t -> t.name } }
+
+        assertThat(organisationFunctionNames).hasSize(8)
+        assertThat(organisationFunctionNames).containsAll(listOf("get", "post", "getById", "putById", "deleteById"))
+
+        // RepositoryController should contain 8 operations from both /repositories
+        // and /repositories/{parent-id}/pull-requests (first tag is "repository")
+        val repositoryFunctionNames = controllers.files
+            .filter { it.name == "RepositoryController" }
+            .flatMap { it.members }
+            .flatMap { (it as TypeSpec).funSpecs.map { t -> t.name } }
+
+        assertThat(repositoryFunctionNames).hasSize(8)
+        assertThat(repositoryFunctionNames).containsAll(listOf("get", "post", "getById", "putById"))
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING uses first tag when operation has multiple tags`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+        val controllers = MicronautControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        // /organisations/{parent-id}/contributors has tags [organisation, contributor]
+        // Should go to OrganisationController (first tag), not ContributorController
+        val organisationOpCount = controllers.files
+            .filter { it.name == "OrganisationController" }
+            .flatMap { it.members }
+            .filterIsInstance<TypeSpec>()
+            .flatMap { it.funSpecs }
+            .size
+
+        // ContributorController should only have /contributors operations (4)
+        val contributorOpCount = controllers.files
+            .filter { it.name == "ContributorController" }
+            .flatMap { it.members }
+            .filterIsInstance<TypeSpec>()
+            .flatMap { it.funSpecs }
+            .size
+
+        assertThat(organisationOpCount).isEqualTo(8)
+        assertThat(contributorOpCount).isEqualTo(4)
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING preserves total operation count`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+
+        val pathBased = MicronautControllerInterfaceGenerator(
+            Packages(basePackage), api, JavaxValidationAnnotations, emptySet(),
+        ).generate()
+
+        val tagBased = MicronautControllerInterfaceGenerator(
+            Packages(basePackage), api, JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        fun countOps(c: MicronautControllers) = c.files
+            .flatMap { it.members }
+            .filterIsInstance<TypeSpec>()
+            .flatMap { it.funSpecs }
+            .size
+
+        assertThat(countOps(tagBased)).isEqualTo(countOps(pathBased))
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING falls back to path grouping when no tags present`() {
+        val api = SourceApi(readTextResource("/examples/tagGroupingNoTags/api.yaml"))
+        val controllers = MicronautControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        assertThat(controllers.files).size().isEqualTo(1)
+        assertThat(controllers.files.map { it.name }).containsExactly("UsersController")
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING falls back to path grouping when tags array is empty`() {
+        val api = SourceApi(readTextResource("/examples/tagGroupingEmptyTags/api.yaml"))
+        val controllers = MicronautControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        assertThat(controllers.files).size().isEqualTo(1)
+        assertThat(controllers.files.map { it.name }).containsExactly("OrdersController")
+    }
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -327,4 +327,124 @@ class SpringControllerGeneratorTest {
             assertThat(content).isEqualTo(expectedFiles[key])
         }
     }
+
+    @Test
+    fun `ensure TAG_GROUPING produces controllers grouped by first tag`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+        val controllers = SpringControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        assertThat(controllers.files).size().isEqualTo(4)
+        assertThat(controllers.files.map { it.name }).containsExactlyInAnyOrder(
+            "EventsController",
+            "ContributorController",
+            "OrganisationController",
+            "RepositoryController",
+        )
+
+        // OrganisationController should contain 8 operations from both /organisations
+        // and /organisations/{parent-id}/contributors (first tag is "organisation")
+        val organisationFunctionNames = controllers.files
+            .filter { it.name == "OrganisationController" }
+            .flatMap { it.members }
+            .flatMap { (it as TypeSpec).funSpecs.map { t -> t.name } }
+
+        assertThat(organisationFunctionNames).hasSize(8)
+        assertThat(organisationFunctionNames).containsAll(listOf("get", "post", "getById", "putById", "deleteById"))
+
+        // RepositoryController should contain 8 operations from both /repositories
+        // and /repositories/{parent-id}/pull-requests (first tag is "repository")
+        val repositoryFunctionNames = controllers.files
+            .filter { it.name == "RepositoryController" }
+            .flatMap { it.members }
+            .flatMap { (it as TypeSpec).funSpecs.map { t -> t.name } }
+
+        assertThat(repositoryFunctionNames).hasSize(8)
+        assertThat(repositoryFunctionNames).containsAll(listOf("get", "post", "getById", "putById"))
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING uses first tag when operation has multiple tags`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+        val controllers = SpringControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        // /organisations/{parent-id}/contributors has tags [organisation, contributor]
+        // Should go to OrganisationController (first tag), not ContributorController
+        val organisationOpCount = controllers.files
+            .filter { it.name == "OrganisationController" }
+            .flatMap { it.members }
+            .filterIsInstance<TypeSpec>()
+            .flatMap { it.funSpecs }
+            .size
+
+        // ContributorController should only have /contributors operations (4)
+        val contributorOpCount = controllers.files
+            .filter { it.name == "ContributorController" }
+            .flatMap { it.members }
+            .filterIsInstance<TypeSpec>()
+            .flatMap { it.funSpecs }
+            .size
+
+        assertThat(organisationOpCount).isEqualTo(8)
+        assertThat(contributorOpCount).isEqualTo(4)
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING preserves total operation count`() {
+        val api = SourceApi(readTextResource("/examples/githubApi/api.yaml"))
+
+        val pathBased = SpringControllerInterfaceGenerator(
+            Packages(basePackage), api, JavaxValidationAnnotations, emptySet(),
+        ).generate()
+
+        val tagBased = SpringControllerInterfaceGenerator(
+            Packages(basePackage), api, JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        fun countOps(c: SpringControllers) = c.files
+            .flatMap { it.members }
+            .filterIsInstance<TypeSpec>()
+            .flatMap { it.funSpecs }
+            .size
+
+        assertThat(countOps(tagBased)).isEqualTo(countOps(pathBased))
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING falls back to path grouping when no tags present`() {
+        val api = SourceApi(readTextResource("/examples/tagGroupingNoTags/api.yaml"))
+        val controllers = SpringControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        assertThat(controllers.files).size().isEqualTo(1)
+        assertThat(controllers.files.map { it.name }).containsExactly("UsersController")
+    }
+
+    @Test
+    fun `ensure TAG_GROUPING falls back to path grouping when tags array is empty`() {
+        val api = SourceApi(readTextResource("/examples/tagGroupingEmptyTags/api.yaml"))
+        val controllers = SpringControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+        ).generate()
+
+        assertThat(controllers.files).size().isEqualTo(1)
+        assertThat(controllers.files.map { it.name }).containsExactly("OrdersController")
+    }
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -6,7 +6,6 @@ import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.cli.OutputOptionType
 import com.cjbooms.fabrikt.cli.ValidationLibrary
 import com.cjbooms.fabrikt.configurations.Packages
-import com.cjbooms.fabrikt.generators.controller.KtorControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.SpringControllerInterfaceGenerator
 import com.cjbooms.fabrikt.generators.controller.SpringControllers
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports
@@ -335,7 +334,7 @@ class SpringControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(4)
@@ -374,7 +373,7 @@ class SpringControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         // /organisations/{parent-id}/contributors has tags [organisation, contributor]
@@ -408,7 +407,7 @@ class SpringControllerGeneratorTest {
 
         val tagBased = SpringControllerInterfaceGenerator(
             Packages(basePackage), api, JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         fun countOps(c: SpringControllers) = c.files
@@ -427,7 +426,7 @@ class SpringControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(1)
@@ -441,7 +440,7 @@ class SpringControllerGeneratorTest {
             Packages(basePackage),
             api,
             JavaxValidationAnnotations,
-            setOf(ControllerCodeGenOptionType.TAG_GROUPING),
+            setOf(ControllerCodeGenOptionType.GROUP_BY_TAG),
         ).generate()
 
         assertThat(controllers.files).size().isEqualTo(1)

--- a/src/test/resources/examples/tagGroupingEmptyTags/api.yaml
+++ b/src/test/resources/examples/tagGroupingEmptyTags/api.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: Empty Tags Test
+  version: 1.0.0
+paths:
+  /orders:
+    get:
+      tags: []
+      summary: Empty tags array
+      responses:
+        200:
+          description: OK

--- a/src/test/resources/examples/tagGroupingNoTags/api.yaml
+++ b/src/test/resources/examples/tagGroupingNoTags/api.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: No Tags Test
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: No tags defined
+      responses:
+        200:
+          description: OK


### PR DESCRIPTION
Add option that enables grouping controllers by the first tag instead of URL path segments. 

* Add tag based grouping for controllers
  - Add new controller generation option - TAG_GROUPING
  - Update Ktor, Micronaut, Spring controller generators
  - Add unit tests and test in playground