### PR TITLE
Add required=true to @JsonProperty for required primitive fields

### DIFF
--- a/end2end-tests/models-jackson/openapi/api.yaml
+++ b/end2end-tests/models-jackson/openapi/api.yaml
@@ -472,3 +472,34 @@ components:
           type: number
           format: double
           default: 0.1
+
+    # Required primitives - for testing issue #489
+    RequiredPrimitives:
+      type: object
+      required:
+        - required_string
+        - required_int
+        - required_long
+        - required_double
+        - required_float
+        - required_boolean
+      properties:
+        required_string:
+          type: string
+        required_int:
+          type: integer
+          format: int32
+        required_long:
+          type: integer
+          format: int64
+        required_double:
+          type: number
+          format: double
+        required_float:
+          type: number
+          format: float
+        required_boolean:
+          type: boolean
+        optional_int:
+          type: integer
+          format: int32

--- a/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/RequiredPrimitivesTest.kt
+++ b/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/RequiredPrimitivesTest.kt
@@ -1,0 +1,152 @@
+package com.cjbooms.fabrikt.models.jackson
+
+import com.example.models.RequiredPrimitives
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for issue #489: Required primitives are not actually required.
+ *
+ * When Jackson deserializes missing fields for primitive types (Int, Long, Double, Float, Boolean),
+ * it assigns JVM defaults (0, 0L, 0.0, 0.0f, false) instead of throwing an exception.
+ * This is because JVM primitives cannot be null, so there's no null value flowing through
+ * jackson-module-kotlin's null checks.
+ *
+ * The fix adds `required = true` to `@param:JsonProperty` for required primitive fields,
+ * which tells Jackson to check for field presence before deserialization.
+ */
+class RequiredPrimitivesTest {
+    private val objectMapper: ObjectMapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+
+    @Test
+    fun `must deserialize when all required fields are present`() {
+        val json = """
+            {
+                "required_string": "test",
+                "required_int": 42,
+                "required_long": 123456789,
+                "required_double": 3.14,
+                "required_float": 2.5,
+                "required_boolean": true
+            }
+        """.trimIndent()
+
+        val result = objectMapper.readValue<RequiredPrimitives>(json)
+
+        assertThat(result.requiredString).isEqualTo("test")
+        assertThat(result.requiredInt).isEqualTo(42)
+        assertThat(result.requiredLong).isEqualTo(123456789L)
+        assertThat(result.requiredDouble).isEqualTo(3.14)
+        assertThat(result.requiredFloat).isEqualTo(2.5f)
+        assertThat(result.requiredBoolean).isTrue()
+        assertThat(result.optionalInt).isNull()
+    }
+
+    @Test
+    fun `must fail when required int is missing`() {
+        val json = """
+            {
+                "required_string": "test",
+                "required_long": 123456789,
+                "required_double": 3.14,
+                "required_float": 2.5,
+                "required_boolean": true
+            }
+        """.trimIndent()
+
+        assertThatThrownBy { objectMapper.readValue<RequiredPrimitives>(json) }
+            .isInstanceOf(JsonMappingException::class.java)
+            .hasMessageContaining("required_int")
+    }
+
+    @Test
+    fun `must fail when required long is missing`() {
+        val json = """
+            {
+                "required_string": "test",
+                "required_int": 42,
+                "required_double": 3.14,
+                "required_float": 2.5,
+                "required_boolean": true
+            }
+        """.trimIndent()
+
+        assertThatThrownBy { objectMapper.readValue<RequiredPrimitives>(json) }
+            .isInstanceOf(JsonMappingException::class.java)
+            .hasMessageContaining("required_long")
+    }
+
+    @Test
+    fun `must fail when required double is missing`() {
+        val json = """
+            {
+                "required_string": "test",
+                "required_int": 42,
+                "required_long": 123456789,
+                "required_float": 2.5,
+                "required_boolean": true
+            }
+        """.trimIndent()
+
+        assertThatThrownBy { objectMapper.readValue<RequiredPrimitives>(json) }
+            .isInstanceOf(JsonMappingException::class.java)
+            .hasMessageContaining("required_double")
+    }
+
+    @Test
+    fun `must fail when required float is missing`() {
+        val json = """
+            {
+                "required_string": "test",
+                "required_int": 42,
+                "required_long": 123456789,
+                "required_double": 3.14,
+                "required_boolean": true
+            }
+        """.trimIndent()
+
+        assertThatThrownBy { objectMapper.readValue<RequiredPrimitives>(json) }
+            .isInstanceOf(JsonMappingException::class.java)
+            .hasMessageContaining("required_float")
+    }
+
+    @Test
+    fun `must fail when required boolean is missing`() {
+        val json = """
+            {
+                "required_string": "test",
+                "required_int": 42,
+                "required_long": 123456789,
+                "required_double": 3.14,
+                "required_float": 2.5
+            }
+        """.trimIndent()
+
+        assertThatThrownBy { objectMapper.readValue<RequiredPrimitives>(json) }
+            .isInstanceOf(JsonMappingException::class.java)
+            .hasMessageContaining("required_boolean")
+    }
+
+    @Test
+    fun `must fail when required string is missing`() {
+        val json = """
+            {
+                "required_int": 42,
+                "required_long": 123456789,
+                "required_double": 3.14,
+                "required_float": 2.5,
+                "required_boolean": true
+            }
+        """.trimIndent()
+
+        assertThatThrownBy { objectMapper.readValue<RequiredPrimitives>(json) }
+            .isInstanceOf(JsonMappingException::class.java)
+            .hasMessageContaining("required_string")
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -117,14 +117,14 @@ object PropertyUtils {
                             property.addModifiers(KModifier.OVERRIDE)
                             classBuilder.addSuperclassConstructorParameter(name)
                         }
-                        serializationAnnotations.addParameter(property, oasKey)
+                        serializationAnnotations.addParameter(property, oasKey, isRequired, typeInfo)
                     }
                     serializationAnnotations.addProperty(property, oasKey, typeInfo)
                     property.addValidationAnnotations(this, validationAnnotations)
                 }
 
                 ClassSettings.PolymorphyType.NONE -> {
-                    serializationAnnotations.addParameter(property, oasKey)
+                    serializationAnnotations.addParameter(property, oasKey, isRequired, typeInfo)
                     serializationAnnotations.addProperty(property, oasKey, typeInfo)
                     property.addValidationAnnotations(this, validationAnnotations)
                 }
