### PR TITLE
Install OpenJDK 17 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 # Build stage
 FROM gradle:8-jdk21 AS builder
 
+# Install OpenJDK 17 for Gradle toolchain detection
+USER root
+RUN apt-get update \
+  && apt-get install -y openjdk-17-jdk ca-certificates --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH=$JAVA_HOME/bin:$PATH
+
 WORKDIR /build
 
 # Copy gradle configuration files


### PR DESCRIPTION
Added installation of OpenJDK 17 for Gradle toolchain detection.