### PR TITLE
Follow-up to #574: flesh out discriminatorless oneOf test in discriminatedOneOf example

### DIFF
--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -248,10 +248,12 @@ components:
             - $ref: '#/components/schemas/ChildActionA'
             - $ref: '#/components/schemas/ChildActionB'
 
-    # Regression test: inline oneOf where all members share a common parent WITHOUT a discriminator.
-    # Same as ParentAction case above, but the parent has no discriminator property —
-    # e.g., Kotlin sealed classes serialized without @JsonTypeInfo.
-    # The oneOf is still redundant because all members inherit from the same parent.
+    # Inline oneOf where all members share a common parent WITHOUT a discriminator.
+    # ValidationErr and ServerErr each have distinct properties (fieldName, stackTrace) but the
+    # oneOf carries no discriminator, so Jackson cannot select the correct subtype during
+    # deserialisation. A sealed interface (ErrorWrapperError) is generated so the subtypes are
+    # type-safe to produce; the field is typed as Any? so deserialization captures the raw JSON
+    # as a LinkedHashMap without data loss. The correct fix is in the spec: add a discriminator.
     BaseError:
       type: object
       properties:
@@ -268,9 +270,21 @@ components:
     ValidationErr:
       allOf:
         - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - fieldName
+          properties:
+            fieldName:
+              type: string
     ServerErr:
       allOf:
         - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - stackTrace
+          properties:
+            stackTrace:
+              type: string
     ErrorWrapper:
       type: object
       properties:

--- a/src/test/resources/examples/discriminatedOneOf/models/ServerErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ServerErr.kt
@@ -13,4 +13,8 @@ public data class ServerErr(
   @get:JsonProperty("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
+  @param:JsonProperty("stackTrace")
+  @get:JsonProperty("stackTrace")
+  @get:NotNull
+  public val stackTrace: String,
 )

--- a/src/test/resources/examples/discriminatedOneOf/models/ValidationErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/ValidationErr.kt
@@ -13,4 +13,8 @@ public data class ValidationErr(
   @get:JsonProperty("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
+  @param:JsonProperty("fieldName")
+  @get:JsonProperty("fieldName")
+  @get:NotNull
+  public val fieldName: String,
 )

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ServerErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ServerErr.kt
@@ -13,4 +13,7 @@ public data class ServerErr(
   @SerialName("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
+  @SerialName("stackTrace")
+  @get:NotNull
+  public val stackTrace: String,
 )

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ValidationErr.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ValidationErr.kt
@@ -13,4 +13,7 @@ public data class ValidationErr(
   @SerialName("errorType")
   @get:NotNull
   public val errorType: BaseErrorErrorType,
+  @SerialName("fieldName")
+  @get:NotNull
+  public val fieldName: String,
 )


### PR DESCRIPTION
ValidationErr and ServerErr were empty allOf stubs. Give them distinct properties (fieldName, stackTrace) so the example demonstrates meaningful subtype generation. Update the comment to accurately describe the deserialization behaviour and generated ErrorWrapperError sealed interface.