### PR TITLE
fix: propagate nullable: true on response schema to controller return type

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
@@ -28,7 +28,7 @@ object ControllerGeneratorUtils {
             .contentMediaTypes
             .mapNotNull { it.value?.schema }
             .firstOrNull()
-            ?.let { toModelType(basePackage, KotlinTypeInfo.from(it)) }
+            ?.let { toModelType(basePackage, KotlinTypeInfo.from(it), it.isNullable) }
             ?: Unit::class.asTypeName()
 
     private fun Operation.primarySuccessResponse(): Response =

--- a/src/test/resources/examples/singleAllOf/api.yaml
+++ b/src/test/resources/examples/singleAllOf/api.yaml
@@ -13,6 +13,7 @@ paths:
 components:
   schemas:
     Result:
+      nullable: true
       allOf:
         - $ref: '#/components/schemas/Base'
 

--- a/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/ktor/Controllers.kt
@@ -21,12 +21,12 @@ import kotlin.Suppress
 
 public interface TestController {
     /**
-     * Route is expected to respond with [examples.singleAllOf.models.Result].
+     * Route is expected to respond with [examples.singleAllOf.models.Result?].
      * Use [examples.singleAllOf.controllers.TypedApplicationCall.respondTyped] to send the response.
      *
      * @param call Decorated ApplicationCall with additional typed respond methods
      */
-    public suspend fun test(call: TypedApplicationCall<Result>)
+    public suspend fun test(call: TypedApplicationCall<Result?>)
 
     public companion object {
         /**

--- a/src/test/resources/examples/singleAllOf/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/micronaut/Controllers.kt
@@ -14,5 +14,5 @@ public interface TestController {
      */
     @Get(uri = "/test")
     @Produces(value = ["application/json"])
-    public fun test(): HttpResponse<Result>
+    public fun test(): HttpResponse<Result?>
 }

--- a/src/test/resources/examples/singleAllOf/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/singleAllOf/controllers/spring/Controllers.kt
@@ -20,5 +20,5 @@ public interface TestController {
         produces = ["application/json"],
         method = [RequestMethod.GET],
     )
-    public fun test(): ResponseEntity<Result>
+    public fun test(): ResponseEntity<Result?>
 }


### PR DESCRIPTION
When a response schema has `nullable: true` (OAS 3.0) or an equivalent nullable union type that has been downgraded from OAS 3.1, the generated Spring/Micronaut/Ktor controller method now returns `ResponseEntity<Foo?>` instead of `ResponseEntity<Foo>`.

The fix is a one-liner in `singleSchemaResponseType`: pass `schema.isNullable` to `toModelType`, which already accepted an `isNullable` flag but was never given it in this path.

Adds a new `nullableResponse` test example (OAS 3.0 spec with `nullable: true` on a response schema + a no-body 304) to validate the generated controller signature end-to-end.

Closed #412