### PR TITLE
Escape reserved word query parameters in ktor clients

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
@@ -99,15 +99,15 @@ class KtorClientGenerator(
                                             val isArrayType = param.typeInfo is KotlinTypeInfo.Array
                                             if (isArrayType) {
                                                 if (param.isRequired) {
-                                                    addStatement("%L.forEach { add(\"%L=\${it}\") }", param.name, param.originalName)
+                                                    addStatement("%N.forEach { add(\"%L=\${it}\") }", param.name, param.originalName)
                                                 } else {
-                                                    addStatement("%L?.forEach { add(\"%L=\${it}\") }", param.name, param.originalName)
+                                                    addStatement("%N?.forEach { add(\"%L=\${it}\") }", param.name, param.originalName)
                                                 }
                                             } else {
                                                 if (param.isRequired) {
-                                                    addStatement("add(\"%L=\${%L}\")", param.originalName, param.name)
+                                                    addStatement("add(\"%L=\${%N}\")", param.originalName, param.name)
                                                 } else {
-                                                    addStatement("%L?.let { add(\"%L=\${it}\") }", param.name, param.originalName)
+                                                    addStatement("%N?.let { add(\"%L=\${it}\") }", param.name, param.originalName)
                                                 }
                                             }
                                         }

--- a/src/test/resources/examples/ktorClient/api.yaml
+++ b/src/test/resources/examples/ktorClient/api.yaml
@@ -221,6 +221,49 @@ paths:
         '204':
           description: No content
 
+  /reserved-invalid-words:
+    get:
+      summary: Endpoint with reserved or invalid words as query parameter names
+      operationId: getReservedInvalidWords
+      parameters:
+        - name: for
+          in: query
+          description: what this is for
+          required: true
+          schema:
+            type: string
+        - name: fun
+          in: query
+          description: whether this is fun
+          required: false
+          schema:
+            type: boolean
+        - name: when
+          in: query
+          description: when this is
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Item'
+        - name: if
+          in: query
+          description: if this should exist
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Item'
+        - name: "1234"
+          in: query
+          description: is this 1234?
+          required: true
+          schema:
+            type: boolean
+      responses:
+        '204':
+          description: No content
+
 components:
   schemas:
     SortOrder:

--- a/src/test/resources/examples/ktorClient/client/ktor/KtorClient.kt
+++ b/src/test/resources/examples/ktorClient/client/ktor/KtorClient.kt
@@ -17,6 +17,7 @@ import io.ktor.http.isSuccess
 import io.ktor.serialization.ContentConvertException
 import kotlinx.coroutines.CancellationException
 import java.io.IOException
+import kotlin.Boolean
 import kotlin.Double
 import kotlin.Int
 import kotlin.String
@@ -529,6 +530,89 @@ public class NoContentClient(
     public suspend fun getNoContent(apiConfiguration: ApiConfiguration = ApiConfiguration()): NetworkResult<Unit> {
         val basePath = apiConfiguration.basePath.trimEnd('/')
         val url = basePath + """/no-content"""
+
+        return try {
+            val response =
+                httpClient.`get`(url) {
+                    `header`("Accept", "application/json")
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+}
+
+public class ReservedInvalidWordsClient(
+    private val httpClient: HttpClient,
+) {
+    /**
+     * Endpoint with reserved or invalid words as query parameter names
+     *
+     * Parameters:
+     * 	 @param for what this is for
+     * 	 @param if if this should exist
+     * 	 @param 1234 is this 1234?
+     * 	 @param fun whether this is fun
+     * 	 @param when when this is
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.Unit] if the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun getReservedInvalidWords(
+        `for`: String,
+        `if`: List<Item>,
+        `1234`: Boolean,
+        `fun`: Boolean? = null,
+        `when`: List<Item>? = null,
+        apiConfiguration: ApiConfiguration = ApiConfiguration(),
+    ): NetworkResult<Unit> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url =
+            buildString {
+                append(basePath)
+                append("""/reserved-invalid-words""")
+                val params =
+                    buildList {
+                        add("for=${`for`}")
+                        `if`.forEach { add("if=$it") }
+                        add("1234=${`1234`}")
+                        `fun`?.let { add("fun=$it") }
+                        `when`?.forEach { add("when=$it") }
+                    }
+                if (params.isNotEmpty()) append("?").append(params.joinToString("&"))
+            }
 
         return try {
             val response =


### PR DESCRIPTION
### Background
When attempting to generate a `ktor` API client for [Immich](https://github.com/immich-app/), fabrikt generated invalid code for endpoints with query parameters that are kotlin reserved names (in this case, `for`). I dug in a bit and discovered that the Kotlin identifiers were being passed to KotlinPoet as literals (`%L`) rather than names (`%N`), so they weren't being escaped.

### Changes
I changed all four paths in `KtorClientGenerator`'s query param statement generation to use `%N` when referencing the Kotlin argument itself, and added a new `GET /reserved-invalid-words` endpoint to `examples/ktorClient/api.yaml` that covers those four paths.

### See Also
- [Immich OpenAPI spec usage of "for" as a param name](https://github.com/immich-app/immich/blob/dafe9d7966f0f5634a94e6ef9242400ce4646859/open-api/immich-openapi-specs.json#L6341)