### PR TITLE
chore: use gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,54 +38,45 @@ allprojects {
     }
 }
 
-val jacksonVersion by extra { "2.20.1" }
-val junitVersion by extra { "5.9.2" }
-val ktorVersion by extra { "3.0.1" }
-val kotlinxSerializationVersion by extra { "1.9.0" }
-val kotlinxDateTimeVersion by extra { "0.7.1-0.6.x-compat" }
-
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("com.github.jknack:handlebars:4.3.1")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.core:jackson-core")
-    implementation("com.fasterxml.jackson.core:jackson-annotations")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-    implementation("com.beust:jcommander:1.82")
-    implementation("io.fabrikt:kaizen-openapi-parser:4.1.0") { exclude(group = "junit") }
-    implementation("com.reprezen.jsonoverlay:jsonoverlay:4.0.4")
-    implementation("com.squareup:kotlinpoet:1.14.2") { exclude(module = "kotlin-stdlib-jre7") }
-    implementation("com.google.flogger:flogger:0.7.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
+    implementation(platform(libs.jackson.bom))
+    implementation(platform(libs.kotlin.bom))
+    implementation(libs.kotlin.stdlib.jdk8)
+    implementation(libs.handlebars)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jcommander)
+    implementation(libs.openapi.parser) { exclude(group = "junit") }
+    implementation(libs.jsonoverlay)
+    implementation(libs.kotlinpoet) { exclude(module = "kotlin-stdlib-jre7") }
+    implementation(libs.flogger)
+    implementation(libs.kotlinx.serialization.json)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion")
+    implementation(libs.kotlinx.datetime)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
 
     // Below dependencies are solely present so code examples in the test resources dir compile
-    testImplementation("javax.validation:validation-api:2.0.1.Final")
-    testImplementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    testImplementation("org.springframework:spring-webmvc:6.0.9")
-    testImplementation("org.springframework.security:spring-security-web:6.1.0")
-    testImplementation("io.micronaut:micronaut-core:3.8.7")
-    testImplementation("io.micronaut:micronaut-http:3.8.7")
-    //testCompileOnly("io.micronaut.security:micronaut-security:3.8.7")
-    testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
-    testImplementation("org.openapitools:jackson-databind-nullable:0.2.6")
-    testImplementation("io.ktor:ktor-server-core:$ktorVersion")
-    testImplementation("io.ktor:ktor-server-auth:$ktorVersion")
+    testImplementation(libs.validation.api)
+    testImplementation(libs.jakarta.validation.api)
+    testImplementation(libs.spring.webmvc)
+    testImplementation(libs.spring.security.web)
+    testImplementation(libs.micronaut.core)
+    testImplementation(libs.micronaut.http)
+    testImplementation(libs.okhttp)
+    testImplementation(libs.jackson.databind.nullable)
+    testImplementation(libs.ktor.server.core)
+    testImplementation(libs.ktor.server.auth)
 
