### PR TITLE
Take ownership of kaizen openapi-parser.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-annotations")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.beust:jcommander:1.82")
-    implementation("com.reprezen.kaizen:openapi-parser:4.0.4") { exclude(group = "junit") }
+    implementation("io.fabrikt:kaizen-openapi-parser:4.1.0") { exclude(group = "junit") }
     implementation("com.reprezen.jsonoverlay:jsonoverlay:4.0.4")
     implementation("com.squareup:kotlinpoet:1.14.2") { exclude(module = "kotlin-stdlib-jre7") }
     implementation("com.google.flogger:flogger:0.7.4")


### PR DESCRIPTION
Migrate fabrikt to make use of the newly published version of kaizen-openapi-parser now released from the fabrikt-io org. This will allow us to adjust the formerly unmaintained parser as we need to handle the evolution of the OpenApi specification.

Related to #513 and #514