### PR TITLE
feat: opt-in Jackson DEDUCTION for discriminator-less inline oneOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This library was built to take advantage of the complex modeling features availa
  - GraalVM Native Reflection Registration
  - Json Merge Patch (via `JsonNullable`) (add `x-json-merge-patch: true` to schemas)
  - Override Jackson Include NonNull (via `JsonInclude`) (add `x-jackson-include-non-null: true` to schemas)
- - Type discriminator-less inline `oneOf` properties as the sealed super-interface using Jackson's deduction-based polymorphism (add `x-fabrikt-jackson-deduction: true` to the `oneOf` schema; subtypes need distinguishing required fields)
+ - Type discriminator-less inline `oneOf` properties as the sealed super-interface using Jackson's deduction-based polymorphism (add `x-jackson-subtype-deduction: true` to the `oneOf` schema; subtypes need distinguishing required fields)
  
 as well as HTTP clients and controllers for a number of popular frameworks (see [Features](#features)).
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This library was built to take advantage of the complex modeling features availa
  - GraalVM Native Reflection Registration
  - Json Merge Patch (via `JsonNullable`) (add `x-json-merge-patch: true` to schemas)
  - Override Jackson Include NonNull (via `JsonInclude`) (add `x-jackson-include-non-null: true` to schemas)
+ - Type discriminator-less inline `oneOf` properties as the sealed super-interface using Jackson's deduction-based polymorphism (add `x-fabrikt-jackson-deduction: true` to the `oneOf` schema; subtypes need distinguishing required fields)
  
 as well as HTTP clients and controllers for a number of popular frameworks (see [Features](#features)).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This library was built to take advantage of the complex modeling features availa
  - GraalVM Native Reflection Registration
  - Json Merge Patch (via `JsonNullable`) (add `x-json-merge-patch: true` to schemas)
  - Override Jackson Include NonNull (via `JsonInclude`) (add `x-jackson-include-non-null: true` to schemas)
- - Type discriminator-less inline `oneOf` properties as the sealed super-interface using Jackson's deduction-based polymorphism (add `x-jackson-subtype-deduction: true` to the `oneOf` schema; subtypes need distinguishing required fields)
+ - Jackson's polymorphic subtype deduction (add `x-jackson-subtype-deduction: true` to the `oneOf` schema) to gain Sealed Interface polymorphism, without needing to declare a discriminator property. Requires subtypes to have distinguishing required fields.
  
 as well as HTTP clients and controllers for a number of popular frameworks (see [Features](#features)).
 

--- a/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfWithDeductionTest.kt
+++ b/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfWithDeductionTest.kt
@@ -25,30 +25,6 @@ class DiscriminatorlessOneOfWithDeductionTest {
     private val objectMapper = mapper()
 
     @Test
-    fun `serialization uses runtime type - NetworkFailure unique field emitted`() {
-        val report = DiagnosticReport(
-            failure = NetworkFailure(kind = "network", retries = 3),
-        )
-
-        val json = objectMapper.writeValueAsString(report)
-
-        assertThat(json).contains("\"kind\":\"network\"")
-        assertThat(json).contains("\"retries\":3")
-    }
-
-    @Test
-    fun `serialization uses runtime type - DnsFailure unique field emitted`() {
-        val report = DiagnosticReport(
-            failure = DnsFailure(kind = "dns", host = "example.com"),
-        )
-
-        val json = objectMapper.writeValueAsString(report)
-
-        assertThat(json).contains("\"kind\":\"dns\"")
-        assertThat(json).contains("\"host\":\"example.com\"")
-    }
-
-    @Test
     fun `deserialization deduces NetworkFailure from retries field`() {
         val json = """{"failure":{"kind":"network","retries":3}}"""
 

--- a/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfWithDeductionTest.kt
+++ b/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfWithDeductionTest.kt
@@ -8,18 +8,9 @@ import com.example.oneof.models.NetworkFailure
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-/**
- * Demonstrates Jackson serde behaviour for a discriminator-less inline oneOf that opts into
- * `x-fabrikt-jackson-deduction: true`.
- *
- * Unlike [DiscriminatorlessOneOfTest] (where the property stays `Any?`), the property is typed as
- * the sealed super-interface [DiagnosticReportFailure]. Jackson dispatches to the correct subtype
- * by deduction — inspecting which properties are present in the JSON. Subtypes have distinguishing
- * required fields (`retries` vs `host`) so deduction is unambiguous.
- *
- * Constraint: subtypes must have distinguishing required properties for deduction to succeed; if
- * they don't, deserialization fails at runtime.
- */
+/** Counterpart to [DiscriminatorlessOneOfTest]: opting into `x-jackson-subtype-deduction`
+ *  types the property as the sealed interface and lets Jackson dispatch by required-property
+ *  shape (`retries` vs `host`). */
 class DiscriminatorlessOneOfWithDeductionTest {
 
     private val objectMapper = mapper()

--- a/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfWithDeductionTest.kt
+++ b/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/DiscriminatorlessOneOfWithDeductionTest.kt
@@ -1,0 +1,89 @@
+package com.cjbooms.fabrikt.models.jackson
+
+import com.cjbooms.fabrikt.models.jackson.Helpers.mapper
+import com.example.oneof.models.DiagnosticReport
+import com.example.oneof.models.DiagnosticReportFailure
+import com.example.oneof.models.DnsFailure
+import com.example.oneof.models.NetworkFailure
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Demonstrates Jackson serde behaviour for a discriminator-less inline oneOf that opts into
+ * `x-fabrikt-jackson-deduction: true`.
+ *
+ * Unlike [DiscriminatorlessOneOfTest] (where the property stays `Any?`), the property is typed as
+ * the sealed super-interface [DiagnosticReportFailure]. Jackson dispatches to the correct subtype
+ * by deduction — inspecting which properties are present in the JSON. Subtypes have distinguishing
+ * required fields (`retries` vs `host`) so deduction is unambiguous.
+ *
+ * Constraint: subtypes must have distinguishing required properties for deduction to succeed; if
+ * they don't, deserialization fails at runtime.
+ */
+class DiscriminatorlessOneOfWithDeductionTest {
+
+    private val objectMapper = mapper()
+
+    @Test
+    fun `serialization uses runtime type - NetworkFailure unique field emitted`() {
+        val report = DiagnosticReport(
+            failure = NetworkFailure(kind = "network", retries = 3),
+        )
+
+        val json = objectMapper.writeValueAsString(report)
+
+        assertThat(json).contains("\"kind\":\"network\"")
+        assertThat(json).contains("\"retries\":3")
+    }
+
+    @Test
+    fun `serialization uses runtime type - DnsFailure unique field emitted`() {
+        val report = DiagnosticReport(
+            failure = DnsFailure(kind = "dns", host = "example.com"),
+        )
+
+        val json = objectMapper.writeValueAsString(report)
+
+        assertThat(json).contains("\"kind\":\"dns\"")
+        assertThat(json).contains("\"host\":\"example.com\"")
+    }
+
+    @Test
+    fun `deserialization deduces NetworkFailure from retries field`() {
+        val json = """{"failure":{"kind":"network","retries":3}}"""
+
+        val result = objectMapper.readValue(json, DiagnosticReport::class.java)
+
+        val failure: DiagnosticReportFailure? = result.failure
+        assertThat(failure).isInstanceOf(NetworkFailure::class.java)
+        val network = failure as NetworkFailure
+        assertThat(network.kind).isEqualTo("network")
+        assertThat(network.retries).isEqualTo(3)
+    }
+
+    @Test
+    fun `deserialization deduces DnsFailure from host field`() {
+        val json = """{"failure":{"kind":"dns","host":"example.com"}}"""
+
+        val result = objectMapper.readValue(json, DiagnosticReport::class.java)
+
+        val failure: DiagnosticReportFailure? = result.failure
+        assertThat(failure).isInstanceOf(DnsFailure::class.java)
+        val dns = failure as DnsFailure
+        assertThat(dns.kind).isEqualTo("dns")
+        assertThat(dns.host).isEqualTo("example.com")
+    }
+
+    @Test
+    fun `round-trip preserves runtime subtype and all fields`() {
+        val original = DiagnosticReport(
+            failure = NetworkFailure(kind = "network", retries = 7),
+        )
+
+        val json = objectMapper.writeValueAsString(original)
+        val deserialized = objectMapper.readValue(json, DiagnosticReport::class.java)
+
+        assertThat(deserialized.failure).isInstanceOf(NetworkFailure::class.java)
+        assertThat(deserialized).isEqualTo(original)
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
@@ -84,4 +84,19 @@ object JacksonMetadata {
         return AnnotationSpec.builder(JSON_SUB_TYPES_CLASS)
             .addMember(codeBuilder.build()).build()
     }
+
+    fun deductionPolymorphicType(): AnnotationSpec = AnnotationSpec
+        .builder(JSON_TYPE_INFO_CLASS)
+        .addMember("use = %T.Id.DEDUCTION", JSON_TYPE_INFO_CLASS)
+        .build()
+
+    fun deductionPolymorphicSubTypes(types: List<TypeName>): AnnotationSpec {
+        val codeBuilder = CodeBlock.builder()
+        types.forEach { type ->
+            if (codeBuilder.isNotEmpty()) codeBuilder.add(",")
+            codeBuilder.add("%T.Type(value = %T::class)", JSON_SUB_TYPES_CLASS, type)
+        }
+        return AnnotationSpec.builder(JSON_SUB_TYPES_CLASS)
+            .addMember(codeBuilder.build()).build()
+    }
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -53,7 +53,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaOfTy
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedOneOfUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinitionUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeyForSchemaName
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsJacksonDeduction
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsSubTypeDeduction
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeys
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -241,7 +241,7 @@ class ModelGenerator(
                 allSchemas = allSchemas,
                 members = schemaInfo.schema.oneOfSchemas,
                 oneOfSuperInterfaces = schemaInfo.schema.findOneOfSuperInterface(allSchemas.map { it.schema }),
-                requestsDeduction = schemaInfo.schema.requestsJacksonDeduction(),
+                isSubTypeDeductionEnabled = schemaInfo.schema.requestsSubTypeDeduction(),
             )
 
             schemaInfo.schema.isPolymorphicSuperType() && schemaInfo.schema.isPolymorphicSubType(api) ->
@@ -310,7 +310,7 @@ class ModelGenerator(
                                     allSchemas = sourceApi.allSchemas,
                                     members = it.schema.oneOfSchemas,
                                     oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                                    requestsDeduction = it.schema.requestsJacksonDeduction(),
+                                    isSubTypeDeductionEnabled = it.schema.requestsSubTypeDeduction(),
                                 )
                             )
                         }
@@ -367,7 +367,7 @@ class ModelGenerator(
                                 allSchemas = sourceApi.allSchemas,
                                 members = it.schema.oneOfSchemas,
                                 oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                                requestsDeduction = it.schema.requestsJacksonDeduction(),
+                                isSubTypeDeductionEnabled = it.schema.requestsSubTypeDeduction(),
                             )
                         )
                     } else {
@@ -390,7 +390,7 @@ class ModelGenerator(
                                 allSchemas = sourceApi.allSchemas,
                                 members = it.schema.oneOfSchemas,
                                 oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                                requestsDeduction = it.schema.requestsJacksonDeduction(),
+                                isSubTypeDeductionEnabled = it.schema.requestsSubTypeDeduction(),
                             )
                         )
                     } else emptySet()
@@ -437,7 +437,7 @@ class ModelGenerator(
                             allSchemas = sourceApi.allSchemas,
                             members = items.oneOfSchemas,
                             oneOfSuperInterfaces = items.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                            requestsDeduction = items.requestsJacksonDeduction(),
+                            isSubTypeDeductionEnabled = items.requestsSubTypeDeduction(),
                         )
                     )
 
@@ -683,7 +683,7 @@ class ModelGenerator(
         allSchemas: List<SchemaInfo>,
         members: List<Schema>,
         oneOfSuperInterfaces: Set<Schema>,
-        requestsDeduction: Boolean,
+        isSubTypeDeductionEnabled: Boolean,
     ): TypeSpec {
         val interfaceBuilder = TypeSpec.interfaceBuilder(generatedType(packages.base, modelName))
             .addModifiers(KModifier.SEALED)
@@ -702,7 +702,7 @@ class ModelGenerator(
                 )
             }
             serializationAnnotations.addPolymorphicSubTypesAnnotation(interfaceBuilder, kotlinMappings)
-        } else if (requestsDeduction) {
+        } else if (isSubTypeDeductionEnabled) {
             val subTypeNames = members.map { member ->
                 toModelType(packages.base, KotlinTypeInfo.from(member, member.safeName()))
             }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -683,7 +683,7 @@ class ModelGenerator(
         allSchemas: List<SchemaInfo>,
         members: List<Schema>,
         oneOfSuperInterfaces: Set<Schema>,
-        requestsDeduction: Boolean = false,
+        requestsDeduction: Boolean,
     ): TypeSpec {
         val interfaceBuilder = TypeSpec.interfaceBuilder(generatedType(packages.base, modelName))
             .addModifiers(KModifier.SEALED)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -53,6 +53,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaOfTy
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedOneOfUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinitionUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeyForSchemaName
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsJacksonDeduction
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeys
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -240,6 +241,7 @@ class ModelGenerator(
                 allSchemas = allSchemas,
                 members = schemaInfo.schema.oneOfSchemas,
                 oneOfSuperInterfaces = schemaInfo.schema.findOneOfSuperInterface(allSchemas.map { it.schema }),
+                requestsDeduction = schemaInfo.schema.requestsJacksonDeduction(),
             )
 
             schemaInfo.schema.isPolymorphicSuperType() && schemaInfo.schema.isPolymorphicSubType(api) ->
@@ -307,7 +309,8 @@ class ModelGenerator(
                                     discriminator = it.schema.discriminator,
                                     allSchemas = sourceApi.allSchemas,
                                     members = it.schema.oneOfSchemas,
-                                    oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema })
+                                    oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
+                                    requestsDeduction = it.schema.requestsJacksonDeduction(),
                                 )
                             )
                         }
@@ -363,7 +366,8 @@ class ModelGenerator(
                                 discriminator = it.schema.discriminator,
                                 allSchemas = sourceApi.allSchemas,
                                 members = it.schema.oneOfSchemas,
-                                oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema })
+                                oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
+                                requestsDeduction = it.schema.requestsJacksonDeduction(),
                             )
                         )
                     } else {
@@ -385,7 +389,8 @@ class ModelGenerator(
                                 discriminator = it.schema.discriminator,
                                 allSchemas = sourceApi.allSchemas,
                                 members = it.schema.oneOfSchemas,
-                                oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema })
+                                oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
+                                requestsDeduction = it.schema.requestsJacksonDeduction(),
                             )
                         )
                     } else emptySet()