-    testImplementation(platform("com.pinterest.ktlint:ktlint-bom:1.7.1"))
-    testImplementation("com.pinterest.ktlint:ktlint-rule-engine-core")
-    testImplementation("com.pinterest.ktlint:ktlint-rule-engine")
-    testImplementation("com.pinterest.ktlint:ktlint-ruleset-standard")
+    testImplementation(platform(libs.ktlint.bom))
+    testImplementation(libs.ktlint.rule.engine.core)
+    testImplementation(libs.ktlint.rule.engine)
+    testImplementation(libs.ktlint.ruleset.standard)
 }
 
 tasks {

--- a/end2end-tests/ktor-client-jackson/build.gradle.kts
+++ b/end2end-tests/ktor-client-jackson/build.gradle.kts
@@ -20,27 +20,21 @@ kotlin {
     jvmToolchain(17)
 }
 
-val junitVersion: String by rootProject.extra
-val ktorVersion: String by rootProject.extra
-
 dependencies {
     // ktor client
-    implementation("io.ktor:ktor-client-core:$ktorVersion")
-    implementation("io.ktor:ktor-client-cio:$ktorVersion")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.jackson)
 
     // ktor test
-    testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
-    testImplementation("io.mockk:mockk:1.13.7")
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.mockk)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.wiremock:wiremock:3.3.1")
-    testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.bundles.wiremock)
 }
 
 tasks {

--- a/end2end-tests/ktor-client-kotlinx/build.gradle.kts
+++ b/end2end-tests/ktor-client-kotlinx/build.gradle.kts
@@ -21,30 +21,23 @@ kotlin {
     jvmToolchain(17)
 }
 
-val junitVersion: String by rootProject.extra
-val ktorVersion: String by rootProject.extra
-val kotlinxDateTimeVersion: String by rootProject.extra
-
 dependencies {
     // ktor client
-    implementation("io.ktor:ktor-client-core:$ktorVersion")
-    implementation("io.ktor:ktor-client-cio:$ktorVersion")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion")
+    implementation(libs.kotlinx.datetime)
 
     // ktor test
-    testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
-    testImplementation("io.mockk:mockk:1.13.7")
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.mockk)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.wiremock:wiremock:3.3.1")
-    testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.bundles.wiremock)
 }
 
 tasks {

--- a/end2end-tests/ktor/build.gradle.kts
+++ b/end2end-tests/ktor/build.gradle.kts
@@ -19,45 +19,39 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-val jacksonVersion: String by rootProject.extra
-val junitVersion: String by rootProject.extra
-val ktorVersion: String by rootProject.extra
-
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    implementation("javax.validation:validation-api:2.0.1.Final")
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.core:jackson-core")
-    implementation("com.fasterxml.jackson.core:jackson-annotations")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation(platform(libs.jackson.bom))
+    implementation(libs.jakarta.validation.api)
+    implementation(libs.validation.api)
+    implementation(libs.kotlinx.datetime.v062)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.datatype.jsr310)
 
     // ktor server
-    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
-    implementation("io.ktor:ktor-server-auth:$ktorVersion")
-    implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
-    implementation("io.ktor:ktor-server-data-conversion:$ktorVersion")
+    implementation(libs.ktor.server.content.negotiation.jvm)
+    implementation(libs.ktor.serialization.jackson)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.server.auth)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.data.conversion)
 
     // ktor test
-    testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
-    testImplementation("io.ktor:ktor-server-auth:$ktorVersion")
-    testImplementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")
-    testImplementation("io.ktor:ktor-server-status-pages:$ktorVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:1.8.20")
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.ktor.server.auth)
+    testImplementation(libs.ktor.server.auth.jwt)
+    testImplementation(libs.ktor.server.status.pages)
+    testImplementation(libs.kotlin.test)
 
-    testImplementation("io.mockk:mockk:1.13.7")
+    testImplementation(libs.mockk)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
 
-    testImplementation("ch.qos.logback:logback-classic:1.4.3")
+    testImplementation(libs.logback.classic.v143)
 }
 
 tasks {

--- a/end2end-tests/models-jackson/build.gradle.kts
+++ b/end2end-tests/models-jackson/build.gradle.kts
@@ -18,24 +18,19 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-val jacksonVersion: String by rootProject.extra
-val junitVersion: String by rootProject.extra
-
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    implementation("javax.validation:validation-api:2.0.1.Final")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.core:jackson-core")
-    implementation("com.fasterxml.jackson.core:jackson-annotations")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation(platform(libs.jackson.bom))
+    implementation(libs.jakarta.validation.api)
+    implementation(libs.validation.api)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.datatype.jsr310)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
 }
 
 fun createGenerateCodeTask(name: String, apiFilePath: String, basePackage: String, additionalArgs: List<String> = emptyList()) =

--- a/end2end-tests/models-kotlinx/build.gradle.kts
+++ b/end2end-tests/models-kotlinx/build.gradle.kts
@@ -19,19 +19,13 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-val junitVersion: String by rootProject.extra
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotlinxDateTimeVersion: String by rootProject.extra
-
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion")
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.datetime)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
 }
 
 fun createGenerateCodeTask(name: String, apiFilePath: String, basePackage: String, additionalArgs: List<String> = emptyList()) =

