### PR TITLE
Modify header function to handle generic values

### DIFF
--- a/src/main/resources/templates/client-code/http-util.kt.hbs
+++ b/src/main/resources/templates/client-code/http-util.kt.hbs
@@ -29,7 +29,7 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: T?): Headers.Builder = this.apply {
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
     if (value != null) this.add(key, value.toString())
 }
 

--- a/src/test/resources/examples/byteArrayStream/client/HttpUtil.kt
+++ b/src/test/resources/examples/byteArrayStream/client/HttpUtil.kt
@@ -29,8 +29,8 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
-    if (value != null) this.add(key, value)
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/externalReferences/aggressive/client/HttpUtil.kt
+++ b/src/test/resources/examples/externalReferences/aggressive/client/HttpUtil.kt
@@ -29,8 +29,8 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
-    if (value != null) this.add(key, value)
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/multiMediaType/client/HttpUtil.kt
+++ b/src/test/resources/examples/multiMediaType/client/HttpUtil.kt
@@ -29,8 +29,8 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
-    if (value != null) this.add(key, value)
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
@@ -29,8 +29,8 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
-    if (value != null) this.add(key, value)
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
@@ -29,8 +29,8 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
-    if (value != null) this.add(key, value)
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
+++ b/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
@@ -29,8 +29,8 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
-    if (value != null) this.add(key, value)
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
@@ -29,8 +29,8 @@ fun HttpUrl.Builder.queryParam(key: String, values: List<Any>?, explode: Boolean
 }
 
 @Suppress("unused")
-fun Headers.Builder.header(key: String, value: String?): Headers.Builder = this.apply {
-    if (value != null) this.add(key, value)
+fun Headers.Builder.header(key: String, value: Any?): Headers.Builder = this.apply {
+    if (value != null) this.add(key, value.toString())
 }
 
 @Throws(ApiException::class)


### PR DESCRIPTION
There is currently an issue with OkHttp client generation, when dealing with header parameters that are defined as a schema other than 'string.' Namely, there is no conversion in the code from the generated type of the parameter to String, which results in a compilation error in the generated code.

This PR addresses that issue by using the same pattern used in other methods in this file to accept any type of parameter and attempt to convert it into a String before adding it as a header.