@@ -431,7 +436,8 @@ class ModelGenerator(
                             discriminator = items.discriminator,
                             allSchemas = sourceApi.allSchemas,
                             members = items.oneOfSchemas,
-                            oneOfSuperInterfaces = items.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema })
+                            oneOfSuperInterfaces = items.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
+                            requestsDeduction = items.requestsJacksonDeduction(),
                         )
                     )
 
@@ -677,6 +683,7 @@ class ModelGenerator(
         allSchemas: List<SchemaInfo>,
         members: List<Schema>,
         oneOfSuperInterfaces: Set<Schema>,
+        requestsDeduction: Boolean = false,
     ): TypeSpec {
         val interfaceBuilder = TypeSpec.interfaceBuilder(generatedType(packages.base, modelName))
             .addModifiers(KModifier.SEALED)
@@ -695,6 +702,11 @@ class ModelGenerator(
                 )
             }
             serializationAnnotations.addPolymorphicSubTypesAnnotation(interfaceBuilder, kotlinMappings)
+        } else if (requestsDeduction) {
+            val subTypeNames = members.map { member ->
+                toModelType(packages.base, KotlinTypeInfo.from(member, member.safeName()))
+            }
+            serializationAnnotations.addDeductionPolymorphicTypeAnnotation(interfaceBuilder, subTypeNames)
         }
 
         for (oneOfSuperInterface in oneOfSuperInterfaces) {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -53,7 +53,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaOfTy
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedOneOfUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinitionUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeyForSchemaName
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsSubTypeDeduction
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSubTypeDeductionEnabled
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeys
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -241,7 +241,7 @@ class ModelGenerator(
                 allSchemas = allSchemas,
                 members = schemaInfo.schema.oneOfSchemas,
                 oneOfSuperInterfaces = schemaInfo.schema.findOneOfSuperInterface(allSchemas.map { it.schema }),
-                isSubTypeDeductionEnabled = schemaInfo.schema.requestsSubTypeDeduction(),
+                isSubTypeDeductionEnabled = schemaInfo.schema.isSubTypeDeductionEnabled(),
             )
 
             schemaInfo.schema.isPolymorphicSuperType() && schemaInfo.schema.isPolymorphicSubType(api) ->
@@ -310,7 +310,7 @@ class ModelGenerator(
                                     allSchemas = sourceApi.allSchemas,
                                     members = it.schema.oneOfSchemas,
                                     oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                                    isSubTypeDeductionEnabled = it.schema.requestsSubTypeDeduction(),
+                                    isSubTypeDeductionEnabled = it.schema.isSubTypeDeductionEnabled(),
                                 )
                             )
                         }
