### PR TITLE
Fix Ktor client operationId with special characters (#498)

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
@@ -6,6 +6,7 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.splitByType
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
 import com.cjbooms.fabrikt.generators.client.ClientGenerator
+import com.cjbooms.fabrikt.util.NormalisedString.camelCase
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.happyPathResponse
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Clients
@@ -274,7 +275,7 @@ class KtorClientGenerator(
 
     private fun clientRequestFunctionName(op: Operation, verb: String, params: List<RequestParameter>) =
         if (op.operationId != null) {
-            op.operationId.replaceFirstChar { it.lowercase() }
+            op.operationId.camelCase()
         } else {
             buildString {
                 append(verb.lowercase())

--- a/src/test/resources/examples/ktorClient/client/ktor/KtorClient.kt
+++ b/src/test/resources/examples/ktorClient/client/ktor/KtorClient.kt
@@ -417,7 +417,7 @@ public class UptimeClient(
      * 	[NetworkResult.Success] with [kotlin.String] if the request was successful.
      * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
      */
-    public suspend fun `get_System-Uptime`(): NetworkResult<String> {
+    public suspend fun getSystemUptime(): NetworkResult<String> {
         val url = """/uptime"""
 
         return try {


### PR DESCRIPTION
## Summary
- Sanitize operationId in KtorClientGenerator using `camelCase()` to handle special characters like dots that are invalid in Kotlin function names
- Add regression test for operationId with dots
- Update expected test output for existing test case

Fixes #498