### PR TITLE
fix: extend oneOf redundancy check to non-discriminated allOf hierarchies

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -328,10 +328,11 @@ object KaizenParserExtensions {
 
     fun Schema.isOneOfWhereAllTypesInheritFromACommonAllOfSuperType(): Boolean {
         val maybeAllOfInFirstOneOf = this.oneOfSchemas?.firstOrNull()?.allOfSchemas?.firstOrNull()
-        // This identifies the OLD allOf-based polymorphism pattern where the BASE type has the discriminator
-        return if (maybeAllOfInFirstOneOf != null && maybeAllOfInFirstOneOf.hasDiscriminator())  {
-            this.oneOfSchemas.all { it.allOfSchemas.contains(maybeAllOfInFirstOneOf) }
-        } else false
+            ?: return false
+        // All oneOf members must share the same allOf parent — with or without a discriminator.
+        // When the parent has no discriminator (e.g., Kotlin sealed classes without @JsonTypeInfo),
+        // the oneOf is still redundant because the parent type already represents the hierarchy.
+        return this.oneOfSchemas.all { it.allOfSchemas.contains(maybeAllOfInFirstOneOf) }
     }
 
     fun Schema.isOneOfResolvingToAnyType(): Boolean {
@@ -349,16 +350,17 @@ object KaizenParserExtensions {
     fun Schema.isOneOfSuperInterface(): Boolean =
         oneOfSchemas.isNotEmpty() && allOfSchemas.isEmpty() && anyOfSchemas.isEmpty() && properties.isEmpty() &&
             oneOfSchemas.all { it.isObjectType() || it.isAggregatedObject() || it.isOneOfSuperInterface() } &&
-            !isRedundantOneOfForExistingDiscriminatedHierarchy() &&
+            !isRedundantOneOfForExistingHierarchy() &&
             isSealedInterfacesForOneOfEnabled()
 
     /**
      * A oneOf is redundant when all its members already inherit from a common allOf super type
-     * that has its own discriminator, and the oneOf itself declares no discriminator.
-     * In this case the polymorphism is fully handled by the parent type, and generating
-     * a sealed interface would create a phantom type that subtypes reference but is never emitted.
+     * and the oneOf itself declares no discriminator.
+     * In this case the polymorphism is fully handled by the parent type (whether or not it has
+     * a discriminator), and generating a sealed interface would create a phantom type that
+     * subtypes reference but is never emitted.
      */
-    private fun Schema.isRedundantOneOfForExistingDiscriminatedHierarchy(): Boolean =
+    private fun Schema.isRedundantOneOfForExistingHierarchy(): Boolean =
         isOneOfWhereAllTypesInheritFromACommonAllOfSuperType() && hasNoDiscriminator()
 
     fun Schema.isOneOfSuperInterfaceWithDiscriminator() =

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -247,3 +247,34 @@ components:
           oneOf:
             - $ref: '#/components/schemas/ChildActionA'
             - $ref: '#/components/schemas/ChildActionB'
+
+    # Regression test: inline oneOf where all members share a common parent WITHOUT a discriminator.
+    # Same as ParentAction case above, but the parent has no discriminator property —
+    # e.g., Kotlin sealed classes serialized without @JsonTypeInfo.
+    # The oneOf is still redundant because all members inherit from the same parent.
+    BaseError:
+      type: object
+      properties:
+        message:
+          type: string
+        errorType:
+          type: string
+          enum:
+            - VALIDATION
+            - SERVER
+      required:
+        - message
+        - errorType
+    ValidationErr:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+    ServerErr:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+    ErrorWrapper:
+      type: object
+      properties:
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/ValidationErr'
+            - $ref: '#/components/schemas/ServerErr'

--- a/src/test/resources/examples/discriminatedOneOf/models/BaseError.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/BaseError.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class BaseError(
+  @param:JsonProperty("message")
+  @get:JsonProperty("message")
+  @get:NotNull
+  public val message: String,
+  @param:JsonProperty("errorType")
+  @get:JsonProperty("errorType")
+  @get:NotNull
+  public val errorType: BaseErrorErrorType,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/BaseErrorErrorType.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/BaseErrorErrorType.kt
@@ -1,0 +1,23 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class BaseErrorErrorType(
+  @JsonValue
+  public val `value`: String,
+) {
+  VALIDATION("VALIDATION"),
+  SERVER("SERVER"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, BaseErrorErrorType> =
+        entries.associateBy(BaseErrorErrorType::value)
+
+    public fun fromValue(`value`: String): BaseErrorErrorType? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/discriminatedOneOf/models/ErrorWrapper.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ErrorWrapper.kt
@@ -1,0 +1,11 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.Valid
+
+public data class ErrorWrapper(
+  @param:JsonProperty("error")
+  @get:JsonProperty("error")
+  @get:Valid
+  public val error: BaseError? = null,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/ServerErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ServerErr.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class ServerErr(
+  @param:JsonProperty("message")
+  @get:JsonProperty("message")
+  @get:NotNull
+  public val message: String,
+  @param:JsonProperty("errorType")
+  @get:JsonProperty("errorType")
+  @get:NotNull
+  public val errorType: BaseErrorErrorType,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/ValidationErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ValidationErr.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class ValidationErr(
+  @param:JsonProperty("message")
+  @get:JsonProperty("message")
+  @get:NotNull
+  public val message: String,
+  @param:JsonProperty("errorType")
+  @get:JsonProperty("errorType")
+  @get:NotNull
+  public val errorType: BaseErrorErrorType,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/BaseError.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/BaseError.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class BaseError(
+  @SerialName("message")
+  @get:NotNull
+  public val message: String,
+  @SerialName("errorType")
+  @get:NotNull
+  public val errorType: BaseErrorErrorType,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/BaseErrorErrorType.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/BaseErrorErrorType.kt
@@ -1,0 +1,24 @@
+package examples.discriminatedOneOf.models
+
+import kotlin.String
+import kotlin.collections.Map
+import kotlinx.serialization.SerialName
+
+public enum class BaseErrorErrorType(
+  public val `value`: String,
+) {
+  @SerialName("VALIDATION")
+  VALIDATION("VALIDATION"),
+  @SerialName("SERVER")
+  SERVER("SERVER"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, BaseErrorErrorType> =
+        entries.associateBy(BaseErrorErrorType::value)
+
+    public fun fromValue(`value`: String): BaseErrorErrorType? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ErrorWrapper.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ErrorWrapper.kt
@@ -1,0 +1,12 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.Valid
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class ErrorWrapper(
+  @SerialName("error")
+  @get:Valid
+  public val error: BaseError? = null,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ServerErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ServerErr.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class ServerErr(
+  @SerialName("message")
+  @get:NotNull
+  public val message: String,
+  @SerialName("errorType")
+  @get:NotNull
+  public val errorType: BaseErrorErrorType,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ValidationErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ValidationErr.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class ValidationErr(
+  @SerialName("message")
+  @get:NotNull
+  public val message: String,
+  @SerialName("errorType")
+  @get:NotNull
+  public val errorType: BaseErrorErrorType,
+)


### PR DESCRIPTION
## Summary

Follow-up to #562. Extends the phantom sealed interface fix to handle `oneOf` schemas where all members inherit from a common `allOf` parent that has **no discriminator**.

### Root cause

`isOneOfWhereAllTypesInheritFromACommonAllOfSuperType()` required the common parent to have a discriminator (`hasDiscriminator()`). This meant non-discriminated parents (e.g., Kotlin sealed classes without `@JsonTypeInfo`) weren't recognized, and a phantom sealed interface was still generated.

### Fix

One-line change: remove the `hasDiscriminator()` requirement from the common parent check. The redundancy condition is: all `oneOf` members share a common `allOf` parent AND the `oneOf` itself has no discriminator. Whether the parent has a discriminator is irrelevant — if all members already inherit from the same type, the `oneOf` is redundant either way.

### Test

Extends the regression test from #562 with a non-discriminated variant:
- `BaseError` (no discriminator) ← `ServerErr`, `ValidationErr` via `allOf`
- `ErrorWrapper.error` has `oneOf: [ServerErr, ValidationErr]`
- Expected: `ErrorWrapper.error` resolves to `BaseError?`, no phantom `ErrorWrapperError` interface

Both Jackson and Kotlinx serialization expected outputs included.

### Results

- All model generator tests pass (both Jackson and Kotlinx)
- Full test suite: 36 failures (down from 39 on master — this fix resolves 3 pre-existing test failures)

Fixes #573