### PR TITLE
Docker multi architecture publishing

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -19,6 +19,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build executable JAR
+        run: ./gradlew clean shadowJar -x jar --no-daemon
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -41,6 +59,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile.release
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
 FROM gradle:8-jdk21 AS builder
+ARG TARGETARCH
 
 # Install OpenJDK 17 for Gradle toolchain detection
 USER root
@@ -7,7 +8,7 @@ RUN apt-get update \
   && apt-get install -y openjdk-17-jdk ca-certificates --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}
 ENV PATH=$JAVA_HOME/bin:$PATH
 
 WORKDIR /build

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:21-jre-alpine
+
+# Package the JAR built by the workflow's Gradle step.
+COPY build/libs/fabrikt-*.jar /app/fabrikt.jar
+
+WORKDIR /workspace
+
+ENTRYPOINT ["java", "-jar", "/app/fabrikt.jar"]
+CMD ["--help"]


### PR DESCRIPTION
Publish builds for both linux/amd64 and linux/arm64 to ensure support for e.g. Apple Silicon Macs.