### PR TITLE
fix #493: add CollectionFormat.CSV to @RequestLine for explode:false array query params

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
@@ -16,6 +16,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.getReturnType
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.optionallyParameterizeWithResponseEntity
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.metadata.OpenFeignAnnotations
+import com.cjbooms.fabrikt.generators.client.metadata.OpenFeignImports
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Clients
 import com.cjbooms.fabrikt.model.GeneratedFile
@@ -37,6 +38,7 @@ import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.buildCodeBlock
+import java.util.logging.Logger
 
 class OpenFeignInterfaceGenerator(
     private val packages: Packages,
@@ -143,6 +145,10 @@ class OpenFeignInterfaceGenerator(
         private val verb: String,
         private val parameters: List<IncomingParameter>,
     ) {
+        companion object {
+            private val logger = Logger.getGlobal()
+        }
+
         /**
          * Gives the url path so that it can be used as input for OpenFeign's @RequestLine.
          * For query and path variables, the deduplicated parameter name will be used instead of the original name.
@@ -190,9 +196,33 @@ class OpenFeignInterfaceGenerator(
 
         fun build(): AnnotationSpec {
             val urlPath = buildUrlPath()
-            return OpenFeignAnnotations.requestLineBuilder()
+            val builder = OpenFeignAnnotations.requestLineBuilder()
                 .addMember("%S", "${verb.toUpperCase()} $urlPath")
-                .build()
+
+            val arrayQueryParams = parameters
+                .filterIsInstance<RequestParameter>()
+                .filter { it.parameterLocation is QueryParam && it.typeInfo is KotlinTypeInfo.Array }
+
+            if (arrayQueryParams.isNotEmpty()) {
+                val allExplodeFalse = arrayQueryParams.all { it.explode == false }
+                val anyExplodeFalse = arrayQueryParams.any { it.explode == false }
+                when {
+                    allExplodeFalse ->
+                        builder.addMember(
+                            "collectionFormat = %T.%L",
+                            OpenFeignImports.COLLECTION_FORMAT,
+                            "CSV",
+                        )
+                    anyExplodeFalse ->
+                        logger.warning(
+                            "Operation ${verb.toUpperCase()} $resource has array query parameters " +
+                                "with mixed explode values. Cannot use a consistent collectionFormat. " +
+                                "Defaulting to exploded format.",
+                        )
+                }
+            }
+
+            return builder.build()
         }
     }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/OpenFeign.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/OpenFeign.kt
@@ -20,6 +20,8 @@ object OpenFeignImports {
 
     val PARAM = ClassName(Packages.FEIGN, "Param")
 
+    val COLLECTION_FORMAT = ClassName(Packages.FEIGN, "CollectionFormat")
+
     val FEIGN_CLIENT = ClassName(Packages.SPRING_STARTER, "FeignClient")
 }
 

--- a/src/test/resources/examples/openFeignClient/api.yaml
+++ b/src/test/resources/examples/openFeignClient/api.yaml
@@ -101,6 +101,16 @@ paths:
         204:
           description: "Operation successful"
 
+  /example-path-4:
+    get:
+      summary: "GET example path 4 - mixed explode list query params"
+      parameters:
+        - $ref: "#/components/parameters/ListQueryParamCsv"
+        - $ref: "#/components/parameters/ListQueryParamExploded"
+      responses:
+        200:
+          description: "successful operation"
+
 components:
   parameters:
     PathParam:

--- a/src/test/resources/examples/openFeignClient/client/OpenFeignClient.kt
+++ b/src/test/resources/examples/openFeignClient/client/OpenFeignClient.kt
@@ -3,6 +3,7 @@ package examples.openFeignClient.client
 import examples.openFeignClient.models.Content
 import examples.openFeignClient.models.FirstModel
 import examples.openFeignClient.models.QueryResult
+import feign.CollectionFormat
 import feign.HeaderMap
 import feign.Headers
 import feign.Param
@@ -124,13 +125,33 @@ public interface ExamplePath3SubresourceClient {
      * @param ifMatch The RFC7232 If-Match header field
      * @param csvListQueryParam
      */
-    @RequestLine("PUT /example-path-3/{pathParam}/subresource?csv_list_query_param={csvListQueryParam}")
+    @RequestLine(
+        "PUT /example-path-3/{pathParam}/subresource?csv_list_query_param={csvListQueryParam}",
+        collectionFormat = CollectionFormat.CSV,
+    )
     @Headers("If-Match: {ifMatch}")
     public fun putExamplePath3PathParamSubresource(
         firstModel: FirstModel,
         @Param("pathParam") pathParam: String,
         @Param("ifMatch") ifMatch: String,
         @Param("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    )
+}
+
+@Suppress("unused")
+public interface ExamplePath4Client {
+    /**
+     * GET example path 4 - mixed explode list query params
+     *
+     * @param csvListQueryParam
+     * @param explodeListQueryParam
+     */
+    @RequestLine("GET /example-path-4?csv_list_query_param={csvListQueryParam}&explode_list_query_param={explodeListQueryParam}")
+    public fun getExamplePath4(
+        @Param("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @Param("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
         @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
         @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
     )

--- a/src/test/resources/examples/openFeignClient/client/OpenFeignClientWithResponseEntity.kt
+++ b/src/test/resources/examples/openFeignClient/client/OpenFeignClientWithResponseEntity.kt
@@ -3,6 +3,7 @@ package examples.openFeignClient.client
 import examples.openFeignClient.models.Content
 import examples.openFeignClient.models.FirstModel
 import examples.openFeignClient.models.QueryResult
+import feign.CollectionFormat
 import feign.HeaderMap
 import feign.Headers
 import feign.Param
@@ -139,13 +140,37 @@ public interface ExamplePath3SubresourceClient {
      * @param ifMatch The RFC7232 If-Match header field
      * @param csvListQueryParam
      */
-    @RequestLine("PUT /example-path-3/{pathParam}/subresource?csv_list_query_param={csvListQueryParam}")
+    @RequestLine(
+        "PUT /example-path-3/{pathParam}/subresource?csv_list_query_param={csvListQueryParam}",
+        collectionFormat = CollectionFormat.CSV,
+    )
     @Headers("If-Match: {ifMatch}")
     public fun putExamplePath3PathParamSubresource(
         firstModel: FirstModel,
         @Param("pathParam") pathParam: String,
         @Param("ifMatch") ifMatch: String,
         @Param("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ResponseEntity<Unit>
+}
+
+@Suppress("unused")
+@FeignClient(
+    name = "test-feign-client-name",
+    contextId = "ExamplePath4",
+)
+public interface ExamplePath4Client {
+    /**
+     * GET example path 4 - mixed explode list query params
+     *
+     * @param csvListQueryParam
+     * @param explodeListQueryParam
+     */
+    @RequestLine("GET /example-path-4?csv_list_query_param={csvListQueryParam}&explode_list_query_param={explodeListQueryParam}")
+    public fun getExamplePath4(
+        @Param("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @Param("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
         @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
         @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
     ): ResponseEntity<Unit>

--- a/src/test/resources/examples/openFeignClient/client/SuspendableOpenFeignClient.kt
+++ b/src/test/resources/examples/openFeignClient/client/SuspendableOpenFeignClient.kt
@@ -3,6 +3,7 @@ package examples.openFeignClient.client
 import examples.openFeignClient.models.Content
 import examples.openFeignClient.models.FirstModel
 import examples.openFeignClient.models.QueryResult
+import feign.CollectionFormat
 import feign.HeaderMap
 import feign.Headers
 import feign.Param
@@ -124,13 +125,33 @@ public interface ExamplePath3SubresourceClient {
      * @param ifMatch The RFC7232 If-Match header field
      * @param csvListQueryParam
      */
-    @RequestLine("PUT /example-path-3/{pathParam}/subresource?csv_list_query_param={csvListQueryParam}")
+    @RequestLine(
+        "PUT /example-path-3/{pathParam}/subresource?csv_list_query_param={csvListQueryParam}",
+        collectionFormat = CollectionFormat.CSV,
+    )
     @Headers("If-Match: {ifMatch}")
     public suspend fun putExamplePath3PathParamSubresource(
         firstModel: FirstModel,
         @Param("pathParam") pathParam: String,
         @Param("ifMatch") ifMatch: String,
         @Param("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    )
+}
+
+@Suppress("unused")
+public interface ExamplePath4Client {
+    /**
+     * GET example path 4 - mixed explode list query params
+     *
+     * @param csvListQueryParam
+     * @param explodeListQueryParam
+     */
+    @RequestLine("GET /example-path-4?csv_list_query_param={csvListQueryParam}&explode_list_query_param={explodeListQueryParam}")
+    public suspend fun getExamplePath4(
+        @Param("csvListQueryParam") csvListQueryParam: List<String>? = null,
+        @Param("explodeListQueryParam") explodeListQueryParam: List<String>? = null,
         @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
         @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
     )


### PR DESCRIPTION

When all array query parameters in a Feign operation have explode:false, add collectionFormat = CollectionFormat.CSV to @RequestLine so the client serializes them as comma-separated values (e.g. param=a,b,c) instead of the default exploded format (param=a&param=b&param=c).

If array params within the same operation have mixed explode values, a warning is logged and the default (exploded) behavior is used, since @RequestLine's collectionFormat applies to all collection params in the method.

Test fixture updated with a CSV-only endpoint (path 3) that gains the annotation, and a mixed-explode endpoint (path 4) that verifies the fallback with no collectionFormat.

Fixes #493 