### PR TITLE
feat(playground): add CLI command output to sidebar

### DIFF
--- a/playground/src/main/kotlin/PlaygroundApplication.kt
+++ b/playground/src/main/kotlin/PlaygroundApplication.kt
@@ -27,9 +27,10 @@ import kotlinx.html.style
 import kotlinx.html.unsafe
 import lib.generateCodeSynchronized
 import lib.GenerationSettings.Companion.receiveGenerationSettings
-import views.elements.fileViewForFile
+import views.elements.cliCommandView
 import views.elements.codeView
 import views.elements.fileView
+import views.elements.fileViewForFile
 import views.elements.specForm
 import views.layout.columnPanel
 import views.layout.mainLayout
@@ -59,7 +60,7 @@ fun main() {
                     }
 
                 call.respondHtml {
-                    mainLayout {
+                    mainLayout(Version.GIT_VERSION) {
                         columnPanel(
                             flexSizes = listOf(1.0, 0.4, 1.5),
                             // first column: spec form
@@ -75,6 +76,10 @@ fun main() {
                                     div(classes = "file-sidebar-empty") {
                                         +"// Files will appear here"
                                     }
+                                }
+                                div {
+                                    id = "cli-command"
+                                    style = "flex-shrink: 0; border-top: 1px solid #e0e0e0;"
                                 }
                                 div {
                                     style = "flex-shrink: 0; padding: 8px 10px; border-top: 1px solid #e0e0e0; font-size: 12px; color: #999;"
@@ -136,6 +141,12 @@ fun main() {
                             id = "file-sidebar"
                             attributes["hx-swap-oob"] = "innerHTML"
                             if (fileNames.isNotEmpty()) fileList(fileNames)
+                        }
+                        // OOB swap: update the CLI command
+                        div {
+                            id = "cli-command"
+                            attributes["hx-swap-oob"] = "innerHTML"
+                            cliCommandView(generationSettings.toCliCommand())
                         }
                     }
                 }.onFailure { error ->

--- a/playground/src/main/kotlin/lib/GenerationSettings.kt
+++ b/playground/src/main/kotlin/lib/GenerationSettings.kt
@@ -74,6 +74,29 @@ data class GenerationSettings(
     }
 
     /**
+     * Construct the equivalent fabrikt CLI command for these settings.
+     */
+    fun toCliCommand(): String {
+        fun q(v: String) = "'$v'"
+        val args = mutableListOf<String>()
+        args += "--api-file ${q("api.yaml")}"
+        args += "--base-package ${q("com.example")}"
+        genTypes.forEach { args += "--targets ${q(it.name)}" }
+        if (serializationLibrary != SerializationLibrary.default) args += "--serialization-library ${q(serializationLibrary.name)}"
+        modelOptions.forEach { args += "--http-model-opts ${q(it.name)}" }
+        if (modelSuffix.isNotBlank()) args += "--http-model-suffix ${q(modelSuffix)}"
+        if (controllerTarget != ControllerCodeGenTargetType.default) args += "--http-controller-target ${q(controllerTarget.name)}"
+        controllerOptions.forEach { args += "--http-controller-opts ${q(it.name)}" }
+        if (clientTarget != ClientCodeGenTargetType.default) args += "--http-client-target ${q(clientTarget.name)}"
+        clientOptions.forEach { args += "--http-client-opts ${q(it.name)}" }
+        typeOverrides.forEach { args += "--type-overrides ${q(it.name)}" }
+        if (validationLibrary != ValidationLibrary.default) args += "--validation-library ${q(validationLibrary.name)}"
+        if (externalRefResolutionMode != ExternalReferencesResolutionMode.default) args += "--external-ref-resolution ${q(externalRefResolutionMode.name)}"
+        outputOptions.forEach { args += "--output-opts ${q(it.name)}" }
+        return "java -jar fabrikt.jar \\\n" + args.joinToString(" \\\n") { "  $it" }
+    }
+
+    /**
      * Construct the query parameters string for the settings
      */
     fun toQueryParams(): String {

--- a/playground/src/main/kotlin/views/elements/CliCommandView.kt
+++ b/playground/src/main/kotlin/views/elements/CliCommandView.kt
@@ -1,0 +1,26 @@
+package views.elements
+
+import kotlinx.html.FlowContent
+import kotlinx.html.div
+import kotlinx.html.pre
+import kotlinx.html.span
+
+fun FlowContent.cliCommandView(command: String) {
+    div(classes = "cli-command-section") {
+        div(classes = "cli-command-header") {
+            attributes["onclick"] = "toggleCli(this)"
+            div(classes = "cli-command-title") {
+                span { +"▶" }
+                +" CLI"
+            }
+            div(classes = "cli-copy-btn") {
+                attributes["onclick"] = "event.stopPropagation(); copyCli(this)"
+                +"Copy"
+            }
+        }
+        pre(classes = "cli-command-code") {
+            attributes["style"] = "display: none;"
+            +command
+        }
+    }
+}

--- a/playground/src/main/kotlin/views/layout/Layout.kt
+++ b/playground/src/main/kotlin/views/layout/Layout.kt
@@ -15,7 +15,7 @@ private const val HTMX_VERSION = "2.0.3"
 private const val NORMALIZE_VERSION = "8.0.1"
 private const val BASSCSS = "8.1.0"
 
-fun HTML.mainLayout(content: FlowContent.() -> Unit) = run {
+fun HTML.mainLayout(version: String, content: FlowContent.() -> Unit) = run {
     head {
         title { +"Fabrikt Playground" }
         script { src = "https://cdnjs.cloudflare.com/ajax/libs/prism/$PRISM_VERSION/prism.min.js" }
@@ -49,8 +49,9 @@ fun HTML.mainLayout(content: FlowContent.() -> Unit) = run {
         }
         link {
             rel = "stylesheet"
-            href = "/static/main.css"
+            href = "/static/main.css?v=$version"
         }
+        script { src = "/static/main.js?v=$version" }
         meta ( name = "viewport", content = "width=device-width, initial-scale=1" )
     }
     body {

--- a/playground/src/main/resources/static/main.css
+++ b/playground/src/main/resources/static/main.css
@@ -113,6 +113,53 @@ a, a:visited, a:hover, a:active {
 .file-tag.config     { background: rgba(0,0,0,0.07);      color: #777; }
 
 
+.cli-command-section {
+    padding: 8px 10px;
+}
+
+.cli-command-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: #aaa;
+    margin-bottom: 6px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.cli-command-header:hover {
+    color: #888;
+}
+
+.cli-copy-btn {
+    cursor: pointer;
+    font-size: 10px;
+    font-weight: 600;
+    color: #3BAFDA;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.cli-copy-btn:hover {
+    text-decoration: underline;
+}
+
+.cli-command-code {
+    font-family: monospace;
+    font-size: 11px;
+    color: #444;
+    background: #f7f7f7;
+    border-radius: 4px;
+    padding: 8px;
+    margin: 0;
+    overflow-x: auto;
+    white-space: pre;
+}
+
 .btn-generate {
     background-color: #3399CC;
     color: white;

--- a/playground/src/main/resources/static/main.js
+++ b/playground/src/main/resources/static/main.js
@@ -1,0 +1,20 @@
+function toggleCli(header) {
+    var section = header.closest('.cli-command-section');
+    var code = section.querySelector('.cli-command-code');
+    var arrow = header.querySelector('span');
+    var open = code.style.display !== 'none';
+    code.style.display = open ? 'none' : 'block';
+    arrow.textContent = open ? '▶' : '▼';
+}
+
+function copyCli(btn) {
+    if (!navigator.clipboard) {
+        console.warn('Clipboard API not available — use localhost instead of 0.0.0.0');
+        return;
+    }
+    var code = btn.closest('.cli-command-section').querySelector('.cli-command-code').textContent;
+    navigator.clipboard.writeText(code).then(function() {
+        btn.textContent = 'Copied!';
+        setTimeout(function() { btn.textContent = 'Copy'; }, 1500);
+    });
+}


### PR DESCRIPTION
## Summary

- Adds a collapsible "CLI" section to the file sidebar showing the equivalent `java -jar fabrikt.jar` command for the current playground configuration
- `GenerationSettings.toCliCommand()` maps all settings to their CLI flags, omits default values, and quotes all values
- CLI section updates via HTMX OOB swap alongside the file list on each Generate
- Collapsed by default. Click the `▶ CLI` header to expand/collapse.
- Copy button uses `navigator.clipboard` with a console warning if unavailable
- JS extracted to static `main.js` to ensure functions are always defined
- Static assets (`main.css`, `main.js`) versioned with `?v=GIT_VERSION` for cache-busting