--- a/end2end-tests/okhttp/build.gradle.kts
+++ b/end2end-tests/okhttp/build.gradle.kts
@@ -19,27 +19,21 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-val jacksonVersion: String by rootProject.extra
-val junitVersion: String by rootProject.extra
-
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("io.github.resilience4j:resilience4j-circuitbreaker:2.1.0")
-    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    implementation("javax.validation:validation-api:2.0.1.Final")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.core:jackson-core")
-    implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation(platform(libs.jackson.bom))
+    implementation(libs.okhttp)
+    implementation(libs.resilience4j.circuitbreaker)
+    implementation(libs.jakarta.validation.api)
+    implementation(libs.validation.api)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.annotations)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.wiremock:wiremock:3.3.1")
-    testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.bundles.wiremock)
 }
 
 tasks {

--- a/end2end-tests/openfeign/build.gradle.kts
+++ b/end2end-tests/openfeign/build.gradle.kts
@@ -19,29 +19,23 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-val jacksonVersion: String by rootProject.extra
-val junitVersion: String by rootProject.extra
-
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("io.github.openfeign:feign-core:13.3")
-    implementation("io.github.openfeign:feign-jackson:13.3")
-    implementation("io.github.openfeign:feign-okhttp:13.3")
-    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    implementation("javax.validation:validation-api:2.0.1.Final")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.core:jackson-core")
-    implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation(platform(libs.jackson.bom))
+    implementation(libs.okhttp)
+    implementation(libs.feign.core)
+    implementation(libs.feign.jackson)
+    implementation(libs.feign.okhttp)
+    implementation(libs.jakarta.validation.api)
+    implementation(libs.validation.api)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.annotations)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.wiremock:wiremock:3.3.1")
-    testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.bundles.wiremock)
 }
 
 tasks {

--- a/end2end-tests/spring-http-interface/build.gradle.kts
+++ b/end2end-tests/spring-http-interface/build.gradle.kts
@@ -19,27 +19,21 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-val jacksonVersion: String by rootProject.extra
-val junitVersion: String by rootProject.extra
-
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("org.springframework.boot:spring-boot-starter-web:3.4.3")
-    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
-    implementation("javax.validation:validation-api:2.0.1.Final")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.core:jackson-core")
-    implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation(platform(libs.jackson.bom))
+    implementation(libs.okhttp)
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.jakarta.validation.api)
+    implementation(libs.validation.api)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.annotations)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.wiremock:wiremock:3.3.1")
-    testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.bundles.wiremock)
 }
 
 tasks {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,129 @@
+[versions]
+# Core / Kotlin
+kotlin-test = "1.8.20"
+kotlinpoet = "1.14.2"
+kotlinx-datetime = "0.7.1-0.6.x-compat"
+kotlinx-datetime-compat = "0.6.2"
+kotlinx-serialization = "1.9.0"
+
+# Jackson / Serialization
+jackson = "2.20.1"
+jackson-databind-nullable = "0.2.6"
+
+# OpenAPI
+kaizen-openapi-parser = "4.1.0"
+jsonoverlay = "4.0.4"
+
+# Code generation
+handlebars = "4.3.1"
+jcommander = "1.82"
+flogger = "0.7.4"
+
+# Ktor
+ktor = "3.0.1"
+
+# Spring
+spring-boot = "3.4.3"
+spring-webmvc = "6.0.9"
+spring-security = "6.1.0"
+
+# Micronaut
+micronaut = "3.8.7"
+
+# HTTP clients
+okhttp = "4.10.0"
+feign = "13.3"
+resilience4j = "2.1.0"
+
+# Validation
+jakarta-validation = "3.0.2"
+validation-api = "2.0.1.Final"
+
+# Logging
+logback = "1.5.6"
+logback-legacy = "1.4.3"
+
+# Testing
+junit = "5.9.2"
+assertj = "3.24.2"
+mockk = "1.13.7"
+wiremock = "3.3.1"
+kotlin-wiremock = "2.1.1"
+
+# Linting
+ktlint = "1.7.1"
+
+[libraries]
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
+jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" }
+jackson-databind-nullable = { module = "org.openapitools:jackson-databind-nullable", version.ref = "jackson-databind-nullable" }
+
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin-test" }
+
+handlebars = { module = "com.github.jknack:handlebars", version.ref = "handlebars" }
+jcommander = { module = "com.beust:jcommander", version.ref = "jcommander" }
+openapi-parser = { module = "io.fabrikt:kaizen-openapi-parser", version.ref = "kaizen-openapi-parser" }
+jsonoverlay = { module = "com.reprezen.jsonoverlay:jsonoverlay", version.ref = "jsonoverlay" }
+kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
+flogger = { module = "com.google.flogger:flogger", version.ref = "flogger" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+kotlinx-datetime-v062 = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime-compat" }
+
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+validation-api = { module = "javax.validation:validation-api", version.ref = "validation-api" }
+jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version.ref = "jakarta-validation" }
+spring-webmvc = { module = "org.springframework:spring-webmvc", version.ref = "spring-webmvc" }
+spring-security-web = { module = "org.springframework.security:spring-security-web", version.ref = "spring-security" }
+spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring-boot" }
+micronaut-core = { module = "io.micronaut:micronaut-core", version.ref = "micronaut" }
+micronaut-http = { module = "io.micronaut:micronaut-http", version.ref = "micronaut" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
+ktor-server-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor" }
+ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+ktor-server-data-conversion = { module = "io.ktor:ktor-server-data-conversion", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-server-netty-jvm = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
+ktor-server-content-negotiation-jvm = { module = "io.ktor:ktor-server-content-negotiation-jvm", version.ref = "ktor" }
+ktor-server-html-builder = { module = "io.ktor:ktor-server-html-builder", version.ref = "ktor" }
+ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
+ktor-serialization-jackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+logback-classic-v143 = { module = "ch.qos.logback:logback-classic", version.ref = "logback-legacy" }
+
+wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
+kotlin-wiremock = { module = "com.marcinziolo:kotlin-wiremock", version.ref = "kotlin-wiremock" }
+resilience4j-circuitbreaker = { module = "io.github.resilience4j:resilience4j-circuitbreaker", version.ref = "resilience4j" }
+feign-core = { module = "io.github.openfeign:feign-core", version.ref = "feign" }
+feign-jackson = { module = "io.github.openfeign:feign-jackson", version.ref = "feign" }
+feign-okhttp = { module = "io.github.openfeign:feign-okhttp", version.ref = "feign" }
+
+ktlint-bom = { module = "com.pinterest.ktlint:ktlint-bom", version.ref = "ktlint" }
+ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core" }
+ktlint-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine" }
+ktlint-ruleset-standard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard" }
+
+[bundles]
+junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-jupiter-params"]
+wiremock = ["wiremock", "kotlin-wiremock"]

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -14,21 +14,19 @@ repositories {
     mavenCentral()
 }
 
-val ktorVersion: String by rootProject.extra
-
 dependencies {
     implementation(project(":"))
 
     // ktor server
-    implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-server-html-builder:$ktorVersion")
-    implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
+    implementation(libs.ktor.server.netty.jvm)
+    implementation(libs.ktor.server.content.negotiation.jvm)
+    implementation(libs.ktor.server.html.builder)
+    implementation(libs.ktor.server.call.logging)
 
     // logging
-    implementation("ch.qos.logback:logback-classic:1.5.6")
+    implementation(libs.logback.classic)
 
-    implementation("com.squareup:kotlinpoet:1.14.2") { exclude(module = "kotlin-stdlib-jre7") }
+    implementation(libs.kotlinpoet) { exclude(module = "kotlin-stdlib-jre7") }
 
     testImplementation(kotlin("test"))
 }


### PR DESCRIPTION
Started looking at what would be necessary to support Jackson 3 clients (https://github.com/fabrikt-io/fabrikt/issues/556) and noticed that we could probably use the Gradle version catalog instead of properties in the extra field.