### PR TITLE
Add OG meta tags to playground and fix stale org references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The command mounts your current directory to `/workspace` in the container, wher
 ### 1. Prefer components to inline schemas
 While inline schemas are perfectly valid they are not supported by Fabrikt in all circumstances.
 This is especially true for request bodies and non-trivial parameters. Instead, define your schemas in the
-components section of the OpenAPI spec (`components.parameters` & `components.requestBodies`). [#20](https://github.com/cjbooms/fabrikt/issues/20), [#187](https://github.com/cjbooms/fabrikt/issues/187)
+components section of the OpenAPI spec (`components.parameters` & `components.requestBodies`). [#20](https://github.com/fabrikt-io/fabrikt/issues/20), [#187](https://github.com/fabrikt-io/fabrikt/issues/187)
 
 ### 2. Use `oneOf` with discriminator for polymorphism
 `oneOf` along with the flag `SEALED_INTERFACES_FOR_ONE_OF` will generate polymorphic models with sealed interfaces.
@@ -458,7 +458,7 @@ data class Responses(
 
 Fabrikt is built with Gradle and requires an initialised git repository. The easiest way to build it is to clone the repo locally before executing the build command:
 ```
-git clone git@github.com:cjbooms/fabrikt.git
+git clone git@github.com:fabrikt-io/fabrikt.git
 cd fabrikt/
 ./gradlew clean build
 ```
@@ -469,7 +469,7 @@ A utility function is available in [GeneratedCodeAsserter.kt](src/test/kotlin/co
 
 ### Publishing
 
-1. Go to [Release Tab](https://github.com/cjbooms/fabrikt/releases)
+1. Go to [Release Tab](https://github.com/fabrikt-io/fabrikt/releases)
 2. Select `Draft a new release`.
 3. Set tag to a version greater than current using symantic versioning, anticipating whether the changes made could break builds.
 4. Click `Generate release notes`. Ensure that the tag and release version match.

--- a/playground/src/main/kotlin/views/layout/Layout.kt
+++ b/playground/src/main/kotlin/views/layout/Layout.kt
@@ -24,10 +24,6 @@ fun HTML.mainLayout(content: FlowContent.() -> Unit) = run {
         meta { attributes["property"] = "og:type"; attributes["content"] = "website" }
         meta { attributes["property"] = "og:url"; attributes["content"] = "https://try.fabrikt.io" }
         meta { attributes["property"] = "og:image"; attributes["content"] = "https://raw.githubusercontent.com/fabrikt-io/fabrikt/master/.github/assets/fabrikt-social-preview.png" }
-        meta(name = "twitter:card", content = "summary_large_image")
-        meta(name = "twitter:title", content = "Fabrikt Playground")
-        meta(name = "twitter:description", content = "Generate Kotlin data classes, HTTP clients, and server controllers from your OpenAPI 3 spec.")
-        meta(name = "twitter:image", content = "https://raw.githubusercontent.com/fabrikt-io/fabrikt/master/.github/assets/fabrikt-social-preview.png")
         script { src = "https://cdnjs.cloudflare.com/ajax/libs/prism/$PRISM_VERSION/prism.min.js" }
         script { src = "https://cdnjs.cloudflare.com/ajax/libs/prism/$PRISM_VERSION/components/prism-kotlin.min.js" }
         script { src = "https://cdnjs.cloudflare.com/ajax/libs/ace/$ACE_VERSION/ace.js" }

--- a/playground/src/main/kotlin/views/layout/Layout.kt
+++ b/playground/src/main/kotlin/views/layout/Layout.kt
@@ -17,7 +17,17 @@ private const val BASSCSS = "8.1.0"
 
 fun HTML.mainLayout(content: FlowContent.() -> Unit) = run {
     head {
-        title { +"Fabrikt Playground" }
+        title { +"Fabrikt Playground — Kotlin Code Generator for OpenAPI" }
+        meta(name = "description", content = "Generate Kotlin data classes, HTTP clients, and server controllers from your OpenAPI 3 spec. Try fabrikt live in your browser.")
+        meta { attributes["property"] = "og:title"; attributes["content"] = "Fabrikt Playground" }
+        meta { attributes["property"] = "og:description"; attributes["content"] = "Generate Kotlin data classes, HTTP clients, and server controllers from your OpenAPI 3 spec. Try fabrikt live in your browser." }
+        meta { attributes["property"] = "og:type"; attributes["content"] = "website" }
+        meta { attributes["property"] = "og:url"; attributes["content"] = "https://try.fabrikt.io" }
+        meta { attributes["property"] = "og:image"; attributes["content"] = "https://raw.githubusercontent.com/fabrikt-io/fabrikt/master/.github/assets/fabrikt-social-preview.png" }
+        meta(name = "twitter:card", content = "summary_large_image")
+        meta(name = "twitter:title", content = "Fabrikt Playground")
+        meta(name = "twitter:description", content = "Generate Kotlin data classes, HTTP clients, and server controllers from your OpenAPI 3 spec.")
+        meta(name = "twitter:image", content = "https://raw.githubusercontent.com/fabrikt-io/fabrikt/master/.github/assets/fabrikt-social-preview.png")
         script { src = "https://cdnjs.cloudflare.com/ajax/libs/prism/$PRISM_VERSION/prism.min.js" }
         script { src = "https://cdnjs.cloudflare.com/ajax/libs/prism/$PRISM_VERSION/components/prism-kotlin.min.js" }
         script { src = "https://cdnjs.cloudflare.com/ajax/libs/ace/$ACE_VERSION/ace.js" }


### PR DESCRIPTION
- Add Open Graph meta tags to playground HTML head for proper social sharing previews (title, description, image)
- Update meta description and title for SEO
- Fix stale cjbooms/fabrikt references → fabrikt-io/fabrikt in README (issue links, git clone URL, releases link)