### PR TITLE
Fallback to OAS key for property name in case of normalization conflict

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/PropertyInfo.kt
@@ -23,14 +23,16 @@ import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import com.reprezen.kaizen.oasparser.model3.Schema
 
 sealed class PropertyInfo {
+    /**
+     * Property name used in generated code. For most properties, it is derived
+     * from a normalized version of [oasKey].
+     */
+    abstract val name: String
     abstract val oasKey: String
     abstract val typeInfo: KotlinTypeInfo
     abstract val schema: Schema
     open val isRequired: Boolean = false
     open val isInherited: Boolean = false
-
-    val name: String
-        get() = oasKey.camelCase()
 
     companion object {
 
@@ -88,14 +90,33 @@ sealed class PropertyInfo {
             enclosingSchema: Schema? = null,
             additionalRequiredFields: Collection<String> = emptySet()
         ): Collection<PropertyInfo> {
+            // Group raw keys by their normalized names to find any groups that would conflict.
+            // If there are any conflicts, use the raw keys for that group as names, otherwise
+            // use the normalized name. This prevents conflation when two different OAS property
+            // names convert to the same camel case representation (i.e. `T` and `t`, or
+            // `foo_bar` and `fooBar`)
+            val names = properties.keys
+                .groupBy { it.camelCase() }
+                .flatMap { (normalizedName, rawNames) ->
+                    if (rawNames.size > 1) {
+                        rawNames.map { it to it }
+                    } else {
+                        listOf(rawNames.first() to normalizedName)
+                    }
+                }.toMap()
+
             val mainProperties: List<PropertyInfo> = properties.map { property ->
+                val oasKey = property.key
+                val name = names[oasKey]!!
+
                 when (property.value.safeType()) {
                     OasType.Set.type ->
                         ListField(
                             isRequired = isRequired(
                                 api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields
                             ),
-                            oasKey = property.key,
+                            name = name,
+                            oasKey = oasKey,
                             schema = property.value,
                             isInherited = settings.markAsInherited,
                             parentSchema = this,
@@ -108,7 +129,8 @@ sealed class PropertyInfo {
                             isRequired = isRequired(
                                 api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields
                             ),
-                            oasKey = property.key,
+                            name = name,
+                            oasKey = oasKey,
                             schema = property.value,
                             isInherited = settings.markAsInherited,
                             parentSchema = this,
@@ -122,7 +144,8 @@ sealed class PropertyInfo {
                                 isRequired = isRequired(
                                     api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields
                                 ),
-                                oasKey = property.key,
+                                name = name,
+                                oasKey = oasKey,
                                 schema = property.value,
                                 isInherited = settings.markAsInherited,
                                 parentSchema = this
@@ -133,7 +156,8 @@ sealed class PropertyInfo {
                                 isRequired = isRequired(
                                     api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields
                                 ),
-                                oasKey = property.key,
+                                name = name,
+                                oasKey = oasKey,
                                 schema = property.value,
                                 isInherited = settings.markAsInherited,
                                 parentSchema = this,
@@ -144,7 +168,8 @@ sealed class PropertyInfo {
                                 isRequired = isRequired(
                                     api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields
                                 ),
-                                oasKey = property.key,
+                                name = name,
+                                oasKey = oasKey,
                                 schema = property.value,
                                 isInherited = settings.markAsInherited,
                                 parentSchema = this
@@ -158,7 +183,8 @@ sealed class PropertyInfo {
                                 isRequired = isRequired(
                                     api, property, settings.markReadWriteOnlyOptional, settings.markAllOptional, additionalRequiredFields = additionalRequiredFields
                                 ),
-                                oasKey = property.key,
+                                name = name,
+                                oasKey = oasKey,
                                 schema = property.value,
                                 isInherited = settings.markAsInherited,
                                 isPolymorphicDiscriminator = isDiscriminatorProperty(api, property),
@@ -189,6 +215,7 @@ sealed class PropertyInfo {
 
     data class Field(
         override val isRequired: Boolean,
+        override val name: String,
         override val oasKey: String,
         override val schema: Schema,
         override val isInherited: Boolean,
@@ -216,6 +243,7 @@ sealed class PropertyInfo {
 
     data class ListField(
         override val isRequired: Boolean,
+        override val name: String,
         override val oasKey: String,
         override val schema: Schema,
         override val isInherited: Boolean,
@@ -240,6 +268,7 @@ sealed class PropertyInfo {
 
     data class MapField(
         override val isRequired: Boolean,
+        override val name: String,
         override val oasKey: String,
         override val schema: Schema,
         override val isInherited: Boolean,
@@ -250,6 +279,7 @@ sealed class PropertyInfo {
 
     data class ObjectRefField(
         override val isRequired: Boolean,
+        override val name: String,
         override val oasKey: String,
         override val schema: Schema,
         override val isInherited: Boolean,
@@ -260,6 +290,7 @@ sealed class PropertyInfo {
 
     data class ObjectInlinedField(
         override val isRequired: Boolean,
+        override val name: String,
         override val oasKey: String,
         override val schema: Schema,
         override val isInherited: Boolean,
@@ -279,6 +310,7 @@ sealed class PropertyInfo {
         override val isInherited: Boolean,
         val parentSchema: Schema
     ) : PropertyInfo() {
+        override val name: String = "properties"
         override val oasKey: String = "properties"
         override val typeInfo: KotlinTypeInfo = KotlinTypeInfo.from(schema, "additionalProperties")
         override val isRequired: Boolean = true
@@ -287,6 +319,7 @@ sealed class PropertyInfo {
     data class OneOfAny(
         override val schema: Schema,
     ) : PropertyInfo() {
+        override val name: String = "oneOf"
         override val oasKey: String = "oneOf"
         override val typeInfo: KotlinTypeInfo = KotlinTypeInfo.AnyType
     }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
@@ -34,6 +34,7 @@ class KotlinSerializationModelGeneratorTest {
     private fun testCases(): Stream<String> = Stream.of(
         "discriminatedOneOf",
         "primitiveTypes",
+        "normalizedNameConflation"
     )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -76,6 +76,7 @@ class ModelGeneratorTest {
         "inlinedEnumParameter",
         "unsupportedInlinedDefinitions",
         "requestBodiesSchema",
+        "normalizedNameConflation",
     )
 
     @BeforeEach

--- a/src/test/resources/examples/normalizedNameConflation/api.yaml
+++ b/src/test/resources/examples/normalizedNameConflation/api.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+components:
+  schemas:
+    NormalizedNameConflation:
+      type: object
+      properties:
+        x:
+          type: string
+          description: Description of lowercase x
+        X:
+          type: string
+          description: Description of uppercase X
+        fooBar:
+          type: string
+          description: Description of camel case fooBar
+        foo_bar:
+          type: string
+          description: Description of snake case foo_bar
+        aBC:
+          type: string
+          description: Description of aBC
+        ABC:
+          type: string
+          description: Description of ABC
+        a_b_c:
+          type: string
+          description: Description of a_b_c
+        control_case:
+          type: string
+          description: Description of control_case - this should get normalized because it conflicts with no other property

--- a/src/test/resources/examples/normalizedNameConflation/models/NormalizedNameConflation.kt
+++ b/src/test/resources/examples/normalizedNameConflation/models/NormalizedNameConflation.kt
@@ -1,0 +1,56 @@
+package examples.normalizedNameConflation.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class NormalizedNameConflation(
+  /**
+   * Description of lowercase x
+   */
+  @param:JsonProperty("x")
+  @get:JsonProperty("x")
+  public val x: String? = null,
+  /**
+   * Description of uppercase X
+   */
+  @param:JsonProperty("X")
+  @get:JsonProperty("X")
+  public val X: String? = null,
+  /**
+   * Description of camel case fooBar
+   */
+  @param:JsonProperty("fooBar")
+  @get:JsonProperty("fooBar")
+  public val fooBar: String? = null,
+  /**
+   * Description of snake case foo_bar
+   */
+  @param:JsonProperty("foo_bar")
+  @get:JsonProperty("foo_bar")
+  public val foo_bar: String? = null,
+  /**
+   * Description of aBC
+   */
+  @param:JsonProperty("aBC")
+  @get:JsonProperty("aBC")
+  public val aBC: String? = null,
+  /**
+   * Description of ABC
+   */
+  @param:JsonProperty("ABC")
+  @get:JsonProperty("ABC")
+  public val ABC: String? = null,
+  /**
+   * Description of a_b_c
+   */
+  @param:JsonProperty("a_b_c")
+  @get:JsonProperty("a_b_c")
+  public val a_b_c: String? = null,
+  /**
+   * Description of control_case - this should get normalized because it conflicts with no other
+   * property
+   */
+  @param:JsonProperty("control_case")
+  @get:JsonProperty("control_case")
+  public val controlCase: String? = null,
+)

--- a/src/test/resources/examples/normalizedNameConflation/models/kotlinx/NormalizedNameConflation.kt
+++ b/src/test/resources/examples/normalizedNameConflation/models/kotlinx/NormalizedNameConflation.kt
@@ -1,0 +1,50 @@
+package examples.normalizedNameConflation.models
+
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class NormalizedNameConflation(
+  /**
+   * Description of lowercase x
+   */
+  @SerialName("x")
+  public val x: String? = null,
+  /**
+   * Description of uppercase X
+   */
+  @SerialName("X")
+  public val X: String? = null,
+  /**
+   * Description of camel case fooBar
+   */
+  @SerialName("fooBar")
+  public val fooBar: String? = null,
+  /**
+   * Description of snake case foo_bar
+   */
+  @SerialName("foo_bar")
+  public val foo_bar: String? = null,
+  /**
+   * Description of aBC
+   */
+  @SerialName("aBC")
+  public val aBC: String? = null,
+  /**
+   * Description of ABC
+   */
+  @SerialName("ABC")
+  public val ABC: String? = null,
+  /**
+   * Description of a_b_c
+   */
+  @SerialName("a_b_c")
+  public val a_b_c: String? = null,
+  /**
+   * Description of control_case - this should get normalized because it conflicts with no other
+   * property
+   */
+  @SerialName("control_case")
+  public val controlCase: String? = null,
+)


### PR DESCRIPTION
Closes #608 

This PR resolves the above issue by adding some additional logic to `Schema.getInLinedProperties`: If two or more properties in an object have distinct raw OAS names that are the same after normalization, all properties in the conflicting group will fall back to using the raw OAS name instead of the normalized name in generated code.

I did dig into the usage of property names in discriminators, but that system is too complex for me to figure out in a few hours of reading and tinkering. However, it appeared to me that much of the discriminator code relies on the schema's property name matching `PropertyInfo.name`, which may only work for schema names that are already camel case. The `discriminatedOneOf` test case `api.yaml` only has camel case property names, so it doesn't seem to test that discriminator property names that get transformed during normalization work correctly. 

As an aside, this work did not fully fix my use case - I'm targeting JVM, so even though this change properly generates `val t` and `val T` in the model's constructor args, it doesn't compile due to JVM getter collisions (both have getters named `getT`). I'm ready to move on for the moment, though, so I figured I'd put up what I did accomplish for review.