### PR TITLE
Fix incorrect generation of `$ref` item schemas in inline parameter array schemas

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
@@ -44,9 +44,8 @@ data class SourceApi(
         val inlineEnumParams = openApi3.paths.values.flatMap { path ->
             val allParams = path.parameters + path.operations.values.flatMap { it.parameters }
             allParams.filter { param ->
-                Overlay.of(param.schema).pathFromRoot.contains("paths") &&
-                    (param.schema?.isEnumDefinition() == true ||
-                        (param.schema?.type == "array" && param.schema?.itemsSchema?.isEnumDefinition() == true))
+                isInlineEnum(param.schema) ||
+                        (param.schema?.type == "array" && isInlineEnum(param.schema?.itemsSchema))
             }.map { param ->
                 val schema = if (param.schema?.type == "array") param.schema.itemsSchema else param.schema
                 param.name to schema
@@ -94,6 +93,10 @@ data class SourceApi(
             .plus(inlineEnumParams)
             .map { (key, schema) -> SchemaInfo(key, schema) }
     }
+
+    private fun isInlineEnum(schema: Schema?): Boolean =
+        Overlay.of(schema).pathFromRoot.contains("paths") &&
+                schema?.isEnumDefinition() == true
 
     private fun validateSchemaObjects(api: OpenApi3): List<ValidationError> {
         val schemaErrors = api.schemas.entries.fold(emptyList<ValidationError>()) { errors, entry ->

--- a/src/test/resources/examples/arrays/api.yaml
+++ b/src/test/resources/examples/arrays/api.yaml
@@ -6,6 +6,14 @@ paths:
       summary: Get items with a status filter
       description: Retrieve a list of items filtered by their status.
       parameters:
+        - name: category
+          in: query
+          required: false
+          description: Filter items by category.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SomeEnum'
         - name: status
           in: query
           required: false
@@ -21,6 +29,11 @@ paths:
                 $ref: '#/components/schemas/ArrayContainingComplexInlined'
 components:
   schemas:
+    ContainsEnum:
+      type: object
+      properties:
+        somes:
+          $ref: "#/components/schemas/SomeEnum"
     ContainsArrayOfArrays:
       type: object
       properties:
@@ -60,7 +73,14 @@ components:
         some_value:
           type: integer
           example: 100
-          
+
+    SomeEnum:
+      type: string
+      enum:
+        - foo
+        - bar
+        - baz
+
     ArraySimpleInLined:
       type: object
       required:

--- a/src/test/resources/examples/arrays/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/arrays/controllers/spring/Controllers.kt
@@ -1,6 +1,7 @@
 package examples.arrays.controllers
 
 import examples.arrays.models.ArrayContainingComplexInlined
+import examples.arrays.models.SomeEnum
 import examples.arrays.models.Something
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -19,6 +20,7 @@ public interface ItemsController {
     /**
      * Get items with a status filter
      * Retrieve a list of items filtered by their status.
+     * @param category Filter items by category.
      * @param status Filter items by status.
      */
     @RequestMapping(
@@ -27,6 +29,8 @@ public interface ItemsController {
         method = [RequestMethod.GET],
     )
     public fun `get`(
+        @Valid @RequestParam(value = "category", required = false)
+        category: List<SomeEnum>?,
         @Valid @RequestParam(value = "status", required = false)
         status: List<Something>?,
     ): ResponseEntity<List<ArrayContainingComplexInlined>>

--- a/src/test/resources/examples/arrays/models/ContainsEnum.kt
+++ b/src/test/resources/examples/arrays/models/ContainsEnum.kt
@@ -1,0 +1,9 @@
+package examples.arrays.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+
+public data class ContainsEnum(
+  @param:JsonProperty("somes")
+  @get:JsonProperty("somes")
+  public val somes: SomeEnum? = null,
+)

--- a/src/test/resources/examples/arrays/models/SomeEnum.kt
+++ b/src/test/resources/examples/arrays/models/SomeEnum.kt
@@ -1,0 +1,23 @@
+package examples.arrays.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class SomeEnum(
+  @JsonValue
+  public val `value`: String,
+) {
+  FOO("foo"),
+  BAR("bar"),
+  BAZ("baz"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, SomeEnum> = entries.associateBy(SomeEnum::value)
+
+    public fun fromValue(`value`: String): SomeEnum? = mapping[value]
+  }
+}


### PR DESCRIPTION
Fixes a problem introduced in #570, where for inline `type: array` schemas with a non-inline item schema, the item schema would be incorrectly marked as inline. This manifests as a schema name being synthesized for it rather than it using the ref'd name. 