### PR TITLE
Adds support for generating fault tolerant enums.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                                |   `INCLUDE_COMPANION_OBJECT` - This option adds a companion object to the generated models. |
 |                                |   `SEALED_INTERFACES_FOR_ONE_OF` - This option enables the generation of interfaces for discriminated oneOf types |
 |                                |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
+|                                |   `FAULT_TOLERANT_ENUMS` - This option adds an UNRECOGNIZED enum entry as a fallback for unmapped values, preventing deserialization exceptions |
 |   `--http-model-suffix`        | Specify custom suffix for all generated model classes. Defaults to no suffix. |
 |   `--instant-library`          | Specify which Instant library to use in generated model classes for kotlinx.serialization. Default: KOTLINX_INSTANT |
 |                                | CHOOSE ONE OF: |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -63,6 +63,7 @@ enum class ModelCodeGenOptionType(val description: String) {
     INCLUDE_COMPANION_OBJECT("This option adds a companion object to the generated models."),
     SEALED_INTERFACES_FOR_ONE_OF("This option enables the generation of interfaces for discriminated oneOf types"),
     NON_NULL_MAP_VALUES("This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable"),
+    FAULT_TOLERANT_ENUMS("This option adds an UNRECOGNIZED enum entry as a fallback for unmapped values, preventing deserialization exceptions"),
     ;
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -48,6 +48,7 @@ class ModelGeneratorTest {
         "enumExamples",
         "enumPolymorphicDiscriminator",
         "externalReferences/targeted",
+        "faultTolerantEnums",
         "githubApi",
         "inLinedObject",
         "mapExamples",
@@ -82,7 +83,7 @@ class ModelGeneratorTest {
     }
 
     @Test
-    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("discriminatedOneOf")
+    fun `debug single test`() = `correct models are generated for different OpenApi Specifications`("enumExamples")
 
     @ParameterizedTest
     @MethodSource("testCases")
@@ -101,6 +102,9 @@ class ModelGeneratorTest {
         }
         if (testCaseName == "byteArrayStream") {
             MutableSettings.addOption(CodeGenTypeOverride.BYTEARRAY_AS_INPUTSTREAM)
+        }
+        if (testCaseName == "faultTolerantEnums") {
+            MutableSettings.addOption(ModelCodeGenOptionType.FAULT_TOLERANT_ENUMS)
         }
         if (testCaseName == "defaultValues") {
             MutableSettings.addOption(JacksonNullabilityMode.ENFORCE_OPTIONAL_NON_NULL)

--- a/src/test/resources/examples/faultTolerantEnums/api.yaml
+++ b/src/test/resources/examples/faultTolerantEnums/api.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+paths:
+info:
+  title: Fault-Tolerant Enums Test
+  version: 1.0.0
+components:
+  schemas:
+    SimpleEnum:
+      type: string
+      enum:
+        - value_one
+        - value_two
+
+    ExtensibleEnum:
+      type: string
+      x-extensible-enum:
+        - extensible_one
+        - extensible_two
+
+    EnumContainer:
+      type: object
+      properties:
+        simple_enum:
+          $ref: '#/components/schemas/SimpleEnum'
+        extensible_enum:
+          $ref: '#/components/schemas/ExtensibleEnum'
+        inlined_enum:
+          type: string
+          enum:
+            - inlined_a
+            - inlined_b
+

--- a/src/test/resources/examples/faultTolerantEnums/models/EnumContainer.kt
+++ b/src/test/resources/examples/faultTolerantEnums/models/EnumContainer.kt
@@ -1,0 +1,15 @@
+package examples.faultTolerantEnums.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+
+public data class EnumContainer(
+  @param:JsonProperty("simple_enum")
+  @get:JsonProperty("simple_enum")
+  public val simpleEnum: SimpleEnum? = null,
+  @param:JsonProperty("extensible_enum")
+  @get:JsonProperty("extensible_enum")
+  public val extensibleEnum: ExtensibleEnum? = null,
+  @param:JsonProperty("inlined_enum")
+  @get:JsonProperty("inlined_enum")
+  public val inlinedEnum: EnumContainerInlinedEnum? = null,
+)

--- a/src/test/resources/examples/faultTolerantEnums/models/EnumContainerInlinedEnum.kt
+++ b/src/test/resources/examples/faultTolerantEnums/models/EnumContainerInlinedEnum.kt
@@ -1,0 +1,24 @@
+package examples.faultTolerantEnums.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class EnumContainerInlinedEnum(
+  @JsonValue
+  public val `value`: String,
+) {
+  INLINED_A("inlined_a"),
+  INLINED_B("inlined_b"),
+  UNRECOGNIZED("UNRECOGNIZED"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, EnumContainerInlinedEnum> =
+        entries.associateBy(EnumContainerInlinedEnum::value)
+
+    public fun fromValue(`value`: String): EnumContainerInlinedEnum = mapping[value] ?: UNRECOGNIZED
+  }
+}

--- a/src/test/resources/examples/faultTolerantEnums/models/ExtensibleEnum.kt
+++ b/src/test/resources/examples/faultTolerantEnums/models/ExtensibleEnum.kt
@@ -1,0 +1,23 @@
+package examples.faultTolerantEnums.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class ExtensibleEnum(
+  @JsonValue
+  public val `value`: String,
+) {
+  EXTENSIBLE_ONE("extensible_one"),
+  EXTENSIBLE_TWO("extensible_two"),
+  UNRECOGNIZED("UNRECOGNIZED"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, ExtensibleEnum> = entries.associateBy(ExtensibleEnum::value)
+
+    public fun fromValue(`value`: String): ExtensibleEnum = mapping[value] ?: UNRECOGNIZED
+  }
+}

--- a/src/test/resources/examples/faultTolerantEnums/models/SimpleEnum.kt
+++ b/src/test/resources/examples/faultTolerantEnums/models/SimpleEnum.kt
@@ -1,0 +1,23 @@
+package examples.faultTolerantEnums.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class SimpleEnum(
+  @JsonValue
+  public val `value`: String,
+) {
+  VALUE_ONE("value_one"),
+  VALUE_TWO("value_two"),
+  UNRECOGNIZED("UNRECOGNIZED"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, SimpleEnum> = entries.associateBy(SimpleEnum::value)
+
+    public fun fromValue(`value`: String): SimpleEnum = mapping[value] ?: UNRECOGNIZED
+  }
+}


### PR DESCRIPTION
Adds `--http-model-opts FAULT_TOLERANT_ENUMS` to generate enums with an `UNRECOGNIZED` fallback, preventing crashes when servers add new enum values.

Fixes #256

## Changes
- Generates `UNRECOGNIZED` enum constant following Protocol Buffers standard
- `fromValue()` returns non-nullable with fallback: `mapping[value] ?: UNRECOGNIZED`

## Example
```kotlin
enum class Status {
  ACTIVE("active"),
  INACTIVE("inactive"),
  UNRECOGNIZED("UNRECOGNIZED")  // ← Added

  companion object {
    fun fromValue(value: String): Status = mapping[value] ?: UNRECOGNIZED  // Non-nullable
  }
}
```