### PR TITLE
Add NetworkResult/NetworkError sealed types to Ktor client

### DIFF
--- a/end2end-tests/ktor-client-jackson/build.gradle.kts
+++ b/end2end-tests/ktor-client-jackson/build.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
 
 val junitVersion: String by rootProject.extra
 val ktorVersion: String by rootProject.extra
-val kotlinxDateTimeVersion: String by rootProject.extra
 
 dependencies {
     // ktor client
@@ -30,8 +29,6 @@ dependencies {
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
-
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion")
 
     // ktor test
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
@@ -54,8 +51,6 @@ tasks {
 
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
-            optIn.add("kotlinx.serialization.ExperimentalSerializationApi")
-            optIn.add("kotlin.time.ExperimentalTime")
             jvmTarget.set(JvmTarget.JVM_17)
         }
         dependsOn(generateCode)
@@ -83,7 +78,7 @@ fun createGenerateCodeTask(name: String, apiFilePath: String, additionalArgs: Li
         "--targets", "http_models",
         "--targets", "client",
         "--http-client-target", "ktor",
-        "--serialization-library", "kotlinx_serialization",
+        "--serialization-library", "jackson",
         "--validation-library", "no_validation"
     ).plus(additionalArgs)
     dependsOn(":jar")

--- a/end2end-tests/ktor-client-jackson/src/test/kotlin/com/cjbooms/fabrikt/clients/KtorClientJacksonTest.kt
+++ b/end2end-tests/ktor-client-jackson/src/test/kotlin/com/cjbooms/fabrikt/clients/KtorClientJacksonTest.kt
@@ -2,24 +2,29 @@ package com.cjbooms.fabrikt.clients
 
 import com.example.client.CatalogsItemsClient
 import com.example.client.CatalogsSearchClient
+import com.example.client.ItemsClient
+import com.example.client.NetworkError
+import com.example.client.NetworkResult
+import com.example.client.NoContentClient
 import com.example.models.Item
 import com.example.models.SortOrder
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.marcinziolo.kotlin.wiremock.get
 import com.marcinziolo.kotlin.wiremock.like
 import com.marcinziolo.kotlin.wiremock.post
 import com.marcinziolo.kotlin.wiremock.returns
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.statement.bodyAsText
 import io.ktor.serialization.jackson.jackson
-import io.ktor.server.response.respond
-import io.ktor.server.routing.get
-import io.ktor.server.testing.testApplication
-import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -28,7 +33,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertInstanceOf
 import java.net.ServerSocket
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KtorClientJacksonTest {
@@ -58,7 +62,261 @@ class KtorClientJacksonTest {
     @Nested
     inner class Client {
         @Test
-        fun `client performs post with body`() {
+        fun `post request sends body and returns success`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 201
+                body = """{"id": "id-1", "name": "item-a", "description": "description-a", "price": 123.45}"""
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Success<Item>>(result)
+                assertEquals("item-a", result.data.name)
+            }
+        }
+
+        @Test
+        fun `post request body contains serialized data`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 201
+                body = """{"id": "id-1", "name": "item-a", "description": "description-a", "price": 123.45}"""
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Success<Item>>(result)
+            }
+
+            wiremock.verify(
+                postRequestedFor(urlPathEqualTo("/catalogs/catalog-a/items"))
+                    .withRequestBody(matchingJsonPath("$.id", equalTo("id-1")))
+                    .withRequestBody(matchingJsonPath("$.name", equalTo("item-a")))
+                    .withRequestBody(matchingJsonPath("$.description", equalTo("description-a")))
+                    .withRequestBody(matchingJsonPath("$.price", equalTo("123.45")))
+            )
+        }
+
+        @Test
+        fun `get request sends path query and header parameters`() {
+            wiremock.get {
+                urlPath like "/catalogs/catalog-a/search"
+            } returns {
+                statusCode = 200
+                body = "[]"
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = CatalogsSearchClient(createHttpClient())
+
+            runBlocking {
+                val result = client.searchCatalogItems(
+                    catalogId = "catalog-a",
+                    query = "query",
+                    page = 10,
+                    sort = SortOrder.DESC,
+                    xTracingID = "request-id-123"
+                )
+
+                assertInstanceOf<NetworkResult.Success<List<Item>>>(result)
+            }
+
+            wiremock.verify(
+                getRequestedFor(urlPathEqualTo("/catalogs/catalog-a/search"))
+                    .withQueryParam("query", equalTo("query"))
+                    .withQueryParam("page", equalTo("10"))
+                    .withQueryParam("sort", equalTo("desc"))
+                    .withHeader("X-Tracing-ID", equalTo("request-id-123"))
+            )
+        }
+
+        @Test
+        fun `get request sends list query parameters`() {
+            wiremock.get {
+                urlPath like "/catalogs/catalog-a/search"
+            } returns {
+                statusCode = 200
+                body = "[]"
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = CatalogsSearchClient(createHttpClient())
+
+            runBlocking {
+                val result = client.searchCatalogItems(
+                    catalogId = "catalog-a",
+                    query = "query",
+                    listParam = listOf("value1", "value2", "value3")
+                )
+
+                assertInstanceOf<NetworkResult.Success<List<Item>>>(result)
+            }
+
+            wiremock.verify(
+                getRequestedFor(urlPathEqualTo("/catalogs/catalog-a/search"))
+                    .withQueryParam("listParam", equalTo("value1"))
+                    .withQueryParam("listParam", equalTo("value2"))
+                    .withQueryParam("listParam", equalTo("value3"))
+            )
+        }
+
+        @Test
+        fun `get request omits null optional parameters`() {
+            wiremock.get {
+                urlPath like "/items"
+            } returns {
+                statusCode = 200
+                body = "[]"
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = ItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.getItems()
+
+                assertInstanceOf<NetworkResult.Success<List<Item>>>(result)
+            }
+
+            wiremock.verify(
+                getRequestedFor(urlPathEqualTo("/items"))
+                    .withoutQueryParam("category")
+                    .withoutQueryParam("limit")
+                    .withoutQueryParam("priceLimit")
+            )
+        }
+
+        @Test
+        fun `get request includes provided optional parameters`() {
+            wiremock.get {
+                urlPath like "/items"
+            } returns {
+                statusCode = 200
+                body = "[]"
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = ItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.getItems(
+                    category = "electronics",
+                    limit = 50,
+                    priceLimit = 99.99
+                )
+
+                assertInstanceOf<NetworkResult.Success<List<Item>>>(result)
+            }
+
+            wiremock.verify(
+                getRequestedFor(urlPathEqualTo("/items"))
+                    .withQueryParam("category", equalTo("electronics"))
+                    .withQueryParam("limit", equalTo("50"))
+                    .withQueryParam("priceLimit", equalTo("99.99"))
+            )
+        }
+
+        @Test
+        fun `get request returns list response`() {
+            wiremock.get {
+                urlPath like "/items"
+            } returns {
+                statusCode = 200
+                body = """
+                    [
+                        {
+                            "id": "item-1",
+                            "name": "First Item",
+                            "description": "Description 1",
+                            "price": 10.99
+                        },
+                        {
+                            "id": "item-2",
+                            "name": "Second Item",
+                            "description": "Description 2",
+                            "price": 20.99
+                        }
+                    ]
+                """.trimIndent()
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = ItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.getItems()
+
+                assertInstanceOf<NetworkResult.Success<List<Item>>>(result)
+                val items = result.data
+                assertEquals(2, items.size)
+                assertEquals("item-1", items[0].id)
+                assertEquals("First Item", items[0].name)
+                assertEquals("item-2", items[1].id)
+                assertEquals("Second Item", items[1].name)
+            }
+        }
+    }
+
+    @Nested
+    inner class Result {
+        @Test
+        fun `200 returns Success with data`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 200
+                body = """
+                    {
+                        "id": "id-1",
+                        "name": "item-a",
+                        "description": "description-a",
+                        "price": 123.45
+                    }
+                """.trimIndent()
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Success<Item>>(result)
+                assertEquals(
+                    Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    result.data
+                )
+            }
+        }
+
+        @Test
+        fun `201 returns Success`() {
             wiremock.post {
                 urlPath like "/catalogs/catalog-a/items"
             } returns {
@@ -78,31 +336,112 @@ class KtorClientJacksonTest {
 
             runBlocking {
                 val result = client.createItem(
-                    item = Item(
-                        id = "id-1",
-                        name = "item-a",
-                        description = "description-a",
-                        price = 123.45
-                    ),
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
                     catalogId = "catalog-a",
                     randomNumber = 123,
                     xRequestID = "request-id"
                 )
 
-                when (result) {
-                    is CatalogsItemsClient.CreateItemResult.Success -> {
-                        println("Created item with name: ${result.data.name}. Status code: ${result.response.status}")
-                    }
-
-                    is CatalogsItemsClient.CreateItemResult.Failure -> {
-                        fail("Failed to create item.\nStatus code: ${result.response.status}\nBody: ${result.response.bodyAsText()}")
-                    }
-                }
+                assertInstanceOf<NetworkResult.Success<Item>>(result)
             }
         }
 
         @Test
-        fun `client performs post and gets 404 back`() {
+        fun `204 returns Success with Unit`() {
+            wiremock.get {
+                urlPath like "/no-content"
+            } returns {
+                statusCode = 204
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = NoContentClient(createHttpClient())
+
+            runBlocking {
+                val result = client.getNoContent()
+
+                assertInstanceOf<NetworkResult.Success<Unit>>(result)
+            }
+        }
+
+        @Test
+        fun `302 returns Failure with Http error`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 302
+                header = "Content-Type" to "application/json"
+                header = "Location" to "http://example.com/other-resource"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(302, result.error.statusCode)
+            }
+        }
+
+        @Test
+        fun `401 returns Failure with Http error`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 401
+                body = "Unauthorized"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(401, result.error.statusCode)
+            }
+        }
+
+        @Test
+        fun `403 returns Failure with Http error`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 403
+                body = "Forbidden"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(403, result.error.statusCode)
+            }
+        }
+
+        @Test
+        fun `404 returns Failure with Http error`() {
             wiremock.post {
                 urlPath like "/catalogs/catalog-a/items"
             } returns {
@@ -114,88 +453,227 @@ class KtorClientJacksonTest {
 
             runBlocking {
                 val result = client.createItem(
-                    item = Item(
-                        id = "id-1",
-                        name = "item-a",
-                        description = "description-a",
-                        price = 123.45
-                    ),
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
                     catalogId = "catalog-a",
                     randomNumber = 123,
                     xRequestID = "request-id"
                 )
 
-                when (result) {
-                    is CatalogsItemsClient.CreateItemResult.Success -> {
-                        fail("Expected 404 but got success")
-                    }
-
-                    is CatalogsItemsClient.CreateItemResult.Failure -> {
-                        println("Failed to create item. Status code: ${result.response.status}")
-                    }
-                }
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(404, result.error.statusCode)
             }
         }
 
         @Test
-        fun `request can be performed using generated client`() = runBlocking {
-            val capturedCatalogId = slot<String?>()
-            val capturedQuery = slot<String?>()
-            val capturedPage = slot<String?>()
-            val capturedSort = slot<String?>()
-            val capturedXTracingID = slot<String?>()
+        fun `500 returns Failure with Http error`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 500
+                body = "Internal Server Error"
+            }
 
-            testApplication {
-                routing {
-                    get("/catalogs/{catalogId}/search") {
-                        val catalogId = call.parameters["catalogId"]
-                        val query = call.request.queryParameters["query"]
-                        val page = call.request.queryParameters["page"]
-                        val sort = call.request.queryParameters["sort"]
-                        val xTracingID = call.request.headers["X-Tracing-ID"]
+            val client = CatalogsItemsClient(createHttpClient())
 
-                        capturedCatalogId.captured = catalogId
-                        capturedQuery.captured = query
-                        capturedPage.captured = page
-                        capturedSort.captured = sort
-                        capturedXTracingID.captured = xTracingID
-
-                        call.response.headers.append("Content-Type", "application/json")
-                        call.respond("""
-                        [
-                            {
-                                "id": "id-1",
-                                "name": "item-a",
-                                "description": "description-a",
-                                "price": 123.45
-                            }
-                        ]
-                    """.trimIndent())
-                    }
-                }
-
-                val httpClient = createClient {
-                    install(ContentNegotiation) {
-                        jackson()
-                    }
-                }
-
-                val client = CatalogsSearchClient(httpClient)
-
-                val response = client.searchCatalogItems(
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
                     catalogId = "catalog-a",
-                    query = "query",
-                    page = 10,
-                    sort = SortOrder.DESC,
-                    xTracingID = "request-id-123"
+                    randomNumber = 123,
+                    xRequestID = "request-id"
                 )
 
-                assertInstanceOf<CatalogsSearchClient.SearchCatalogItemsResult.Success>(response)
-                assertEquals("catalog-a", capturedCatalogId.captured)
-                assertEquals("query", capturedQuery.captured)
-                assertEquals("10", capturedPage.captured)
-                assertEquals("desc", capturedSort.captured)
-                assertEquals("request-id-123", capturedXTracingID.captured)
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(500, result.error.statusCode)
+            }
+        }
+
+        @Test
+        fun `503 returns Failure with Http error`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 503
+                body = "Service Unavailable"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(503, result.error.statusCode)
+            }
+        }
+
+        @Test
+        fun `HTTP error response body is captured`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 400
+                body = """{"error": "validation_failed", "details": "name is required"}"""
+                header = "Content-Type" to "application/json"
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(400, result.error.statusCode)
+                assertEquals("Bad Request", result.error.statusDescription)
+                assertEquals("""{"error": "validation_failed", "details": "name is required"}""", result.error.body)
+            }
+        }
+
+        @Test
+        fun `HTTP error with empty body has null body and status description`() {
+            wiremock.post {
+                urlPath like "/catalogs/catalog-a/items"
+            } returns {
+                statusCode = 404
+                body = ""
+            }
+
+            val client = CatalogsItemsClient(createHttpClient())
+
+            runBlocking {
+                val result = client.createItem(
+                    item = Item(id = "id-1", name = "item-a", description = "description-a", price = 123.45),
+                    catalogId = "catalog-a",
+                    randomNumber = 123,
+                    xRequestID = "request-id"
+                )
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Http>(result.error)
+                assertEquals(404, result.error.statusCode)
+                assertEquals("Not Found", result.error.statusDescription)
+                kotlin.test.assertNull(result.error.body)
+            }
+        }
+    }
+
+    @Nested
+    inner class Error {
+        @Test
+        fun `wrong content type returns Serialization error`() {
+            wiremock.get {
+                urlPath like "/catalogs/catalog-a/search"
+            } returns {
+                statusCode = 200
+                body = "[]"
+                header = "Content-Type" to "text/plain"
+            }
+
+            runBlocking {
+                val result = CatalogsSearchClient(createHttpClient())
+                    .searchCatalogItems(catalogId = "catalog-a", query = "query")
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Serialization>(result.error)
+                kotlin.test.assertNotNull(result.error.cause)
+            }
+        }
+
+        @Test
+        fun `empty response body returns Serialization error`() {
+            wiremock.get {
+                urlPath like "/catalogs/catalog-a/search"
+            } returns {
+                statusCode = 200
+                body = ""
+                header = "Content-Type" to "application/json"
+            }
+
+            runBlocking {
+                val result = CatalogsSearchClient(createHttpClient())
+                    .searchCatalogItems(catalogId = "catalog-a", query = "query")
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Serialization>(result.error)
+            }
+        }
+
+        @Test
+        fun `invalid response body returns Serialization error`() {
+            wiremock.get {
+                urlPath like "/catalogs/catalog-a/search"
+            } returns {
+                statusCode = 200
+                body = "{}"
+                header = "Content-Type" to "application/json"
+            }
+
+            runBlocking {
+                val result = CatalogsSearchClient(createHttpClient())
+                    .searchCatalogItems(catalogId = "catalog-a", query = "query")
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Serialization>(result.error)
+            }
+        }
+
+        @Test
+        fun `connection refused returns Network error`() {
+            val unreachableClient = HttpClient(CIO) {
+                install(ContentNegotiation) {
+                    jackson()
+                }
+                defaultRequest {
+                    url("http://localhost:1")
+                }
+            }
+
+            val client = CatalogsSearchClient(unreachableClient)
+
+            runBlocking {
+                val result = client.searchCatalogItems(catalogId = "catalog-a", query = "query")
+
+                assertInstanceOf<NetworkResult.Failure>(result)
+                assertInstanceOf<NetworkError.Network>(result.error)
+            }
+        }
+
+        @Test
+        fun `cancellation exception is rethrown`() {
+            wiremock.stubFor(
+                com.github.tomakehurst.wiremock.client.WireMock.get(
+                    com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo("/catalogs/catalog-a/search")
+                ).willReturn(
+                    com.github.tomakehurst.wiremock.client.WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[]")
+                        .withFixedDelay(5000)
+                )
+            )
+
+            val client = CatalogsSearchClient(createHttpClient())
+
+            org.junit.jupiter.api.assertThrows<kotlinx.coroutines.CancellationException> {
+                runBlocking {
+                    kotlinx.coroutines.withTimeout(100) {
+                        client.searchCatalogItems(catalogId = "catalog-a", query = "query")
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/HandlebarsTemplates.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/HandlebarsTemplates.kt
@@ -26,6 +26,7 @@ object HandlebarsTemplates {
     val clientOAuth = handlebars.compile("/templates/client-code/oauth.kt")!!
     val clientHttpUtils = handlebars.compile("/templates/client-code/http-util.kt")!!
     val clientHttpResilience4jUtils = handlebars.compile("/templates/client-code/http-resilience4j-util.kt")!!
+    val ktorClientApiModels = handlebars.compile("/templates/client-code/ktor-api-models.kt")!!
 
     fun applyTemplate(
         template: Template,

--- a/src/main/resources/templates/client-code/ktor-api-models.kt.hbs
+++ b/src/main/resources/templates/client-code/ktor-api-models.kt.hbs
@@ -1,0 +1,56 @@
+package {{ client }}
+
+import java.io.IOException
+
+/**
+ * Sealed interface representing all possible network errors that can occur during API calls.
+ */
+sealed interface NetworkError {
+    /**
+     * HTTP error response (4xx, 5xx status codes).
+     * @property statusCode The HTTP status code
+     * @property statusDescription The standard HTTP status description (e.g., "Not Found" for 404)
+     * @property body The response body content, if any
+     */
+    data class Http(
+        val statusCode: Int,
+        val statusDescription: String,
+        val body: String? = null,
+    ) : NetworkError
+
+    /**
+     * Network connectivity error (connection timeout, DNS failure, etc.).
+     * @property cause The underlying IOException, if available
+     */
+    data class Network(val cause: IOException? = null) : NetworkError
+
+    /**
+     * Serialization/deserialization error when parsing the response.
+     * @property cause The underlying exception
+     */
+    data class Serialization(val cause: Exception) : NetworkError
+
+    /**
+     * Unknown error that doesn't fit other categories.
+     * @property cause The underlying exception, if available
+     */
+    data class Unknown(val cause: Throwable? = null) : NetworkError
+}
+
+/**
+ * Sealed interface representing the result of a network operation.
+ * @param T The type of data returned on success
+ */
+sealed interface NetworkResult<out T> {
+    /**
+     * Successful response with data.
+     * @property data The deserialized response data
+     */
+    data class Success<out T>(val data: T) : NetworkResult<T>
+
+    /**
+     * Failure response.
+     * @property error The network error that occurred
+     */
+    data class Failure(val error: NetworkError) : NetworkResult<Nothing>
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
@@ -10,6 +10,7 @@ import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.TestFileUtils.toSingleFile
 import com.cjbooms.fabrikt.util.GeneratedCodeAsserter.Companion.assertThatGenerated
 import com.cjbooms.fabrikt.util.ModelNameRegistry
+import com.cjbooms.fabrikt.model.SimpleFile
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
@@ -39,7 +40,7 @@ class KtorClientGeneratorTest {
 
     @ParameterizedTest
     @MethodSource("fullApiTestCases")
-    fun `correct Ktor routing resources are generated`(testCaseName: String) {
+    fun `correct Ktor client code is generated`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
@@ -55,5 +56,25 @@ class KtorClientGeneratorTest {
             .toSingleFile()
 
         assertThatGenerated(clientCode).isEqualTo(expectedClient)
+    }
+
+    @ParameterizedTest
+    @MethodSource("fullApiTestCases")
+    fun `correct Ktor API models are generated`(testCaseName: String) {
+        val packages = Packages("examples.$testCaseName")
+        val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+
+        val expectedApiModels = "/examples/$testCaseName/client/ktor/KtorApiModels.kt"
+
+        val apiModels = KtorClientGenerator(
+            packages,
+            sourceApi
+        )
+            .generateLibrary(emptySet())
+            .filterIsInstance<SimpleFile>()
+            .first { it.path.fileName.toString() == "KtorApiModels.kt" }
+
+        assertThatGenerated(apiModels.content).isEqualTo(expectedApiModels)
     }
 }

--- a/src/test/resources/examples/ktorClient/client/ktor/KtorApiModels.kt
+++ b/src/test/resources/examples/ktorClient/client/ktor/KtorApiModels.kt
@@ -1,0 +1,56 @@
+package examples.ktorClient.client
+
+import java.io.IOException
+
+/**
+ * Sealed interface representing all possible network errors that can occur during API calls.
+ */
+sealed interface NetworkError {
+    /**
+     * HTTP error response (4xx, 5xx status codes).
+     * @property statusCode The HTTP status code
+     * @property statusDescription The standard HTTP status description (e.g., "Not Found" for 404)
+     * @property body The response body content, if any
+     */
+    data class Http(
+        val statusCode: Int,
+        val statusDescription: String,
+        val body: String? = null,
+    ) : NetworkError
+
+    /**
+     * Network connectivity error (connection timeout, DNS failure, etc.).
+     * @property cause The underlying IOException, if available
+     */
+    data class Network(val cause: IOException? = null) : NetworkError
+
+    /**
+     * Serialization/deserialization error when parsing the response.
+     * @property cause The underlying exception
+     */
+    data class Serialization(val cause: Exception) : NetworkError
+
+    /**
+     * Unknown error that doesn't fit other categories.
+     * @property cause The underlying exception, if available
+     */
+    data class Unknown(val cause: Throwable? = null) : NetworkError
+}
+
+/**
+ * Sealed interface representing the result of a network operation.
+ * @param T The type of data returned on success
+ */
+sealed interface NetworkResult<out T> {
+    /**
+     * Successful response with data.
+     * @property data The deserialized response data
+     */
+    data class Success<out T>(val data: T) : NetworkResult<T>
+
+    /**
+     * Failure response.
+     * @property error The network error that occurred
+     */
+    data class Failure(val error: NetworkError) : NetworkResult<Nothing>
+}

--- a/src/test/resources/examples/parameterNameClash/client/ktor/KtorApiModels.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ktor/KtorApiModels.kt
@@ -1,0 +1,56 @@
+package examples.parameterNameClash.client
+
+import java.io.IOException
+
+/**
+ * Sealed interface representing all possible network errors that can occur during API calls.
+ */
+sealed interface NetworkError {
+    /**
+     * HTTP error response (4xx, 5xx status codes).
+     * @property statusCode The HTTP status code
+     * @property statusDescription The standard HTTP status description (e.g., "Not Found" for 404)
+     * @property body The response body content, if any
+     */
+    data class Http(
+        val statusCode: Int,
+        val statusDescription: String,
+        val body: String? = null,
+    ) : NetworkError
+
+    /**
+     * Network connectivity error (connection timeout, DNS failure, etc.).
+     * @property cause The underlying IOException, if available
+     */
+    data class Network(val cause: IOException? = null) : NetworkError
+
+    /**
+     * Serialization/deserialization error when parsing the response.
+     * @property cause The underlying exception
+     */
+    data class Serialization(val cause: Exception) : NetworkError
+
+    /**
+     * Unknown error that doesn't fit other categories.
+     * @property cause The underlying exception, if available
+     */
+    data class Unknown(val cause: Throwable? = null) : NetworkError
+}
+
+/**
+ * Sealed interface representing the result of a network operation.
+ * @param T The type of data returned on success
+ */
+sealed interface NetworkResult<out T> {
+    /**
+     * Successful response with data.
+     * @property data The deserialized response data
+     */
+    data class Success<out T>(val data: T) : NetworkResult<T>
+
+    /**
+     * Failure response.
+     * @property error The network error that occurred
+     */
+    data class Failure(val error: NetworkError) : NetworkResult<Nothing>
+}


### PR DESCRIPTION
## Summary

Adds `NetworkResult<T>` and `NetworkError` sealed types to the Ktor client generator, providing a type-safe way to handle API responses without exceptions.

## Motivation

The previous Ktor client implementation required try-catch blocks around every API call. This change wraps responses in a sealed `NetworkResult` type, enabling exhaustive `when` expressions and making error handling explicit in the type system.

## Usage

```kotlin
val result = client.getItems()

when (result) {
    is NetworkResult.Success -> println("Got items: ${result.data}")
    is NetworkResult.Failure -> when (result.error) {
        is NetworkError.Http -> println("HTTP ${result.error.statusCode} ${result.error.statusDescription}: ${result.error.body}")
        is NetworkError.Network -> println("Connection failed: ${result.error.cause}")
        is NetworkError.Serialization -> println("Parse error: ${result.error.cause}")
        is NetworkError.Unknown -> println("Unexpected: ${result.error.cause}")
    }
}
```

## Error Mapping

| Scenario | NetworkError |
| --- | --- |
| Non-2xx HTTP response | `Http(statusCode, statusDescription, body)` |
| Connection failure, timeout | `Network(cause: IOException?)` |
| JSON parse error, empty body | `Serialization(cause: Exception)` |
| Wrong content type | `Serialization(cause: Exception)` |
| Any other exception | `Unknown(cause: Throwable?)` |

Note: `CancellationException` is rethrown to preserve coroutine cancellation semantics.

## Generated Types

```kotlin
sealed interface NetworkResult<out T> {
    data class Success<out T>(val data: T) : NetworkResult<T>
    data class Failure(val error: NetworkError) : NetworkResult<Nothing>
}

sealed interface NetworkError {
    data class Http(val statusCode: Int, val statusDescription: String, val body: String?) : NetworkError
    data class Network(val cause: IOException? = null) : NetworkError
    data class Serialization(val cause: Exception) : NetworkError
    data class Unknown(val cause: Throwable? = null) : NetworkError
}
```

## Testing

E2E test cases are duplicated across `ktor-client-jackson` and `ktor-client-kotlinx` modules to verify behavior with both serialization libraries.

## Breaking Changes

- Result types changed from per-method (e.g., `CreateItemResult`) to shared `NetworkResult<T>`
- Raw `response` access removed - use `NetworkError.Http` properties instead
- `httpClient` property is now private in generated client classes
