### PR TITLE
Fix bug #572.

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -216,6 +216,7 @@ object PropertyUtils {
         schemaName: String,
     ) = this is PropertyInfo.Field &&
         isPolymorphicDiscriminator &&
+        classSettings.polymorphyType != ClassSettings.PolymorphyType.NONE &&
         !isSubTypeDiscriminatorWithNoValue(classSettings) &&
         !isSubTypeDiscriminatorWithMultipleValues(classSettings, schemaName)
 

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -329,3 +329,32 @@ components:
       properties:
         actions:
           $ref: '#/components/schemas/ChildActionsPartial'
+    DiscriminatedBase:
+      type: object
+      discriminator:
+        propertyName: errorCode
+        mapping:
+          ERR_ONE: '#/components/schemas/DiscriminatedChild'
+      required: [errorCode, message]
+      properties:
+        errorCode:
+          type: string
+        message:
+          type: string
+    DiscriminatedChild:
+      allOf:
+        - $ref: '#/components/schemas/DiscriminatedBase'
+        - type: object
+  responses:
+    NarrowedDiscriminatorResponse:
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/DiscriminatedChild'
+              - type: object
+                required: [errorCode]
+                properties:
+                  errorCode:
+                    type: string
+                    enum: [ERR_ONE]

--- a/src/test/resources/examples/discriminatedOneOf/models/DiscriminatedBase.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/DiscriminatedBase.kt
@@ -1,0 +1,18 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  property = "errorCode",
+  visible = true,
+)
+@JsonSubTypes(JsonSubTypes.Type(value = DiscriminatedChild::class, name = "ERR_ONE"))
+public sealed class DiscriminatedBase(
+  public open val message: String,
+) {
+  public abstract val errorCode: String
+}

--- a/src/test/resources/examples/discriminatedOneOf/models/DiscriminatedChild.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/DiscriminatedChild.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class DiscriminatedChild(
+  @param:JsonProperty("message")
+  @get:JsonProperty("message")
+  @get:NotNull
+  override val message: String,
+  @get:JsonProperty("errorCode")
+  @get:NotNull
+  @param:JsonProperty("errorCode")
+  override val errorCode: String = "ERR_ONE",
+) : DiscriminatedBase(message)

--- a/src/test/resources/examples/discriminatedOneOf/models/NarrowedDiscriminatorResponse.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/NarrowedDiscriminatorResponse.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class NarrowedDiscriminatorResponse(
+  @param:JsonProperty("errorCode")
+  @get:JsonProperty("errorCode")
+  @get:NotNull
+  public val errorCode: String,
+  @param:JsonProperty("message")
+  @get:JsonProperty("message")
+  @get:NotNull
+  public val message: String,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedBase.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedBase.kt
@@ -1,0 +1,20 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlinx.serialization.Serializable
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  property = "errorCode",
+  visible = true,
+)
+@JsonSubTypes(JsonSubTypes.Type(value = DiscriminatedChild::class, name = "ERR_ONE"))
+@Serializable
+public sealed class DiscriminatedBase(
+  public open val message: String,
+) {
+  public abstract val errorCode: String
+}

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedChild.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedChild.kt
@@ -1,0 +1,13 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class DiscriminatedChild(
+  @SerialName("message")
+  @get:NotNull
+  override val message: String,
+) : DiscriminatedBase(message)

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/NarrowedDiscriminatorResponse.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/NarrowedDiscriminatorResponse.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class NarrowedDiscriminatorResponse(
+  @SerialName("errorCode")
+  @get:NotNull
+  public val errorCode: String,
+  @SerialName("message")
+  @get:NotNull
+  public val message: String,
+)


### PR DESCRIPTION
Attempts to use allOf in responses schema to override a polymorphic allOf in component schemas was resulting in an invalid model.

This change fixes the compile time issue only. It does not attempt to allow polymorphic overrides from responses schemas to component schemas which looks like a much more difficult task

Closes #572