### PR TITLE
feat(playground): replace pill nav with file sidebar

### DIFF
--- a/playground/src/main/kotlin/PlaygroundApplication.kt
+++ b/playground/src/main/kotlin/PlaygroundApplication.kt
@@ -19,10 +19,8 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import kotlinx.html.a
-import kotlinx.html.classes
 import kotlinx.html.div
-import kotlinx.html.h3
-import kotlinx.html.p
+import kotlinx.html.id
 import kotlinx.html.script
 import kotlinx.html.stream.appendHTML
 import kotlinx.html.style
@@ -63,36 +61,32 @@ fun main() {
                 call.respondHtml {
                     mainLayout {
                         columnPanel(
-                            flexSizes = listOf(1.0, 1.0, 0.5),
-                            // first column
+                            flexSizes = listOf(1.0, 0.4, 1.5),
+                            // first column: spec form
                             {
                                 specForm(generationSettings)
                             },
-                            // second column
+                            // second column: file sidebar
+                            {
+                                style = "flex: 0.4; padding: 0; overflow-y: hidden; display: flex; flex-direction: column; border-left: 1px solid #e0e0e0; border-right: 1px solid #e0e0e0;"
+                                div {
+                                    id = "file-sidebar"
+                                    style = "flex: 1; overflow-y: auto; min-height: 0; padding: 10px 0;"
+                                    div(classes = "file-sidebar-empty") {
+                                        +"// Files will appear here"
+                                    }
+                                }
+                                div {
+                                    style = "flex-shrink: 0; padding: 8px 10px; border-top: 1px solid #e0e0e0; font-size: 12px; color: #999;"
+                                    a(href = "https://github.com/fabrikt-io/fabrikt", target = "_blank") {
+                                        +"Fabrikt on GitHub"
+                                    }
+                                    div { +"v${Version.GIT_VERSION}" }
+                                }
+                            },
+                            // third column: code output
                             {
                                 codeView { fileView("// Output will appear here") }
-                            },
-                            // third column
-                            {
-                                classes = classes + "flex flex-column justify-between"
-                                div {
-                                    h3 {
-                                        style = "margin-top: 0;"
-                                        +"Happy with what you see?"
-                                    }
-                                    p {
-                                        +"Embed Fabrikt in your project and start generating code from OpenAPI specs today!"
-                                    }
-                                    p {
-                                        a(href = "https://github.com/cjbooms/fabrikt", target = "_blank") {
-                                            +"Fabrikt on GitHub"
-                                        }
-                                    }
-                                }
-                                div {
-                                    style = "color: #999;"
-                                    +"Fabrikt version: ${Version.GIT_VERSION}"
-                                }
                             }
                         )
                     }
@@ -132,17 +126,27 @@ fun main() {
                         if (generatedFiles.isEmpty()) {
                             fileView("// No files generated. Try adjusting your settings.")
                         } else {
-                            fileList(fileNames)
                             generatedFiles.forEach {
                                 fileViewForFile(it)
                             }
                         }
                         script { unsafe { +"Prism.highlightAll();" } } // trigger syntax highlighting
+                        // OOB swap: update the file sidebar
+                        div {
+                            id = "file-sidebar"
+                            attributes["hx-swap-oob"] = "innerHTML"
+                            if (fileNames.isNotEmpty()) fileList(fileNames)
+                        }
                     }
                 }.onFailure { error ->
                     call.respondHtmlFragmentDiv {
-                            fileView("// Error: ${error.message}")
-                            script { unsafe { +"Prism.highlightAll();" } } // trigger syntax highlighting
+                        fileView("// Error: ${error.message}")
+                        script { unsafe { +"Prism.highlightAll();" } } // trigger syntax highlighting
+                        // OOB swap: clear the file sidebar on error
+                        div {
+                            id = "file-sidebar"
+                            attributes["hx-swap-oob"] = "innerHTML"
+                        }
                     }
                 }
             }

--- a/playground/src/main/kotlin/views/elements/FileList.kt
+++ b/playground/src/main/kotlin/views/elements/FileList.kt
@@ -1,18 +1,30 @@
 import kotlinx.html.FlowContent
 import kotlinx.html.a
+import kotlinx.html.div
 import kotlinx.html.li
 import kotlinx.html.script
-import kotlinx.html.span
 import kotlinx.html.ul
 import kotlinx.html.unsafe
 
