### PR TITLE
Generate models from inline schemas in components/requestBodies

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
@@ -57,9 +57,40 @@ data class SourceApi(
             ModelNameRegistry.preRegisterByReference(schema, name)
         }
 
+        val inlineRequestBodySchemas = openApi3.requestBodies.entries.flatMap { requestBody ->
+            requestBody.value.contentMediaTypes.entries
+                .filter { content ->
+                    val schema = content.value.schema
+                    Overlay.of(schema).pathFromRoot.contains("requestBodies") &&
+                        schema.oneOfSchemas.isNullOrEmpty() &&
+                        schema.anyOfSchemas.isNullOrEmpty()
+                }
+                .map { content -> requestBody.key to content.value.schema }
+        }
+
+        inlineRequestBodySchemas.forEach { (name, schema) ->
+            ModelNameRegistry.preRegisterByReference(schema, name)
+        }
+
+        val inlineResponseSchemas = openApi3.responses.entries.flatMap { response ->
+            response.value.contentMediaTypes.entries
+                .filter { content ->
+                    val schema = content.value.schema
+                    Overlay.of(schema).pathFromRoot.contains("responses") &&
+                        schema.oneOfSchemas.isNullOrEmpty() &&
+                        schema.anyOfSchemas.isNullOrEmpty()
+                }
+                .map { content -> response.key to content.value.schema }
+        }
+
+        inlineResponseSchemas.forEach { (name, schema) ->
+            ModelNameRegistry.preRegisterByReference(schema, name)
+        }
+
         allSchemas = openApi3.schemas.entries.map { it.key to it.value }
             .plus(openApi3.parameters.entries.map { it.key to it.value.schema })
