### PR TITLE
fix(generators): deduplicate @SerialName for multi-parent oneOf in kotlinx

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -578,13 +578,11 @@ class ModelGenerator(
         for (oneOfInterface in oneOfInterfaces) {
             classBuilder
                 .addSuperinterface(generatedType(packages.base, ModelNameRegistry.getOrRegister(oneOfInterface)))
-
-            // determine the mapping key for this schema as a subtype of the oneOf interface
-            val mappingKey = oneOfInterface.discriminator.mappingKeyForSchemaName(schemaName)
-            if (mappingKey != null) {
-                serializationAnnotations.addSubtypeMappingAnnotation(classBuilder, mappingKey)
-            }
         }
+        oneOfInterfaces
+            .mapNotNull { it.discriminator.mappingKeyForSchemaName(schemaName) }
+            .distinct()
+            .forEach { serializationAnnotations.addSubtypeMappingAnnotation(classBuilder, it) }
 
         if (!generateObject) {
             if (oneOfInterfaces.isNotEmpty()) {

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/Obj1.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/Obj1.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @SerialName("obj1")
-@SerialName("obj1")
 @Serializable
 public data class Obj1(
   @SerialName("id1")


### PR DESCRIPTION
## Summary
- Fixes #536: when a model implements multiple `oneOf` sealed interfaces (e.g. `Obj1 : Poly1, Poly2`) with the same discriminator mapping key, `@SerialName` was emitted once per parent interface, producing invalid Kotlinx code
- Collect distinct mapping keys before annotating to ensure each `@SerialName` appears only once
- Separates superinterface registration from mapping annotation for clarity