### PR TITLE
fix(playground): use soft tabs in Ace editor

### DIFF
--- a/playground/src/main/kotlin/views/elements/SpecForm.kt
+++ b/playground/src/main/kotlin/views/elements/SpecForm.kt
@@ -85,6 +85,8 @@ fun FlowContent.specForm(settings: GenerationSettings) = div {
                 var textarea = document.getElementById("spec");
                 editor.getSession().setValue(textarea.value);
                 editor.getSession().setMode("ace/mode/yaml");
+                editor.getSession().setTabSize(2);
+                editor.getSession().setUseSoftTabs(true);
                 
                 // keep the text area in sync with the editor content
                 editor.getSession().on('change', function(){


### PR DESCRIPTION
## Summary
- Configure Ace editor to use 2-space soft tabs instead of hard tabs, matching standard YAML/OpenAPI formatting conventions