### PR TITLE
write OkHttp Request.Builder() with proper class name

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -214,7 +214,7 @@ data class SimpleClientOperationStatement(
     }
 
     private fun CodeBlock.Builder.addRequestStatement(): CodeBlock.Builder {
-        this.add("\nval request: %T = Request.Builder()", "Request".toClassName("okhttp3"))
+        this.add("\nval request: %T = %T.Builder()", "Request".toClassName("okhttp3"), "Request".toClassName("okhttp3"))
         this.add("\n.url(httpUrl)\n.headers(httpHeaders)")
         when (val op = verb.toUpperCase()) {
             "PUT" -> this.addRequestSerializerStatement("put")


### PR DESCRIPTION
I have an openapi spec that happens to contain a model called 'Request' that is used as the return type for an endpoint. When generating clients from this spec, I get code that won't compile due to what appears to how the conflict between the two models is handled.

They are imported with aliases like this:
```kotlin
import com.redacted.models.Request as ModelsRequest
import okhttp3.Request as Okhttp3Request
```

and then the request gets constructed like

```
    val request: Okhttp3Request = Request.Builder()
    .url(httpUrl)
    .headers(httpHeaders)
    .get()
    .build()
```

so the `Request` class is invalid... I think I identified the issue and hope this is the fix