@@ -367,7 +367,7 @@ class ModelGenerator(
                                 allSchemas = sourceApi.allSchemas,
                                 members = it.schema.oneOfSchemas,
                                 oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                                isSubTypeDeductionEnabled = it.schema.requestsSubTypeDeduction(),
+                                isSubTypeDeductionEnabled = it.schema.isSubTypeDeductionEnabled(),
                             )
                         )
                     } else {
@@ -390,7 +390,7 @@ class ModelGenerator(
                                 allSchemas = sourceApi.allSchemas,
                                 members = it.schema.oneOfSchemas,
                                 oneOfSuperInterfaces = it.schema.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                                isSubTypeDeductionEnabled = it.schema.requestsSubTypeDeduction(),
+                                isSubTypeDeductionEnabled = it.schema.isSubTypeDeductionEnabled(),
                             )
                         )
                     } else emptySet()
@@ -437,7 +437,7 @@ class ModelGenerator(
                             allSchemas = sourceApi.allSchemas,
                             members = items.oneOfSchemas,
                             oneOfSuperInterfaces = items.findOneOfSuperInterface(sourceApi.allSchemas.map { it.schema }),
-                            isSubTypeDeductionEnabled = items.requestsSubTypeDeduction(),
+                            isSubTypeDeductionEnabled = items.isSubTypeDeductionEnabled(),
                         )
                     )
 