-            .plus(openApi3.responses.entries.flatMap { it.value.contentMediaTypes.entries.map { content -> it.key to content.value.schema } })
+            .plus(inlineResponseSchemas)
+            .plus(inlineRequestBodySchemas)
             .plus(inlineEnumParams)
             .map { (key, schema) -> SchemaInfo(key, schema) }
     }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -75,6 +75,7 @@ class ModelGeneratorTest {
         "leadingUnderscoreProperty",
         "inlinedEnumParameter",
         "unsupportedInlinedDefinitions",
+        "requestBodiesSchema",
     )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -50,6 +50,7 @@ class SpringControllerGeneratorTest {
         "multiMediaType",
         "inlinedEnumParameter",
         "tagGrouping",
+        "requestBodiesSchema",
     )
 
     private fun setupGithubApiTestEnv(annotations: ValidationAnnotations = JavaxValidationAnnotations) {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -51,6 +51,7 @@ class SpringControllerGeneratorTest {
         "inlinedEnumParameter",
         "tagGrouping",
         "requestBodiesSchema",
+        "responsesSchema",
     )
 
     private fun setupGithubApiTestEnv(annotations: ValidationAnnotations = JavaxValidationAnnotations) {

--- a/src/test/resources/examples/requestBodiesSchema/api.yaml
+++ b/src/test/resources/examples/requestBodiesSchema/api.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.0
+info:
+  title: Request Bodies Schema Test
+  version: 1.0.0
+paths:
+  /widgets:
+    post:
+      operationId: createWidget
+      tags:
+        - widgets
+      summary: Create a new widget
+      requestBody:
+        $ref: '#/components/requestBodies/CreateWidgetRequest'
+      responses:
+        '201':
+          description: Widget created
+  /widgets/{id}:
+    put:
+      operationId: updateWidget
+      tags:
+        - widgets
+      summary: Update an existing widget
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateWidgetRequest'
+      responses:
+        '200':
+          description: Widget updated
+components:
+  requestBodies:
+    CreateWidgetRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - name
+              - count
+            properties:
+              name:
+                type: string
+              count:
+                type: integer
+    UpdateWidgetRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - name
+            properties:
+              name:
+                type: string
+              description:
+                type: string

--- a/src/test/resources/examples/requestBodiesSchema/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/requestBodiesSchema/controllers/spring/Controllers.kt
@@ -1,0 +1,52 @@
+package examples.requestBodiesSchema.controllers
+
+import examples.requestBodiesSchema.models.CreateWidgetRequest
+import examples.requestBodiesSchema.models.UpdateWidgetRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import javax.validation.Valid
+import kotlin.String
+import kotlin.Unit
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface WidgetsController {
+    /**
+     * Create a new widget
+     *
+     * @param createWidgetRequest
+     */
+    @RequestMapping(
+        value = ["/widgets"],
+        produces = [],
+        method = [RequestMethod.POST],
+        consumes = ["application/json"],
+    )
+    public fun createWidget(
+        @RequestBody @Valid createWidgetRequest: CreateWidgetRequest,
+    ): ResponseEntity<Unit>
+
+    /**
+     * Update an existing widget
+     *
+     * @param updateWidgetRequest
+     * @param id
+     */
+    @RequestMapping(
+        value = ["/widgets/{id}"],
+        produces = [],
+        method = [RequestMethod.PUT],
+        consumes = ["application/json"],
+    )
+    public fun updateWidget(
+        @RequestBody @Valid updateWidgetRequest: UpdateWidgetRequest,
+        @PathVariable(value = "id", required = true) id: String,
+    ): ResponseEntity<Unit>
+}

--- a/src/test/resources/examples/requestBodiesSchema/models/CreateWidgetRequest.kt
+++ b/src/test/resources/examples/requestBodiesSchema/models/CreateWidgetRequest.kt
@@ -1,0 +1,20 @@
+package examples.requestBodiesSchema.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.Int
+import kotlin.String
+
+public data class CreateWidgetRequest(
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  @get:NotNull
+  public val name: String,
+  @param:JsonProperty(
+    "count",
+    required = true,
+  )
+  @get:JsonProperty("count")
+  @get:NotNull
+  public val count: Int,
+)

--- a/src/test/resources/examples/requestBodiesSchema/models/UpdateWidgetRequest.kt
+++ b/src/test/resources/examples/requestBodiesSchema/models/UpdateWidgetRequest.kt
@@ -1,0 +1,15 @@
+package examples.requestBodiesSchema.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class UpdateWidgetRequest(
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  @get:NotNull
+  public val name: String,
+  @param:JsonProperty("description")
+  @get:JsonProperty("description")
+  public val description: String? = null,
+)

--- a/src/test/resources/examples/responsesSchema/api.yaml
+++ b/src/test/resources/examples/responsesSchema/api.yaml
@@ -1,4 +1,17 @@
 openapi: 3.0.0
+info:
+  title: Responses Schema Test
+  version: 1.0.0
+paths:
+  /things:
+    get:
+      operationId: getThing
+      tags:
+        - things
+      summary: Returns a thing using a ref-backed response — controller should use SharedModel
+      responses:
+        '200':
+          $ref: '#/components/responses/ReferencedResponse'
 components:
   schemas:
     SharedModel:

--- a/src/test/resources/examples/responsesSchema/api.yaml
+++ b/src/test/resources/examples/responsesSchema/api.yaml
@@ -1,5 +1,13 @@
 openapi: 3.0.0
 components:
+  schemas:
+    SharedModel:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
   responses:
     ErrorResponse:
       description: "Response on error"
@@ -26,3 +34,9 @@ components:
             properties:
               message:
                 type: string
+    ReferencedResponse:
+      description: "Response whose schema is a $ref — should NOT generate a duplicate class"
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SharedModel'

--- a/src/test/resources/examples/responsesSchema/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/responsesSchema/controllers/spring/Controllers.kt
@@ -1,0 +1,24 @@
+package examples.responsesSchema.controllers
+
+import examples.responsesSchema.models.SharedModel
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface ThingsController {
+    /**
+     * Returns a thing using a ref-backed response — controller should use SharedModel
+     */
+    @RequestMapping(
+        value = ["/things"],
+        produces = ["application/json"],
+        method = [RequestMethod.GET],
+    )
+    public fun getThing(): ResponseEntity<SharedModel>
+}

--- a/src/test/resources/examples/responsesSchema/models/SharedModel.kt
+++ b/src/test/resources/examples/responsesSchema/models/SharedModel.kt
@@ -1,0 +1,12 @@
+package examples.responsesSchema.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class SharedModel(
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  @get:NotNull
+  public val name: String,
+)


### PR DESCRIPTION
Fabrikt previously only generated models from `components/schemas`, `components/parameters`, and `components/responses`. This adds support for `components/requestBodies`.

### Changes:

 - Inline schemas in `components/requestBodies` are now included in `allSchemas` and generate model classes, using the request body name as the class name (e.g. `CreateWidgetRequest`)
 - `$ref`-backed request body and response schemas are excluded (using `Overlay.pathFromRoot`) to avoid generating duplicate classes for already-named schemas
 - Inline requestBody and response schemas are pre-registered in `ModelNameRegistry` so that controller and client code resolves to the correct type — not the generic `safeName()` fallback
 - Composition schemas (`oneOf`/`anyOf`) in request bodies are excluded from pre-registration as they are already handled by sealed interface detection

Tests:

 - `requestBodiesSchema — validates model generation and Spring controller parameter types for inline request body schemas
 - `responsesSchemas` — validates that $ref-backed response schemas do not generate duplicate classes
 
 Closes #20 