### PR TITLE
fix #595 support multiple mimetypes for request body

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -193,6 +193,15 @@ object GeneratorUtils {
                 )
             }
             .distinctBy { it.schema.safeName().toKotlinParameterName().ifEmpty { it.schema.toVarName() } }
+            .reduceOrNull { acc, _ ->
+                BodyParameter(
+                    oasName = "body",
+                    description = acc.description,
+                    type = acc.type,
+                    schema = acc.schema
+                )
+            }
+            ?.let { listOf(it) } ?: emptyList()
 
         val parameters = mergeParameters(pathParameters, parameters)
             .map {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -311,6 +311,21 @@ class SpringControllerGeneratorTest {
     }
 
     @Test
+    fun `controller functions consumes multiple mime types in request body`() {
+        val basePackage = "examples.sseEmitter"
+        val api = SourceApi(readTextResource("/examples/springControllerMultipleConsumes/api.yaml"))
+        val expectedControllers = "/examples/springControllerMultipleConsumes/controllers/Controllers.kt"
+
+        val controllers = SpringControllerInterfaceGenerator(
+            Packages(basePackage),
+            api,
+            JavaxValidationAnnotations,
+        ).generate().toSingleFile()
+
+        assertThatGenerated(controllers).isEqualTo(expectedControllers)
+    }
+
+    @Test
     fun `sse controller functions return array if disabled`() {
         val basePackage = "examples.sseEmitter"
         val api = SourceApi(readTextResource("/examples/springControllerSse/api.yaml"))

--- a/src/test/resources/examples/springControllerMultipleConsumes/api.yaml
+++ b/src/test/resources/examples/springControllerMultipleConsumes/api.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.0
+info:
+  description: Some description
+  version: 1.0.0
+  title: The API title
+  contact:
+    name: cjbooms
+    email: api@cjbooms.com
+externalDocs:
+  description: The docs are great.
+  url: http://find.them.here
+
+paths:
+  /internal/upload:
+    post:
+      tags:
+        - upload
+      summary: Upload Images
+      parameters:
+        - name: Content-Type
+          in: header
+          description: mime type of the image, "image/png" or "image/jpeg"
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: image binary data
+        content:
+          image/jpeg:
+            schema:
+              type: string
+              format: byte
+          image/png:
+            schema:
+              type: string
+              format: byte
+          application/octet-stream:
+            schema:
+              type: string
+              format: byte
+      responses:
+        '202':
+          description: upload successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadResponse'
+components:
+  schemas:
+    UploadResponse:
+      type: object
+      additionalProperties: true
+      required:
+        - image_id
+      properties:
+        image_id:
+          type: string
+          description: The id of the image

--- a/src/test/resources/examples/springControllerMultipleConsumes/controllers/Controllers.kt
+++ b/src/test/resources/examples/springControllerMultipleConsumes/controllers/Controllers.kt
@@ -1,0 +1,39 @@
+package examples.sseEmitter.controllers
+
+import examples.sseEmitter.models.UploadResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import javax.validation.Valid
+import kotlin.ByteArray
+import kotlin.String
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface InternalUploadController {
+    /**
+     * Upload Images
+     *
+     * @param body image binary data
+     * @param contentType mime type of the image, "image/png" or "image/jpeg"
+     */
+    @RequestMapping(
+        value = ["/internal/upload"],
+        produces = ["application/json"],
+        method = [RequestMethod.POST],
+        consumes = ["image/jpeg", "image/png", "application/octet-stream"],
+    )
+    public fun post(
+        @RequestBody @Valid body: ByteArray,
+        @RequestHeader(
+            value = "Content-Type",
+            required = true,
+        ) contentType: String,
+    ): ResponseEntity<UploadResponse>
+}


### PR DESCRIPTION
It merges multiple bodyParameters into one (can only be one body per endpoint).
It takes `description`, `type` and `schema` from the first, but changes the name to `body`. 

Should we check for incompatible `type` and `schema` declarations if more than one bodyParameter is declared? Normally they should be the same. Or a fallback to ByteArray if they are different?