+private val LABEL_ORDER = listOf("Model", "Client", "Controller", "Config")
+
+private fun String.toHeading() = when (this) {
+    "Model" -> "Models"
+    "Controller" -> "Controllers"
+    else -> this
+}
+
 fun FlowContent.fileList(files: List<Pair<String, String>>) {
-    ul(classes = "file-nav") {
-        files.forEach { (fileName, label) ->
-            li {
-                a(href = "#$fileName") {
-                    +fileName
-                    span(classes = "file-tag ${label.lowercase()}") { +label }
+    val groups = files.sortedBy { it.first }.groupBy { it.second }
+    LABEL_ORDER.forEach { label ->
+        val groupFiles = groups[label] ?: return@forEach
+        div(classes = "file-nav-group") {
+            div(classes = "file-nav-heading") { +label.toHeading() }
+            ul(classes = "file-nav") {
+                groupFiles.forEach { (fileName, _) ->
+                    li {
+                        a(href = "#$fileName") { +fileName }
+                    }
                 }
             }
         }
@@ -24,11 +36,10 @@ fun FlowContent.fileList(files: List<Pair<String, String>>) {
                     link.addEventListener('click', function(e) {
                         e.preventDefault();
                         var target = document.getElementById(this.getAttribute('href').slice(1));
-                        var nav = document.querySelector('.file-nav');
-                        var panel = nav && nav.closest('.panel');
-                        if (target && nav && panel) {
-                            var delta = target.getBoundingClientRect().top - nav.getBoundingClientRect().bottom;
-                            panel.scrollBy({ top: delta });
+                        var codePanel = document.getElementById('codeview') && document.getElementById('codeview').closest('.panel');
+                        if (target && codePanel) {
+                            var delta = target.getBoundingClientRect().top - codePanel.getBoundingClientRect().top;
+                            codePanel.scrollBy({ top: delta });
                         }
                     });
                 });

--- a/playground/src/main/resources/static/main.css
+++ b/playground/src/main/resources/static/main.css
@@ -30,57 +30,70 @@ a, a:visited, a:hover, a:active {
     color: #3BAFDA;
 }
 
-.panel::-webkit-scrollbar {
+.panel::-webkit-scrollbar,
+#file-sidebar::-webkit-scrollbar {
     width: 5px;
 }
 
-.panel::-webkit-scrollbar-track {
+.panel::-webkit-scrollbar-track,
+#file-sidebar::-webkit-scrollbar-track {
     background: #F1F1F1;
 }
 
-.panel::-webkit-scrollbar-thumb {
+.panel::-webkit-scrollbar-thumb,
+#file-sidebar::-webkit-scrollbar-thumb {
     background: #3BAFDA;
 }
 
-.panel::-webkit-scrollbar-thumb:hover {
+.panel::-webkit-scrollbar-thumb:hover,
+#file-sidebar::-webkit-scrollbar-thumb:hover {
     background: #3BAFDA;
+}
+
+.file-sidebar-empty {
+    padding: 10px;
+    font-family: monospace;
+    font-size: 14px;
+    color: #999;
+}
+
+.file-nav-group {
+    margin-bottom: 4px;
+}
+
+.file-nav-heading {
+    padding: 8px 10px 3px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: #aaa;
 }
 
 .file-nav {
-    position: sticky;
-    top: -10px;
-    z-index: 10;
-    background: rgba(255, 255, 255, 0.75);
-    backdrop-filter: blur(6px);
-    border-bottom: 1px solid #e0e0e0;
     list-style: none;
-    padding: 8px 10px;
-    margin: -10px -10px 0 -10px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
+    padding: 0;
+    margin: 0;
+}
+
+.file-nav li {
+    border-bottom: 1px solid #f5f5f5;
 }
 
 .file-nav a {
-    display: inline-block;
-    padding: 2px 10px;
-    border-radius: 12px;
-    border: 1px solid #3BAFDA;
-    color: #3BAFDA;
+    display: block;
+    padding: 4px 10px;
     text-decoration: none;
-    font-size: 13px;
+    color: #333;
     white-space: nowrap;
-    transition: background 0.15s, color 0.15s;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: background 0.1s, color 0.1s;
 }
 
 .file-nav a:hover {
-    background: #3BAFDA;
-    color: #fff;
-}
-
-.file-nav a:hover .file-tag {
-    background: rgba(255,255,255,0.25);
-    color: #fff;
+    background: #f0f8fd;
+    color: #3BAFDA;
 }
 
 .file-tag {


### PR DESCRIPTION
## Summary

- Replaces the wrapping pill navigation with a vertical file sidebar - the pill layout broke with large specs 💥 
- Three-column layout: form | sidebar | code output
- Files in the sidebar are grouped by type (Models / Client / Controllers / Config) and sorted by name
- Sidebar is updated via HTMX out-of-band swap on generate, keeping it decoupled from the code panel
- Sidebar footer holds the GitHub link (updated to fabrikt-io/fabrikt) and version
- Empty state, scrollbar styling, and font sizes are consistent with the rest of the UI

## Screenshots

<img width="1583" height="978" alt="Skærmbillede 2026-03-03 kl  18 25 24" src="https://github.com/user-attachments/assets/228ce512-a2da-496d-83f6-7133d0a7605f" />