### PR TITLE
Revert #574 and fix discriminator-less inline oneOf generation

### DIFF
--- a/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfTest.kt
+++ b/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfTest.kt
@@ -1,0 +1,74 @@
+package com.cjbooms.fabrikt.models.jackson
+
+import com.cjbooms.fabrikt.models.jackson.Helpers.mapper
+import com.example.oneof.models.BaseErrorErrorType
+import com.example.oneof.models.ErrorWrapper
+import com.example.oneof.models.ServerErr
+import com.example.oneof.models.ValidationErr
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Demonstrates correct Jackson serde behaviour for a discriminator-less inline oneOf.
+ *
+ * [ErrorWrapper.error] is typed as [Any]? because [ValidationErr] and [ServerErr] have no
+ * discriminator property — Jackson has no way to select the correct subtype during
+ * deserialization. A sealed interface [com.example.oneof.models.ErrorWrapperError] is still
+ * generated so that [ValidationErr] and [ServerErr] are type-safe to produce, but the field
+ * itself is [Any]? so deserialization captures the raw JSON as a [LinkedHashMap] — no data
+ * is lost. The correct fix for full round-trip type fidelity is in the spec: add a discriminator.
+ */
+class DiscriminatorlessOneOfTest {
+
+    private val objectMapper = mapper()
+
+    @Test
+    fun `serialization uses runtime type - ValidationErr unique field emitted`() {
+        val wrapper = ErrorWrapper(error = ValidationErr(message = "field is required", errorType = BaseErrorErrorType.VALIDATION, fieldName = "username"))
+
+        val json = objectMapper.writeValueAsString(wrapper)
+
+        assertThat(json).contains("\"message\":\"field is required\"")
+        assertThat(json).contains("\"errorType\":\"VALIDATION\"")
+        assertThat(json).contains("\"fieldName\":\"username\"")
+    }
+
+    @Test
+    fun `serialization uses runtime type - ServerErr unique field emitted`() {
+        val wrapper = ErrorWrapper(error = ServerErr(message = "internal error", errorType = BaseErrorErrorType.SERVER, stackTrace = "at com.example.Service.call(Service.kt:42)"))
+
+        val json = objectMapper.writeValueAsString(wrapper)
+
+        assertThat(json).contains("\"message\":\"internal error\"")
+        assertThat(json).contains("\"errorType\":\"SERVER\"")
+        assertThat(json).contains("\"stackTrace\":\"at com.example.Service.call(Service.kt:42)\"")
+    }
+
+    @Test
+    fun `deserialization captures all field values - no data lost`() {
+        val json = """{"error":{"message":"field is required","errorType":"VALIDATION","fieldName":"username"}}"""
+
+        val result = objectMapper.readValue(json, ErrorWrapper::class.java)
+
+        @Suppress("UNCHECKED_CAST")
+        val errorMap = result.error as Map<String, Any>
+        assertThat(errorMap["message"]).isEqualTo("field is required")
+        assertThat(errorMap["errorType"]).isEqualTo("VALIDATION")
+        assertThat(errorMap["fieldName"]).isEqualTo("username")
+    }
+
+    @Test
+    fun `round-trip preserves all field values including unique properties`() {
+        val original = ErrorWrapper(error = ValidationErr(message = "field is required", errorType = BaseErrorErrorType.VALIDATION, fieldName = "username"))
+
+        val json = objectMapper.writeValueAsString(original)
+        val deserialized = objectMapper.readValue(json, ErrorWrapper::class.java)
+
+        @Suppress("UNCHECKED_CAST")
+        val errorMap = deserialized.error as Map<String, Any>
+        assertThat(errorMap["message"]).isEqualTo("field is required")
+        assertThat(errorMap["errorType"]).isEqualTo("VALIDATION")
+        assertThat(errorMap["fieldName"]).isEqualTo("username")
+    }
+}
+

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -352,6 +352,16 @@ class ModelGenerator(
                 is PropertyInfo.Field ->
                     if (it.typeInfo is KotlinTypeInfo.Enum && !it.isInherited) {
                         setOf(buildEnumClass(it.schema, it.typeInfo))
+                    } else if (!it.isInherited && it.schema.isOneOfSuperInterface()) {
+                        setOf(
+                            oneOfSuperInterface(
+                                modelName = ModelNameRegistry.getOrRegister(it.schema, enclosingSchema),
+                                discriminator = it.schema.discriminator,
+                                allSchemas = sourceApi.allSchemas,
+                                members = it.schema.oneOfSchemas,
+                                oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema })
+                            )
+                        )
                     } else {
                         emptySet()
                     }
