### PR TITLE
Guard against similar schema interfaces being added.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -185,7 +185,11 @@ object KaizenParserExtensions {
         return allSchemas
             .filter { it.oneOfSchemas.isNotEmpty() }
             .mapNotNull { schema ->
-                if (schema.oneOfSchemas.toList().contains(this)) schema else null
+                if (schema.oneOfSchemas.toList().contains(this) &&
+                    schema.oneOfSchemas.map { it.safeName() }.contains(this.safeName()) // Guard against identical inlined schemas
+                )
+                    schema
+                else null
             }
             .toSet()
     }


### PR DESCRIPTION
At Zalando, an engineer has come to me with a data class implementing too many sealed interfaces:
```
public data class LikedOutfitInput(
  /**
   * Specifies the type of the item input
   */
  @param:JsonProperty("item_type")
  @get:JsonProperty("item_type")
  @get:NotNull
  public val itemType: GenericItemInputType,
  /**
   * Id of the outfit liked by the customer.
   */
  @param:JsonProperty("outfit_id")
  @get:JsonProperty("outfit_id")
  @get:NotNull
  public val outfitId: String,
) : Item, ItemInput, SavedItemInput
```
Where `ItemInput` should have been the only oneOf interface detected. It turns out the equality check in `.contains` was returning false positives when the structure of the schema was identical with others. This additional `.safeName()` check fixes that