@@ -142,7 +142,7 @@ object PropertyUtils {
                         return // Skip adding the property to the class
                     } else {
                         property.initializer(name)
-                        serializationAnnotations.addParameter(property, oasKey)
+                        serializationAnnotations.addParameter(property, oasKey, isRequired, typeInfo)
                         val constructorParameter: ParameterSpec.Builder = ParameterSpec.builder(name, wrappedType)
                         val discriminators = maybeDiscriminator.getDiscriminatorMappings(schemaName)
                         when (val discriminator = discriminators.first()) {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
@@ -31,10 +31,12 @@ object JacksonMetadata {
         .useSiteTarget(AnnotationSpec.UseSiteTarget.GET)
         .addMember("%S", name).build()
 
-    fun jacksonParameterAnnotation(name: String) = AnnotationSpec
+    fun jacksonParameterAnnotation(name: String, required: Boolean = false) = AnnotationSpec
         .builder(JSON_PROPERTY_CLASS)
         .useSiteTarget(AnnotationSpec.UseSiteTarget.PARAM)
-        .addMember("%S", name).build()
+        .addMember("%S", name)
+        .apply { if (required) addMember("required = %L", true) }
+        .build()
 
     val anySetter = AnnotationSpec.builder(JSON_ANY_SETTER).build()
     val anyGetter = AnnotationSpec.builder(JSON_ANY_GETTER).build()

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
@@ -24,8 +24,14 @@ object JacksonAnnotations : SerializationAnnotations {
     override fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String, kotlinTypeInfo: KotlinTypeInfo): PropertySpec.Builder =
         propertySpecBuilder.addAnnotation(JacksonMetadata.jacksonPropertyAnnotation(oasKey))
 
-    override fun addParameter(propertySpecBuilder: PropertySpec.Builder, oasKey: String) =
-        propertySpecBuilder.addAnnotation(JacksonMetadata.jacksonParameterAnnotation(oasKey))
+    override fun addParameter(
+        propertySpecBuilder: PropertySpec.Builder,
+        oasKey: String,
+        isRequired: Boolean,
+        typeInfo: KotlinTypeInfo,
+    ) = propertySpecBuilder.addAnnotation(
+        JacksonMetadata.jacksonParameterAnnotation(oasKey, required = isRequired && typeInfo.isPrimitiveType)
+    )
 
     override fun addClassAnnotation(typeSpecBuilder: TypeSpec.Builder) =
         typeSpecBuilder

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -74,6 +74,12 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
             else -> false
         }
 
+    val isPrimitiveType: kotlin.Boolean
+        get() = when (this) {
+            is Integer, is BigInt, is Double, is Float, is Boolean -> true
+            else -> false
+        }
+
     companion object {
         private val logger = Logger.getGlobal()
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
@@ -75,8 +75,12 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
             else -> false
         }
 
-    override fun addParameter(propertySpecBuilder: PropertySpec.Builder, oasKey: String) =
-        propertySpecBuilder // not applicable
+    override fun addParameter(
+        propertySpecBuilder: PropertySpec.Builder,
+        oasKey: String,
+        isRequired: Boolean,
+        typeInfo: KotlinTypeInfo,
+    ) = propertySpecBuilder // not applicable
 
     override fun addClassAnnotation(typeSpecBuilder: TypeSpec.Builder) =
         typeSpecBuilder.addAnnotation(AnnotationSpec.builder(Serializable::class).build())

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -21,7 +21,12 @@ sealed interface SerializationAnnotations {
     fun addGetter(funSpecBuilder: FunSpec.Builder): FunSpec.Builder
     fun addSetter(funSpecBuilder: FunSpec.Builder): FunSpec.Builder
     fun addProperty(propertySpecBuilder: PropertySpec.Builder, oasKey: String, kotlinTypeInfo: KotlinTypeInfo): PropertySpec.Builder
-    fun addParameter(propertySpecBuilder: PropertySpec.Builder, oasKey: String): PropertySpec.Builder
+    fun addParameter(
+        propertySpecBuilder: PropertySpec.Builder,
+        oasKey: String,
+        isRequired: Boolean,
+        typeInfo: KotlinTypeInfo,
+    ): PropertySpec.Builder
     fun addClassAnnotation(typeSpecBuilder: TypeSpec.Builder): TypeSpec.Builder
     fun addBasePolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, propertyName: String): TypeSpec.Builder
     fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>): TypeSpec.Builder

--- a/src/test/resources/examples/anyOfOneOfAllOf/models/ComplexParent.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/ComplexParent.kt
@@ -21,7 +21,10 @@ public data class ComplexParent(
   @get:JsonProperty("required_string")
   @get:NotNull
   public val requiredString: String,
-  @param:JsonProperty("required_int")
+  @param:JsonProperty(
+    "required_int",
+    required = true,
+  )
   @get:JsonProperty("required_int")
   @get:NotNull
   public val requiredInt: Int,

--- a/src/test/resources/examples/anyOfOneOfAllOf/models/SimpleTypeWithRequiredProps.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/SimpleTypeWithRequiredProps.kt
@@ -10,7 +10,10 @@ public data class SimpleTypeWithRequiredProps(
   @get:JsonProperty("required_string")
   @get:NotNull
   public val requiredString: String,
-  @param:JsonProperty("required_int")
+  @param:JsonProperty(
+    "required_int",
+    required = true,
+  )
   @get:JsonProperty("required_int")
   @get:NotNull
   public val requiredInt: Int,

--- a/src/test/resources/examples/companionObject/models/Models.kt
+++ b/src/test/resources/examples/companionObject/models/Models.kt
@@ -12,7 +12,10 @@ import kotlin.String
 import kotlin.collections.Map
 
 public data class Cat(
-    @param:JsonProperty("id")
+    @param:JsonProperty(
+        "id",
+        required = true,
+    )
     @get:JsonProperty("id")
     @get:NotNull
     override val id: Long,
@@ -38,7 +41,10 @@ public data class Cat(
 }
 
 public data class Dog(
-    @param:JsonProperty("id")
+    @param:JsonProperty(
+        "id",
+        required = true,
+    )
     @get:JsonProperty("id")
     @get:NotNull
     override val id: Long,
@@ -83,7 +89,10 @@ public enum class DogBreed(
 }
 
 public data class Error(
-    @param:JsonProperty("code")
+    @param:JsonProperty(
+        "code",
+        required = true,
+    )
     @get:JsonProperty("code")
     @get:NotNull
     public val code: Int,

--- a/src/test/resources/examples/jakartaValidationAnnotations/models/Models.kt
+++ b/src/test/resources/examples/jakartaValidationAnnotations/models/Models.kt
@@ -18,7 +18,10 @@ public data class ValidationAnnotations(
     @get:NotNull
     @get:Pattern(regexp = "[a-zA-Z]")
     public val userName: String,
-    @param:JsonProperty("age")
+    @param:JsonProperty(
+        "age",
+        required = true,
+    )
     @get:JsonProperty("age")
     @get:NotNull
     @get:DecimalMin(

--- a/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild11.kt
+++ b/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild11.kt
@@ -30,7 +30,10 @@ public data class ThirdLevelChild11(
   /**
    * timestamp
    */
-  @param:JsonProperty("creationDate")
+  @param:JsonProperty(
+    "creationDate",
+    required = true,
+  )
   @get:JsonProperty("creationDate")
   @get:NotNull
   public val creationDate: Int,

--- a/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild12.kt
+++ b/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild12.kt
@@ -27,7 +27,10 @@ public data class ThirdLevelChild12(
   @get:NotNull
   @get:Valid
   override val metadata: SecondLevelMetadata,
-  @param:JsonProperty("isDeleted")
+  @param:JsonProperty(
+    "isDeleted",
+    required = true,
+  )
   @get:JsonProperty("isDeleted")
   @get:NotNull
   public val isDeleted: Boolean,

--- a/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild21.kt
+++ b/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild21.kt
@@ -30,7 +30,10 @@ public data class ThirdLevelChild21(
   /**
    * timestamp
    */
-  @param:JsonProperty("creationDate")
+  @param:JsonProperty(
+    "creationDate",
+    required = true,
+  )
   @get:JsonProperty("creationDate")
   @get:NotNull
   public val creationDate: Int,

--- a/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild22.kt
+++ b/src/test/resources/examples/nestedPolymorphicModels/models/ThirdLevelChild22.kt
@@ -27,7 +27,10 @@ public data class ThirdLevelChild22(
   @get:NotNull
   @get:Valid
   override val metadata: SecondLevelMetadata,
-  @param:JsonProperty("isDeleted")
+  @param:JsonProperty(
+    "isDeleted",
+    required = true,
+  )
   @get:JsonProperty("isDeleted")
   @get:NotNull
   public val isDeleted: Boolean,

--- a/src/test/resources/examples/noValidationAnnotations/models/Models.kt
+++ b/src/test/resources/examples/noValidationAnnotations/models/Models.kt
@@ -10,7 +10,10 @@ public data class ValidationAnnotations(
     @param:JsonProperty("user_name")
     @get:JsonProperty("user_name")
     public val userName: String,
-    @param:JsonProperty("age")
+    @param:JsonProperty(
+        "age",
+        required = true,
+    )
     @get:JsonProperty("age")
     public val age: Int,
     @param:JsonProperty("bio")

--- a/src/test/resources/examples/oneOfPolymorphicModels/models/ChildTypeB.kt
+++ b/src/test/resources/examples/oneOfPolymorphicModels/models/ChildTypeB.kt
@@ -5,7 +5,10 @@ import javax.validation.constraints.NotNull
 import kotlin.Int
 
 public data class ChildTypeB(
-  @param:JsonProperty("some_int")
+  @param:JsonProperty(
+    "some_int",
+    required = true,
+  )
   @get:JsonProperty("some_int")
   @get:NotNull
   public val someInt: Int,

--- a/src/test/resources/examples/responsesSchema/models/ErrorResponse.kt
+++ b/src/test/resources/examples/responsesSchema/models/ErrorResponse.kt
@@ -10,7 +10,10 @@ public data class ErrorResponse(
   @get:JsonProperty("message")
   @get:NotNull
   public val message: String,
-  @param:JsonProperty("code")
+  @param:JsonProperty(
+    "code",
+    required = true,
+  )
   @get:JsonProperty("code")
   @get:NotNull
   public val code: Int,

--- a/src/test/resources/examples/validationAnnotations/models/ValidationAnnotations.kt
+++ b/src/test/resources/examples/validationAnnotations/models/ValidationAnnotations.kt
@@ -16,7 +16,10 @@ public data class ValidationAnnotations(
   @get:NotNull
   @get:Pattern(regexp = "[a-zA-Z]")
   public val userName: String,
-  @param:JsonProperty("age")
+  @param:JsonProperty(
+    "age",
+    required = true,
+  )
   @get:JsonProperty("age")
   @get:NotNull
   @get:DecimalMin(

--- a/src/test/resources/examples/webhook/models/Pet.kt
+++ b/src/test/resources/examples/webhook/models/Pet.kt
@@ -6,7 +6,10 @@ import kotlin.Long
 import kotlin.String
 
 public data class Pet(
-  @param:JsonProperty("id")
+  @param:JsonProperty(
+    "id",
+    required = true,
+  )
   @get:JsonProperty("id")
   @get:NotNull
   public val id: Long,


### PR DESCRIPTION
As reported in #489, when Jackson deserializes missing fields for primitive types (Int, Long, Double, Float, Boolean), it assigns JVM defaults (0, false) instead of throwing an exception. This happens because JVM primitives cannot be null.

This fix adds `required = true` to `@param:JsonProperty` for required primitive fields, which tells Jackson to check for field presence before deserialization.

Only primitive types are affected - types like String already fail correctly when missing.

Related issue: https://github.com/FasterXML/jackson-module-kotlin/issues/242

Closes #489.