@@ -363,7 +373,18 @@ class ModelGenerator(
                         buildInlinedListDefinition(it.schema, it.name, enclosingSchema, apiDocUrl)
                     }
 
-                is PropertyInfo.OneOfAny -> emptySet()
+                is PropertyInfo.OneOfAny ->
+                    if (it.schema.isOneOfSuperInterface()) {
+                        setOf(
+                            oneOfSuperInterface(
+                                modelName = ModelNameRegistry.getOrRegister(it.schema, enclosingSchema),
+                                discriminator = it.schema.discriminator,
+                                allSchemas = sourceApi.allSchemas,
+                                members = it.schema.oneOfSchemas,
+                                oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema })
+                            )
+                        )
+                    } else emptySet()
             }
         }
     }

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -333,11 +333,10 @@ object KaizenParserExtensions {
 
     fun Schema.isOneOfWhereAllTypesInheritFromACommonAllOfSuperType(): Boolean {
         val maybeAllOfInFirstOneOf = this.oneOfSchemas?.firstOrNull()?.allOfSchemas?.firstOrNull()
-            ?: return false
-        // All oneOf members must share the same allOf parent — with or without a discriminator.
-        // When the parent has no discriminator (e.g., Kotlin sealed classes without @JsonTypeInfo),
-        // the oneOf is still redundant because the parent type already represents the hierarchy.
-        return this.oneOfSchemas.all { it.allOfSchemas.contains(maybeAllOfInFirstOneOf) }
+        // This identifies the OLD allOf-based polymorphism pattern where the BASE type has the discriminator
+        return if (maybeAllOfInFirstOneOf != null && maybeAllOfInFirstOneOf.hasDiscriminator()) {
+            this.oneOfSchemas.all { it.allOfSchemas.contains(maybeAllOfInFirstOneOf) }
+        } else false
     }
 
     fun Schema.isOneOfResolvingToAnyType(): Boolean {
@@ -355,17 +354,16 @@ object KaizenParserExtensions {
     fun Schema.isOneOfSuperInterface(): Boolean =
         oneOfSchemas.isNotEmpty() && allOfSchemas.isEmpty() && anyOfSchemas.isEmpty() && properties.isEmpty() &&
             oneOfSchemas.all { it.isObjectType() || it.isAggregatedObject() || it.isOneOfSuperInterface() } &&
-            !isRedundantOneOfForExistingHierarchy() &&
+            !isRedundantOneOfForExistingDiscriminatedHierarchy() &&
             isSealedInterfacesForOneOfEnabled()
 
     /**
      * A oneOf is redundant when all its members already inherit from a common allOf super type
-     * and the oneOf itself declares no discriminator.
-     * In this case the polymorphism is fully handled by the parent type (whether or not it has
-     * a discriminator), and generating a sealed interface would create a phantom type that
-     * subtypes reference but is never emitted.
+     * that has its own discriminator, and the oneOf itself declares no discriminator.
+     * In this case the polymorphism is fully handled by the parent type, and generating
+     * a sealed interface would create a phantom type that subtypes reference but is never emitted.
      */
-    private fun Schema.isRedundantOneOfForExistingHierarchy(): Boolean =
+    private fun Schema.isRedundantOneOfForExistingDiscriminatedHierarchy(): Boolean =
         isOneOfWhereAllTypesInheritFromACommonAllOfSuperType() && hasNoDiscriminator()
 
     fun Schema.isOneOfSuperInterfaceWithDiscriminator() =

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -248,10 +248,12 @@ components:
             - $ref: '#/components/schemas/ChildActionA'
             - $ref: '#/components/schemas/ChildActionB'
 
-    # Regression test: inline oneOf where all members share a common parent WITHOUT a discriminator.
-    # Same as ParentAction case above, but the parent has no discriminator property —
-    # e.g., Kotlin sealed classes serialized without @JsonTypeInfo.
-    # The oneOf is still redundant because all members inherit from the same parent.
+    # Inline oneOf where all members share a common parent WITHOUT a discriminator.
+    # ValidationErr and ServerErr each have distinct properties (fieldName, stackTrace) but the
+    # oneOf carries no discriminator, so Jackson cannot select the correct subtype during
+    # deserialisation. A sealed interface (ErrorWrapperError) is generated so the subtypes are
+    # type-safe to produce; the field is typed as Any? so deserialization captures the raw JSON
+    # as a LinkedHashMap without data loss. The correct fix is in the spec: add a discriminator.
     BaseError:
       type: object
       properties:
@@ -268,9 +270,21 @@ components:
     ValidationErr:
       allOf:
         - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - fieldName
+          properties:
+            fieldName:
+              type: string
     ServerErr:
       allOf:
         - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - stackTrace
+          properties:
+            stackTrace:
+              type: string
     ErrorWrapper:
       type: object
       properties:

--- a/src/test/resources/examples/discriminatedOneOf/models/ErrorWrapper.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ErrorWrapper.kt
@@ -1,11 +1,10 @@
 package examples.discriminatedOneOf.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
-import jakarta.validation.Valid
+import kotlin.Any
 
 public data class ErrorWrapper(
   @param:JsonProperty("error")
   @get:JsonProperty("error")
-  @get:Valid
-  public val error: BaseError? = null,
+  public val error: Any? = null,
 )

--- a/src/test/resources/examples/discriminatedOneOf/models/ErrorWrapperError.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ErrorWrapperError.kt
@@ -1,0 +1,3 @@
+package examples.discriminatedOneOf.models
+
+public sealed interface ErrorWrapperError

--- a/src/test/resources/examples/discriminatedOneOf/models/ServerErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ServerErr.kt
@@ -13,4 +13,8 @@ public data class ServerErr(
   @get:JsonProperty("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
-)
+  @param:JsonProperty("stackTrace")
+  @get:JsonProperty("stackTrace")
+  @get:NotNull
+  public val stackTrace: String,
+) : ErrorWrapperError

--- a/src/test/resources/examples/discriminatedOneOf/models/ValidationErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ValidationErr.kt
@@ -13,4 +13,8 @@ public data class ValidationErr(
   @get:JsonProperty("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
-)
+  @param:JsonProperty("fieldName")
+  @get:JsonProperty("fieldName")
+  @get:NotNull
+  public val fieldName: String,
+) : ErrorWrapperError

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ErrorWrapper.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ErrorWrapper.kt
@@ -1,12 +1,11 @@
 package examples.discriminatedOneOf.models
 
-import jakarta.validation.Valid
+import kotlin.Any
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class ErrorWrapper(
   @SerialName("error")
-  @get:Valid
-  public val error: BaseError? = null,
+  public val error: Any? = null,
 )

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ErrorWrapperError.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ErrorWrapperError.kt
@@ -1,0 +1,6 @@
+package examples.discriminatedOneOf.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public sealed interface ErrorWrapperError

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ServerErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ServerErr.kt
@@ -13,4 +13,7 @@ public data class ServerErr(
   @SerialName("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
-)
+  @SerialName("stackTrace")
+  @get:NotNull
+  public val stackTrace: String,
+) : ErrorWrapperError

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ValidationErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ValidationErr.kt
@@ -13,4 +13,7 @@ public data class ValidationErr(
   @SerialName("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
-)
+  @SerialName("fieldName")
+  @get:NotNull
+  public val fieldName: String,
+) : ErrorWrapperError


### PR DESCRIPTION
Reverts the functional change in #574 and replaces it with a more principled fix. While the previously generated code would compile, without the JsonType annotations, json serialization/deserialzation would have caused data loss if the sub-types had different properties.

### What #574 did: 

Removed the `hasDiscriminator()` guard from `isOneOfWhereAllTypesInheritFromACommonAllOfSuperType()`, which caused non-discriminated allOf hierarchies to suppress sealed interface generation entirely and resolve member types to the common parent (e.g. `BaseError?`).

Why this is wrong: `BaseError?` is not a valid deserialization target for a discriminator-less oneOf — Jackson cannot dispatch to the correct subtype, and `BaseError` is not a supertype of `ValidationErr/ServerErr` in the generated code anyway. The field must be `Any?` so Jackson captures the raw JSON as a `LinkedHashMap` without data loss.

### What this PR does instead:

 - Restores the `hasDiscriminator()` guard (revert)
 - Keeps the test schema added by #574, updated with distinct properties on each subtype to make it realistic
 - Fixes a related bug: when an inline oneOf property has no discriminator, the sealed interface (`ErrorWrapperError`) was being referenced on the subtypes but never emitted. ModelGenerator now generates the sealed interface from `PropertyInfo.Field` entries whose schema satisfies `isOneOfSuperInterface()`
 - Adds end-to-end Jackson tests proving that serialisation uses the runtime type (all fields present) and deserialisation is non-lossy via `LinkedHashMap`

Net generated output for a discriminator-less inline oneOf:

 `sealed interface ErrorWrapperError          // marker — compiles, type-safe to produce`
 `data class ValidationErr(...) : ErrorWrapperError`
 `data class ServerErr(...) : ErrorWrapperError`
 `data class ErrorWrapper(val error: Any? = null)  // Any? — honest, non-lossy on deserialisation`