### PR TITLE
Handle outer required section with allOf declaration.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -159,11 +159,14 @@ object KaizenParserExtensions {
         prop: Map.Entry<String, Schema>,
         markReadWriteOnlyOptional: Boolean,
         markAllOptional: Boolean,
+        additionalRequiredFields: Collection<String> = emptySet()
     ): Boolean =
         if (markAllOptional || (prop.value.isReadOnly && markReadWriteOnlyOptional) || (prop.value.isWriteOnly && markReadWriteOnlyOptional)) {
             false
         } else {
-            requiredFields.contains(prop.key) || isDiscriminatorProperty(api, prop) // A discriminator property should be required
+            requiredFields.contains(prop.key) || 
+                additionalRequiredFields.contains(prop.key) ||
+                isDiscriminatorProperty(api, prop) // A discriminator property should be required
         }
 
     fun Schema.getSchemaRefName() = Overlay.of(this).jsonReference.split("/").last()

--- a/src/test/resources/examples/anyOfOneOfAllOf/api.yaml
+++ b/src/test/resources/examples/anyOfOneOfAllOf/api.yaml
@@ -34,6 +34,42 @@ components:
           properties:
             top_level_prop:
               type: number
+    
+    # Test case for top-level required with allOf (no duplicate in inline required)
+    TopLevelRequiredWithAllOf:
+      allOf:
+        - type: object
+          properties:
+            inline_prop:
+              type: string
+          required:
+            - inline_prop
+        - type: object
+          properties:
+            top_level_only_prop:
+              type: string
+            optional_prop:
+              type: string
+      required:
+        - top_level_only_prop
+    
+    # Test case for nested objects - required should NOT leak to nested properties
+    OuterWithNestedObject:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Outer name property
+        nested:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Nested name - different property, should NOT be required
+            id:
+              type: string
+      required:
+        - name
 
     ContainsNestedOneOf:
       oneOf:

--- a/src/test/resources/examples/anyOfOneOfAllOf/models/OuterWithNestedObject.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/OuterWithNestedObject.kt
@@ -1,0 +1,20 @@
+package examples.anyOfOneOfAllOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class OuterWithNestedObject(
+  /**
+   * Outer name property
+   */
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  @get:NotNull
+  public val name: String,
+  @param:JsonProperty("nested")
+  @get:JsonProperty("nested")
+  @get:Valid
+  public val nested: OuterWithNestedObjectNested? = null,
+)

--- a/src/test/resources/examples/anyOfOneOfAllOf/models/OuterWithNestedObjectNested.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/OuterWithNestedObjectNested.kt
@@ -1,0 +1,16 @@
+package examples.anyOfOneOfAllOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class OuterWithNestedObjectNested(
+  /**
+   * Nested name - different property, should NOT be required
+   */
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  public val name: String? = null,
+  @param:JsonProperty("id")
+  @get:JsonProperty("id")
+  public val id: String? = null,
+)

--- a/src/test/resources/examples/anyOfOneOfAllOf/models/TopLevelRequiredWithAllOf.kt
+++ b/src/test/resources/examples/anyOfOneOfAllOf/models/TopLevelRequiredWithAllOf.kt
@@ -1,0 +1,19 @@
+package examples.anyOfOneOfAllOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class TopLevelRequiredWithAllOf(
+  @param:JsonProperty("inline_prop")
+  @get:JsonProperty("inline_prop")
+  @get:NotNull
+  public val inlineProp: String,
+  @param:JsonProperty("top_level_only_prop")
+  @get:JsonProperty("top_level_only_prop")
+  @get:NotNull
+  public val topLevelOnlyProp: String,
+  @param:JsonProperty("optional_prop")
+  @get:JsonProperty("optional_prop")
+  public val optionalProp: String? = null,
+)


### PR DESCRIPTION
Fixes properties being incorrectly marked as nullable when `required` array is placed at the same level as `allOf` (valid OpenAPI 3 syntax).

Handle outer required section with allOf declaration
- Add additionalRequiredFields parameter that flows through allOf contexts only
- Prevents required fields leaking to nested objects with same property names
- Fixes top-level required with allOf for both named and inline schemas
- Fixes issue https://github.com/fabrikt-io/fabrikt/issues/494 (inline schemas with allOf + required)

### Example
```yaml
Schema:
  allOf:
    - properties: {prop1: ...}
       required: [prop1]
  required: [prop2]  # Now honored!
```  
 
 Both prop1 and prop2 are now correctly marked as @NotNull. 

Related to #128 and #494