@@ -706,7 +706,7 @@ class ModelGenerator(
             val subTypeNames = members.map { member ->
                 toModelType(packages.base, KotlinTypeInfo.from(member, member.safeName()))
             }
-            serializationAnnotations.addDeductionPolymorphicTypeAnnotation(interfaceBuilder, subTypeNames)
+            serializationAnnotations.addPolymorphicSubTypeDeductionAnnotation(interfaceBuilder, subTypeNames)
         }
 
         for (oneOfSuperInterface in oneOfSuperInterfaces) {

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
@@ -4,6 +4,8 @@ import com.cjbooms.fabrikt.generators.model.JacksonMetadata
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.JSON_ENUM_DEFAULT_VALUE
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.JSON_VALUE
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.basePolymorphicType
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.deductionPolymorphicSubTypes
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.deductionPolymorphicType
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.polymorphicSubTypes
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
@@ -42,6 +44,11 @@ object JacksonAnnotations : SerializationAnnotations {
 
     override fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>) =
         typeSpecBuilder.addAnnotation(polymorphicSubTypes(mappings, enumDiscriminator = null))
+
+    override fun addDeductionPolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
+        typeSpecBuilder
+            .addAnnotation(deductionPolymorphicType())
+            .addAnnotation(deductionPolymorphicSubTypes(subTypes))
 
     override fun addSubtypeMappingAnnotation(typeSpecBuilder: TypeSpec.Builder, mapping: String) =
         typeSpecBuilder

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
@@ -45,7 +45,7 @@ object JacksonAnnotations : SerializationAnnotations {
     override fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>) =
         typeSpecBuilder.addAnnotation(polymorphicSubTypes(mappings, enumDiscriminator = null))
 
-    override fun addDeductionPolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
+    override fun addPolymorphicSubTypeDeductionAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
         typeSpecBuilder
             .addAnnotation(deductionPolymorphicType())
             .addAnnotation(deductionPolymorphicSubTypes(subTypes))

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -12,8 +12,10 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedDiscriminatedOne
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedTypedAdditionalProperties
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isNotDefined
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterfaceWithDiscriminator
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaWithOneOf
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsJacksonDeduction
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaOfTypeObject
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isUnsupportedComplexInlinedDefinition
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -172,7 +174,11 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
 
                 OasType.Any -> AnyType
                 OasType.OneOfAny ->
-                    if (schema.isOneOfSuperInterfaceWithDiscriminator()) {
+                    if (schema.isOneOfSuperInterfaceWithDiscriminator() ||
+                        (schema.isOneOfSuperInterface() &&
+                            schema.requestsJacksonDeduction() &&
+                            MutableSettings.serializationLibrary != KOTLINX_SERIALIZATION)
+                    ) {
                         Object(ModelNameRegistry.getOrRegister(schema, enclosingSchema))
                     } else {
                         AnyType

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -15,7 +15,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isNotDefined
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterfaceWithDiscriminator
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaWithOneOf
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsJacksonDeduction
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsSubTypeDeduction
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaOfTypeObject
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isUnsupportedComplexInlinedDefinition
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -176,7 +176,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                 OasType.OneOfAny ->
                     if (schema.isOneOfSuperInterfaceWithDiscriminator() ||
                         (schema.isOneOfSuperInterface() &&
-                            schema.requestsJacksonDeduction() &&
+                            schema.requestsSubTypeDeduction() &&
                             MutableSettings.serializationLibrary != KOTLINX_SERIALIZATION)
                     ) {
                         Object(ModelNameRegistry.getOrRegister(schema, enclosingSchema))

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -15,7 +15,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isNotDefined
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterfaceWithDiscriminator
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaWithOneOf
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsSubTypeDeduction
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSubTypeDeductionEnabled
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.hasInlinedItemsSchemaOfTypeObject
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isUnsupportedComplexInlinedDefinition
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -176,7 +176,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                 OasType.OneOfAny ->
                     if (schema.isOneOfSuperInterfaceWithDiscriminator() ||
                         (schema.isOneOfSuperInterface() &&
-                            schema.requestsSubTypeDeduction() &&
+                            schema.isSubTypeDeductionEnabled() &&
                             MutableSettings.serializationLibrary != KOTLINX_SERIALIZATION)
                     ) {
                         Object(ModelNameRegistry.getOrRegister(schema, enclosingSchema))

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
@@ -101,6 +101,9 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
     override fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>) =
         typeSpecBuilder // not applicable
 
+    override fun addDeductionPolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
+        typeSpecBuilder // not applicable — kotlinx requires a class discriminator field
+
     override fun addSubtypeMappingAnnotation(typeSpecBuilder: TypeSpec.Builder, mapping: String) =
         typeSpecBuilder.addAnnotation(AnnotationSpec.builder(SerialName::class).addMember("%S", mapping).build())
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
@@ -101,7 +101,7 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
     override fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>) =
         typeSpecBuilder // not applicable
 
-    override fun addDeductionPolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
+    override fun addPolymorphicSubTypeDeductionAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
         typeSpecBuilder // not applicable — kotlinx requires a class discriminator field
 
     override fun addSubtypeMappingAnnotation(typeSpecBuilder: TypeSpec.Builder, mapping: String) =

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -137,7 +137,7 @@ sealed class PropertyInfo {
                                 schema = property.value,
                                 isInherited = settings.markAsInherited,
                                 parentSchema = this,
-                                enclosingSchema = enclosingSchema ?: this,
+                                enclosingSchema = enclosingSchema
                             )
                         else
                             ObjectRefField(

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -9,6 +9,8 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedDiscriminatedOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsJacksonDeduction
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedItemsSchemaUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isRequired
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
@@ -125,7 +127,8 @@ sealed class PropertyInfo {
                                 isInherited = settings.markAsInherited,
                                 parentSchema = this
                             )
-                        else if (property.value.isInlinedObjectDefinition())
+                        else if (property.value.isInlinedObjectDefinition() ||
+                            (property.value.isOneOfSuperInterface() && property.value.requestsJacksonDeduction()))
                             ObjectInlinedField(
                                 isRequired = isRequired(
                                     api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields
@@ -134,7 +137,7 @@ sealed class PropertyInfo {
                                 schema = property.value,
                                 isInherited = settings.markAsInherited,
                                 parentSchema = this,
-                                enclosingSchema = enclosingSchema
+                                enclosingSchema = enclosingSchema ?: this,
                             )
                         else
                             ObjectRefField(

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -10,7 +10,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedDiscriminatedOne
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsJacksonDeduction
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsSubTypeDeduction
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedItemsSchemaUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isRequired
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
@@ -128,7 +128,7 @@ sealed class PropertyInfo {
                                 parentSchema = this
                             )
                         else if (property.value.isInlinedObjectDefinition() ||
-                            (property.value.isOneOfSuperInterface() && property.value.requestsJacksonDeduction()))
+                            (property.value.isOneOfSuperInterface() && property.value.requestsSubTypeDeduction()))
                             ObjectInlinedField(
                                 isRequired = isRequired(
                                     api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -10,7 +10,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedDiscriminatedOne
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedObjectDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.requestsSubTypeDeduction
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSubTypeDeductionEnabled
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedItemsSchemaUnderTopLevelArrayDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isRequired
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
@@ -128,7 +128,7 @@ sealed class PropertyInfo {
                                 parentSchema = this
                             )
                         else if (property.value.isInlinedObjectDefinition() ||
-                            (property.value.isOneOfSuperInterface() && property.value.requestsSubTypeDeduction()))
+                            (property.value.isOneOfSuperInterface() && property.value.isSubTypeDeductionEnabled()))
                             ObjectInlinedField(
                                 isRequired = isRequired(
                                     api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -30,6 +30,20 @@ sealed interface SerializationAnnotations {
     fun addClassAnnotation(typeSpecBuilder: TypeSpec.Builder): TypeSpec.Builder
     fun addBasePolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, propertyName: String): TypeSpec.Builder
     fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>): TypeSpec.Builder
+
+    /**
+     * Emit annotations enabling discriminator-less polymorphic deserialization for the sealed
+     * super-interface — Jackson uses `@JsonTypeInfo(use = DEDUCTION)` + `@JsonSubTypes(...)` so it
+     * can pick the subtype by inspecting which properties are present in the JSON.
+     *
+     * Other libraries (kotlinx) have no DEDUCTION equivalent and treat this as a no-op; the
+     * source property type stays `Any?` for them in `KotlinTypeInfo.from`.
+     */
+    fun addDeductionPolymorphicTypeAnnotation(
+        typeSpecBuilder: TypeSpec.Builder,
+        subTypes: List<TypeName>,
+    ): TypeSpec.Builder
+
     fun addSubtypeMappingAnnotation(typeSpecBuilder: TypeSpec.Builder, mapping: String): TypeSpec.Builder
     fun addEnumPropertyAnnotation(propSpecBuilder: PropertySpec.Builder): PropertySpec.Builder
     fun addEnumConstantAnnotation(enumSpecBuilder: TypeSpec.Builder, enumValue: String): TypeSpec.Builder

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -31,14 +31,8 @@ sealed interface SerializationAnnotations {
     fun addBasePolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, propertyName: String): TypeSpec.Builder
     fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>): TypeSpec.Builder
 
-    /**
-     * Emit annotations enabling discriminator-less polymorphic deserialization for the sealed
-     * super-interface — Jackson uses `@JsonTypeInfo(use = DEDUCTION)` + `@JsonSubTypes(...)` so it
-     * can pick the subtype by inspecting which properties are present in the JSON.
-     *
-     * Other libraries (kotlinx) have no DEDUCTION equivalent and treat this as a no-op; the
-     * source property type stays `Any?` for them in `KotlinTypeInfo.from`.
-     */
+    /** Discriminator-less polymorphism for the sealed super-interface. No-op for libraries
+     *  without a deduction equivalent (e.g. kotlinx). */
     fun addDeductionPolymorphicTypeAnnotation(
         typeSpecBuilder: TypeSpec.Builder,
         subTypes: List<TypeName>,

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -33,7 +33,7 @@ sealed interface SerializationAnnotations {
 
     /** Discriminator-less polymorphism for the sealed super-interface. No-op for libraries
      *  without a deduction equivalent (e.g. kotlinx). */
-    fun addDeductionPolymorphicTypeAnnotation(
+    fun addPolymorphicSubTypeDeductionAnnotation(
         typeSpecBuilder: TypeSpec.Builder,
         subTypes: List<TypeName>,
     ): TypeSpec.Builder

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -376,17 +376,12 @@ object KaizenParserExtensions {
     fun Schema.isOneOfSuperInterfaceWithDiscriminator() =
         discriminator != null && discriminator.propertyName != null && isOneOfSuperInterface()
 
-    /**
-     * Per-schema opt-in: `x-fabrikt-jackson-deduction: true` on a discriminator-less inline
-     * `oneOf` schema asks the generator to type the property as the sealed super-interface and
-     * emit `@JsonTypeInfo(use = DEDUCTION)` so Jackson can dispatch by inspecting which
-     * properties are present in the JSON. Subtypes must have distinguishing required fields —
-     * if they don't, deserialization fails at runtime.
-     */
-    fun Schema.requestsJacksonDeduction(): Boolean =
-        extensions[X_FABRIKT_JACKSON_DEDUCTION] as? Boolean == true
+    /** Per-schema opt-in for Jackson DEDUCTION-style polymorphism. Subtypes must have
+     *  distinguishing required fields or deserialization fails at runtime. */
+    fun Schema.requestsSubTypeDeduction(): Boolean =
+        extensions[X_JACKSON_SUBTYPE_DEDUCTION] as? Boolean == true
 
-    private const val X_FABRIKT_JACKSON_DEDUCTION = "x-fabrikt-jackson-deduction"
+    private const val X_JACKSON_SUBTYPE_DEDUCTION = "x-jackson-subtype-deduction"
 
     private fun Schema.isInlinedAggregationOfExactlyOne() =
         combinedAnyOfAndAllOfSchemas().size == 1 && isInlinedPropertySchema()

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -376,6 +376,18 @@ object KaizenParserExtensions {
     fun Schema.isOneOfSuperInterfaceWithDiscriminator() =
         discriminator != null && discriminator.propertyName != null && isOneOfSuperInterface()
 
+    /**
+     * Per-schema opt-in: `x-fabrikt-jackson-deduction: true` on a discriminator-less inline
+     * `oneOf` schema asks the generator to type the property as the sealed super-interface and
+     * emit `@JsonTypeInfo(use = DEDUCTION)` so Jackson can dispatch by inspecting which
+     * properties are present in the JSON. Subtypes must have distinguishing required fields —
+     * if they don't, deserialization fails at runtime.
+     */
+    fun Schema.requestsJacksonDeduction(): Boolean =
+        extensions[X_FABRIKT_JACKSON_DEDUCTION] as? Boolean == true
+
+    private const val X_FABRIKT_JACKSON_DEDUCTION = "x-fabrikt-jackson-deduction"
+
     private fun Schema.isInlinedAggregationOfExactlyOne() =
         combinedAnyOfAndAllOfSchemas().size == 1 && isInlinedPropertySchema()
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -378,7 +378,7 @@ object KaizenParserExtensions {
 
     /** Per-schema opt-in for Jackson DEDUCTION-style polymorphism. Subtypes must have
      *  distinguishing required fields or deserialization fails at runtime. */
-    fun Schema.requestsSubTypeDeduction(): Boolean =
+    fun Schema.isSubTypeDeductionEnabled(): Boolean =
         extensions[X_JACKSON_SUBTYPE_DEDUCTION] as? Boolean == true
 
     private const val X_JACKSON_SUBTYPE_DEDUCTION = "x-jackson-subtype-deduction"

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -293,12 +293,9 @@ components:
             - $ref: '#/components/schemas/ValidationErr'
             - $ref: '#/components/schemas/ServerErr'
 
-    # Discriminator-less inline oneOf with x-fabrikt-jackson-deduction: true on the property.
-    # Subtypes have distinguishing required fields (retries vs host), so Jackson DEDUCTION can
-    # pick the correct subtype. The property is typed as the sealed interface
-    # (DiagnosticReportFailure?) and the interface gets @JsonTypeInfo(use = DEDUCTION) +
-    # @JsonSubTypes(...). Kotlinx ignores the extension and keeps Any? — kotlinx has no
-    # DEDUCTION equivalent.
+    # Opted into Jackson DEDUCTION via x-jackson-subtype-deduction. Subtypes (NetworkFailure,
+    # DnsFailure) have distinguishing required fields (retries vs host) so Jackson can pick
+    # the right subtype. Kotlinx has no DEDUCTION equivalent and falls back to Any?.
     NetworkFailure:
       type: object
       required:
@@ -323,7 +320,7 @@ components:
       type: object
       properties:
         failure:
-          x-fabrikt-jackson-deduction: true
+          x-jackson-subtype-deduction: true
           oneOf:
             - $ref: '#/components/schemas/NetworkFailure'
             - $ref: '#/components/schemas/DnsFailure'

--- a/src/test/resources/examples/discriminatedOneOf/api.yaml
+++ b/src/test/resources/examples/discriminatedOneOf/api.yaml
@@ -293,6 +293,41 @@ components:
             - $ref: '#/components/schemas/ValidationErr'
             - $ref: '#/components/schemas/ServerErr'
 
+    # Discriminator-less inline oneOf with x-fabrikt-jackson-deduction: true on the property.
+    # Subtypes have distinguishing required fields (retries vs host), so Jackson DEDUCTION can
+    # pick the correct subtype. The property is typed as the sealed interface
+    # (DiagnosticReportFailure?) and the interface gets @JsonTypeInfo(use = DEDUCTION) +
+    # @JsonSubTypes(...). Kotlinx ignores the extension and keeps Any? — kotlinx has no
+    # DEDUCTION equivalent.
+    NetworkFailure:
+      type: object
+      required:
+        - kind
+        - retries
+      properties:
+        kind:
+          type: string
+        retries:
+          type: integer
+    DnsFailure:
+      type: object
+      required:
+        - kind
+        - host
+      properties:
+        kind:
+          type: string
+        host:
+          type: string
+    DiagnosticReport:
+      type: object
+      properties:
+        failure:
+          x-fabrikt-jackson-deduction: true
+          oneOf:
+            - $ref: '#/components/schemas/NetworkFailure'
+            - $ref: '#/components/schemas/DnsFailure'
+
     # Named top-level array schemas whose items are a discriminated oneOf.
     # ChildActionsAll covers all members of ParentAction's discriminator mapping —
     # references to it should resolve to List<ParentAction> (the parent type).

--- a/src/test/resources/examples/discriminatedOneOf/models/DiagnosticReport.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/DiagnosticReport.kt
@@ -1,0 +1,11 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.Valid
+
+public data class DiagnosticReport(
+  @param:JsonProperty("failure")
+  @get:JsonProperty("failure")
+  @get:Valid
+  public val failure: DiagnosticReportFailure? = null,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/DiagnosticReportFailure.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/DiagnosticReportFailure.kt
@@ -1,0 +1,9 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes(JsonSubTypes.Type(value = NetworkFailure::class),JsonSubTypes.Type(value =
+    DnsFailure::class))
+public sealed interface DiagnosticReportFailure

--- a/src/test/resources/examples/discriminatedOneOf/models/DnsFailure.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/DnsFailure.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class DnsFailure(
+  @param:JsonProperty("kind")
+  @get:JsonProperty("kind")
+  @get:NotNull
+  public val kind: String,
+  @param:JsonProperty("host")
+  @get:JsonProperty("host")
+  @get:NotNull
+  public val host: String,
+) : DiagnosticReportFailure

--- a/src/test/resources/examples/discriminatedOneOf/models/NetworkFailure.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/NetworkFailure.kt
@@ -1,0 +1,20 @@
+package examples.discriminatedOneOf.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.Int
+import kotlin.String
+
+public data class NetworkFailure(
+  @param:JsonProperty("kind")
+  @get:JsonProperty("kind")
+  @get:NotNull
+  public val kind: String,
+  @param:JsonProperty(
+    "retries",
+    required = true,
+  )
+  @get:JsonProperty("retries")
+  @get:NotNull
+  public val retries: Int,
+) : DiagnosticReportFailure

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiagnosticReport.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiagnosticReport.kt
@@ -1,0 +1,11 @@
+package examples.discriminatedOneOf.models
+
+import kotlin.Any
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class DiagnosticReport(
+  @SerialName("failure")
+  public val failure: Any? = null,
+)

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiagnosticReportFailure.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiagnosticReportFailure.kt
@@ -1,0 +1,6 @@
+package examples.discriminatedOneOf.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public sealed interface DiagnosticReportFailure

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DnsFailure.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DnsFailure.kt
@@ -1,0 +1,16 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class DnsFailure(
+  @SerialName("kind")
+  @get:NotNull
+  public val kind: String,
+  @SerialName("host")
+  @get:NotNull
+  public val host: String,
+) : DiagnosticReportFailure

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/NetworkFailure.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/NetworkFailure.kt
@@ -1,0 +1,17 @@
+package examples.discriminatedOneOf.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.Int
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class NetworkFailure(
+  @SerialName("kind")
+  @get:NotNull
+  public val kind: String,
+  @SerialName("retries")
+  @get:NotNull
+  public val retries: Int,
+) : DiagnosticReportFailure


### PR DESCRIPTION
## Summary

Follow-up to #580 (which reverted #574). Adds an opt-in path that recovers the typed-property ergonomics #574 was reaching for, without the data-loss problems that motivated the revert.

Per-schema vendor extension `x-fabrikt-jackson-deduction: true` on a discriminator-less inline `oneOf` property opts that property into typed polymorphism:

- The field is typed as the sealed super-interface (e.g. `DiagnosticReportFailure?`) instead of `Any?`.
- The interface gets `@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)` + `@JsonSubTypes(...)` so Jackson dispatches by inspecting which properties are present in the JSON.

Default behavior (#580: `Any?` + non-lossy `LinkedHashMap` fallback) is unchanged for any `oneOf` without the extension. The existing `DiscriminatorlessOneOfTest` still passes.

## Why per-schema extension (not a CLI flag)

DEDUCTION is inherently per-schema safe: it only works when subtypes have distinguishing required properties. A spec may have several discriminator-less `oneOf`s — only some of which qualify. A global flag would either force-enable on schemas that fail at runtime, or stay off for schemas that would benefit. The vendor extension lets the spec author opt in only where they've confirmed it's safe.

This also matches the precedent set by `x-jackson-include-non-null`, `x-json-merge-patch`, and `x-async-support` — all per-property/operation opt-ins for serialization-library-specific behavior.

## Generated output

For:

```yaml
DiagnosticReport:
  type: object
  properties:
    failure:
      x-fabrikt-jackson-deduction: true
      oneOf:
        - \$ref: '#/components/schemas/NetworkFailure'
        - \$ref: '#/components/schemas/DnsFailure'
```

Jackson:

```kotlin
data class DiagnosticReport(val failure: DiagnosticReportFailure? = null)

@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
@JsonSubTypes(
  JsonSubTypes.Type(value = NetworkFailure::class),
  JsonSubTypes.Type(value = DnsFailure::class),
)
sealed interface DiagnosticReportFailure
```

Kotlinx (extension ignored — no DEDUCTION equivalent):

```kotlin
data class DiagnosticReport(val failure: Any? = null)
@Serializable sealed interface DiagnosticReportFailure
```

## Constraint

Subtypes must have distinguishing required properties for deduction to succeed. The fixture (`NetworkFailure.retries` vs `DnsFailure.host`) demonstrates this; if subtypes have identical property sets, deserialization fails at runtime. Documented in the helper KDoc and on the test fixture YAML.

## Test plan

- [x] Unit: full `ModelGeneratorTest` + `KotlinSerializationModelGeneratorTest` suites pass — existing fixtures untouched, new fixtures added for the opt-in case (Jackson + kotlinx).
- [x] End-to-end: new `DiscriminatorlessOneOfWithDeductionTest` proves typed round-trip — `objectMapper.readValue(json, DiagnosticReport::class.java).failure` returns a real `NetworkFailure`/`DnsFailure` instance (not a `LinkedHashMap`), and `failure as NetworkFailure` succeeds.
- [x] No regression on `DiscriminatorlessOneOfTest` (the `Any?` baseline added in #580) — opt-in is purely additive.
- [x] Full `./gradlew test` (root + all end2end-tests modules) passes.

cc @cjbooms — this is the follow-up I mentioned would address the gap left after #580. Happy to iterate on naming (`x-fabrikt-jackson-deduction` vs `x-jackson-typeinfo-deduction` vs other) or on whether DEDUCTION should be the right mechanism at all. Marking draft so you can weigh in before we land it.