### PR TITLE
fix #612 keep parameters with a default value non-nullable

### DIFF
--- a/end2end-tests/spring/build.gradle.kts
+++ b/end2end-tests/spring/build.gradle.kts
@@ -1,0 +1,71 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+val generationDir = "$buildDir/generated"
+val apiFile = "$projectDir/openapi/api.yaml"
+
+sourceSets {
+    main { java.srcDirs("$generationDir/src/main/kotlin") }
+}
+
+plugins {
+    kotlin("jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+val springBootVersion = "3.4.3"
+
+dependencies {
+    implementation(platform(libs.jackson.bom))
+    implementation(libs.jakarta.validation.api)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.annotations)
+
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+}
+
+tasks {
+    val generateCode by creating(JavaExec::class) {
+        inputs.files(apiFile)
+        outputs.dir(generationDir)
+        outputs.cacheIf { true }
+        doFirst { delete(generationDir) }
+        classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
+        mainClass.set("io.fabrikt.cli.CodeGen")
+        args = listOf(
+            "--output-directory", generationDir,
+            "--base-package", "com.example",
+            "--api-file", apiFile,
+            "--targets", "http_models",
+            "--targets", "controllers",
+            "--http-controller-target", "SPRING",
+            "--validation-library", "jakarta_validation"
+        )
+        dependsOn(":jar")
+        dependsOn(":shadowJar")
+    }
+
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+            javaParameters.set(true)
+        }
+        dependsOn(generateCode)
+    }
+
+    withType<Test> {
+        useJUnitPlatform()
+        jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED")
+    }
+}

--- a/end2end-tests/spring/openapi/api.yaml
+++ b/end2end-tests/spring/openapi/api.yaml
@@ -1,0 +1,45 @@
+openapi: "3.0.3"
+info:
+  title: Parameter Defaults Example
+  version: "1.0"
+paths:
+  /example:
+    get:
+      operationId: getExample
+      summary: Echoes back the resolved parameter values
+      parameters:
+        - name: param1
+          in: header
+          required: false
+          schema:
+            type: string
+            default: paramValue
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ParameterEcho"
+components:
+  schemas:
+    ParameterEcho:
+      type: object
+      properties:
+        param1:
+          type: string
+        limit:
+          type: integer
+        filter:
+          type: string

--- a/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/ExampleControllerImpl.kt
+++ b/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/ExampleControllerImpl.kt
@@ -1,0 +1,25 @@
+package com.cjbooms.fabrikt.servers.spring
+
+import com.example.controllers.ExampleController
+import com.example.models.ParameterEcho
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Regression coverage for https://github.com/fabrikt-io/fabrikt/issues/612
+ *
+ * This override only compiles if the generated [ExampleController.getExample] declares `param1` and
+ * `limit` as non-nullable. Both are `required: false` but carry a `default`, so Spring always
+ * populates them via `@RequestHeader`/`@RequestParam(defaultValue = ...)`. If the fix regressed and
+ * those parameters were generated as `String?` / `Int?`, this override signature would no longer
+ * match and the module would fail to compile.
+ */
+@RestController
+open class ExampleControllerImpl : ExampleController {
+    override fun getExample(
+        param1: String,
+        limit: Int,
+        filter: String?,
+    ): ResponseEntity<ParameterEcho> =
+        ResponseEntity.ok(ParameterEcho(param1 = param1, limit = limit, filter = filter))
+}

--- a/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/SpringParameterDefaultTest.kt
+++ b/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/SpringParameterDefaultTest.kt
@@ -1,0 +1,55 @@
+package com.cjbooms.fabrikt.servers.spring
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * End-to-end coverage for https://github.com/fabrikt-io/fabrikt/issues/612 against a running Spring
+ * MVC stack: a `required: false` parameter that declares a `default` is always populated by Spring,
+ * so its generated Kotlin type is non-nullable and the handler receives the default when the caller
+ * omits it.
+ */
+@WebMvcTest
+@ContextConfiguration(classes = [ParameterDefaultTestConfig::class])
+class SpringParameterDefaultTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `default header and query values are injected when the caller omits them`() {
+        mockMvc.perform(get("/example"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.param1").value("paramValue"))
+            .andExpect(jsonPath("$.limit").value(10))
+    }
+
+    @Test
+    fun `explicit values override the defaults`() {
+        mockMvc.perform(get("/example?limit=42").header("param1", "custom"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.param1").value("custom"))
+            .andExpect(jsonPath("$.limit").value(42))
+    }
+
+    @Test
+    fun `an optional parameter without a default is absent when omitted`() {
+        mockMvc.perform(get("/example"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.filter").doesNotExist())
+    }
+}
+
+@Configuration
+open class ParameterDefaultTestConfig {
+    @Bean
+    open fun exampleController() = ExampleControllerImpl()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ include(
     "end2end-tests:ktor-client-kotlinx",
     "end2end-tests:ktor-client-jackson",
     "end2end-tests:spring-http-interface",
+    "end2end-tests:spring",
     "end2end-tests:models-jackson",
     "end2end-tests:models-kotlinx",
     "playground",

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -76,10 +76,18 @@ fun <T : GeneratedType> Collection<T>.toFileSpec(): Collection<FileSpec> = this
  */
 sealed class IncomingParameter(val oasName: String, val description: String?, val type: TypeName, val isRequired: Boolean) {
     val name: String = oasName.toKotlinParameterName()
+
+    /**
+     * Whether the generated Kotlin type should be nullable. Optional parameters are nullable unless they
+     * supply a default value, in which case the value is always populated (e.g. Spring's
+     * `@RequestParam(defaultValue = ...)`) and the type stays non-nullable.
+     */
+    open val isNullable: Boolean get() = !isRequired
+
     open fun toParameterSpecBuilder(treatAnyTypeHeadersAsStrings: Boolean = false): ParameterSpec.Builder =
         ParameterSpec.builder(
             name = name,
-            type = if (isRequired) type else type.copy(nullable = true)
+            type = if (isNullable) type.copy(nullable = true) else type
         )
 }
 
@@ -119,11 +127,13 @@ class RequestParameter(
         defaultValue = parameter.schema.default
     )
 
+    override val isNullable: Boolean get() = !isRequired && defaultValue == null
+
     override fun toParameterSpecBuilder(treatAnyTypeHeadersAsStrings: Boolean): ParameterSpec.Builder =
         if (treatAnyTypeHeadersAsStrings && parameterLocation == HeaderParam && typeInfo == KotlinTypeInfo.AnyType) {
             ParameterSpec.builder(
                 name = name,
-                type = if (isRequired) String::class.asTypeName() else String::class.asTypeName().copy(nullable = true)
+                type = if (isNullable) String::class.asTypeName().copy(nullable = true) else String::class.asTypeName()
             )
         } else super.toParameterSpecBuilder(treatAnyTypeHeadersAsStrings)
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/model/IncomingParameterTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/model/IncomingParameterTest.kt
@@ -1,0 +1,54 @@
+package com.cjbooms.fabrikt.model
+
+import com.squareup.kotlinpoet.asTypeName
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class IncomingParameterTest {
+
+    @Test
+    fun `required parameter is non-nullable`() {
+        val parameter = RequestParameter(
+            oasName = "param1",
+            description = null,
+            type = String::class.asTypeName(),
+            isRequired = true,
+            originalName = "param1",
+            parameterLocation = HeaderParam,
+            typeInfo = KotlinTypeInfo.Text,
+        )
+
+        assertThat(parameter.toParameterSpecBuilder().build().type.isNullable).isFalse()
+    }
+
+    @Test
+    fun `optional parameter without default is nullable`() {
+        val parameter = RequestParameter(
+            oasName = "param1",
+            description = null,
+            type = String::class.asTypeName(),
+            isRequired = false,
+            originalName = "param1",
+            parameterLocation = HeaderParam,
+            typeInfo = KotlinTypeInfo.Text,
+        )
+
+        assertThat(parameter.toParameterSpecBuilder().build().type.isNullable).isTrue()
+    }
+
+    @Test
+    fun `optional parameter with a default value is non-nullable`() {
+        val parameter = RequestParameter(
+            oasName = "param1",
+            description = null,
+            type = String::class.asTypeName(),
+            isRequired = false,
+            originalName = "param1",
+            parameterLocation = HeaderParam,
+            typeInfo = KotlinTypeInfo.Text,
+            defaultValue = "paramValue",
+        )
+
+        assertThat(parameter.toParameterSpecBuilder().build().type.isNullable).isFalse()
+    }
+}

--- a/src/test/resources/examples/githubApi/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/micronaut/Controllers.kt
@@ -69,7 +69,7 @@ public interface ContributorsController {
     @Get(uri = "/contributors")
     @Produces(value = ["application/json"])
     public fun searchContributors(
-        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int?,
+        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @QueryValue(value = "include_inactive") includeInactive: Boolean?,
         @QueryValue(value = "cursor") cursor: String?,
@@ -118,7 +118,7 @@ public interface ContributorsController {
     @Produces(value = ["application/json"])
     public fun getContributor(
         @PathVariable(value = "id") id: String,
-        @QueryValue(value = "status", defaultValue = "all") status: StatusQueryParam?,
+        @QueryValue(value = "status", defaultValue = "all") status: StatusQueryParam,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @Header(value = "If-None-Match") ifNoneMatch: String?,
     ): HttpResponse<Contributor>
@@ -176,7 +176,7 @@ public interface OrganisationsController {
     @Get(uri = "/organisations")
     @Produces(value = ["application/json"])
     public fun `get`(
-        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int?,
+        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @QueryValue(value = "include_inactive") includeInactive: Boolean?,
         @QueryValue(value = "cursor") cursor: String?,
@@ -225,7 +225,7 @@ public interface OrganisationsController {
     @Produces(value = ["application/json"])
     public fun getById(
         @PathVariable(value = "id") id: String,
-        @QueryValue(value = "status", defaultValue = "all") status: StatusQueryParam?,
+        @QueryValue(value = "status", defaultValue = "all") status: StatusQueryParam,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @Header(value = "If-None-Match") ifNoneMatch: String?,
     ): HttpResponse<Organisation>
@@ -286,7 +286,7 @@ public interface OrganisationsContributorsController {
     @Produces(value = ["application/json"])
     public fun `get`(
         @PathVariable(value = "parent-id") parentId: String,
-        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int?,
+        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @QueryValue(value = "include_inactive") includeInactive: Boolean?,
         @QueryValue(value = "cursor") cursor: String?,
@@ -386,7 +386,7 @@ public interface RepositoriesController {
     @Get(uri = "/repositories")
     @Produces(value = ["application/json"])
     public fun `get`(
-        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int?,
+        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @Valid @QueryValue(value = "slug") slug: List<String>?,
         @Valid @QueryValue(value = "name") name: List<String>?,
@@ -437,7 +437,7 @@ public interface RepositoriesController {
     @Produces(value = ["application/json"])
     public fun getById(
         @PathVariable(value = "id") id: String,
-        @QueryValue(value = "status", defaultValue = "all") status: StatusQueryParam?,
+        @QueryValue(value = "status", defaultValue = "all") status: StatusQueryParam,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @Header(value = "If-None-Match") ifNoneMatch: String?,
     ): HttpResponse<Repository>
@@ -498,7 +498,7 @@ public interface RepositoriesPullRequestsController {
     @Produces(value = ["application/json"])
     public fun `get`(
         @PathVariable(value = "parent-id") parentId: String,
-        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int?,
+        @Min(1) @Max(100) @QueryValue(value = "limit", defaultValue = "10") limit: Int,
         @Header(value = "X-Flow-Id") xFlowId: String?,
         @QueryValue(value = "include_inactive") includeInactive: Boolean?,
         @QueryValue(value = "cursor") cursor: String?,

--- a/src/test/resources/examples/githubApi/controllers/spring-completion-stage/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/spring-completion-stage/Controllers.kt
@@ -78,7 +78,7 @@ public interface ContributorsController {
     )
     public fun searchContributors(
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,
@@ -135,7 +135,7 @@ public interface ContributorsController {
     public fun getContributor(
         @PathVariable(value = "id", required = true) id: String,
         @RequestParam(value = "status", required = false, defaultValue = "all")
-        status: StatusQueryParam?,
+        status: StatusQueryParam,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestHeader(value = "If-None-Match", required = false) ifNoneMatch: String?,
     ): CompletionStage<ResponseEntity<Contributor>>
@@ -203,7 +203,7 @@ public interface OrganisationsController {
     )
     public fun `get`(
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,
@@ -260,7 +260,7 @@ public interface OrganisationsController {
     public fun getById(
         @PathVariable(value = "id", required = true) id: String,
         @RequestParam(value = "status", required = false, defaultValue = "all")
-        status: StatusQueryParam?,
+        status: StatusQueryParam,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestHeader(value = "If-None-Match", required = false) ifNoneMatch: String?,
     ): CompletionStage<ResponseEntity<Organisation>>
@@ -331,7 +331,7 @@ public interface OrganisationsContributorsController {
     public fun `get`(
         @PathVariable(value = "parent-id", required = true) parentId: String,
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,
@@ -448,7 +448,7 @@ public interface RepositoriesController {
     )
     public fun `get`(
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @Valid @RequestParam(value = "slug", required = false) slug: List<String>?,
         @Valid @RequestParam(value = "name", required = false) name: List<String>?,
@@ -507,7 +507,7 @@ public interface RepositoriesController {
     public fun getById(
         @PathVariable(value = "id", required = true) id: String,
         @RequestParam(value = "status", required = false, defaultValue = "all")
-        status: StatusQueryParam?,
+        status: StatusQueryParam,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestHeader(value = "If-None-Match", required = false) ifNoneMatch: String?,
     ): CompletionStage<ResponseEntity<Repository>>
@@ -578,7 +578,7 @@ public interface RepositoriesPullRequestsController {
     public fun `get`(
         @PathVariable(value = "parent-id", required = true) parentId: String,
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,

--- a/src/test/resources/examples/githubApi/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/githubApi/controllers/spring/Controllers.kt
@@ -77,7 +77,7 @@ public interface ContributorsController {
     )
     public fun searchContributors(
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,
@@ -134,7 +134,7 @@ public interface ContributorsController {
     public fun getContributor(
         @PathVariable(value = "id", required = true) id: String,
         @RequestParam(value = "status", required = false, defaultValue = "all")
-        status: StatusQueryParam?,
+        status: StatusQueryParam,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestHeader(value = "If-None-Match", required = false) ifNoneMatch: String?,
     ): ResponseEntity<Contributor>
@@ -202,7 +202,7 @@ public interface OrganisationsController {
     )
     public fun `get`(
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,
@@ -259,7 +259,7 @@ public interface OrganisationsController {
     public fun getById(
         @PathVariable(value = "id", required = true) id: String,
         @RequestParam(value = "status", required = false, defaultValue = "all")
-        status: StatusQueryParam?,
+        status: StatusQueryParam,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestHeader(value = "If-None-Match", required = false) ifNoneMatch: String?,
     ): ResponseEntity<Organisation>
@@ -330,7 +330,7 @@ public interface OrganisationsContributorsController {
     public fun `get`(
         @PathVariable(value = "parent-id", required = true) parentId: String,
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,
@@ -447,7 +447,7 @@ public interface RepositoriesController {
     )
     public fun `get`(
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @Valid @RequestParam(value = "slug", required = false) slug: List<String>?,
         @Valid @RequestParam(value = "name", required = false) name: List<String>?,
@@ -506,7 +506,7 @@ public interface RepositoriesController {
     public fun getById(
         @PathVariable(value = "id", required = true) id: String,
         @RequestParam(value = "status", required = false, defaultValue = "all")
-        status: StatusQueryParam?,
+        status: StatusQueryParam,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestHeader(value = "If-None-Match", required = false) ifNoneMatch: String?,
     ): ResponseEntity<Repository>
@@ -577,7 +577,7 @@ public interface RepositoriesPullRequestsController {
     public fun `get`(
         @PathVariable(value = "parent-id", required = true) parentId: String,
         @Min(1) @Max(100) @RequestParam(value = "limit", required = false, defaultValue = "10")
-        limit: Int?,
+        limit: Int,
         @RequestHeader(value = "X-Flow-Id", required = false) xFlowId: String?,
         @RequestParam(value = "include_inactive", required = false) includeInactive: Boolean?,
         @RequestParam(value = "cursor", required = false) cursor: String?,

--- a/src/test/resources/examples/okHttpClient/client/ApiClient.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiClient.kt
@@ -130,7 +130,7 @@ public class ExamplePath2Client(
     @Throws(ApiException::class)
     public fun getExamplePath2PathParam(
         pathParam: String,
-        limit: Int? = 500,
+        limit: Int = 500,
         queryParam2: Int? = null,
         ifNoneMatch: String? = null,
         additionalHeaders: Map<String, String> = emptyMap(),

--- a/src/test/resources/examples/okHttpClient/client/ApiService.kt
+++ b/src/test/resources/examples/okHttpClient/client/ApiService.kt
@@ -99,7 +99,7 @@ public class ExamplePath2Service(
     @Throws(ApiException::class)
     public fun getExamplePath2PathParam(
         pathParam: String,
-        limit: Int? = 500,
+        limit: Int = 500,
         queryParam2: Int? = null,
         ifNoneMatch: String? = null,
         additionalHeaders: Map<String, String> = emptyMap(),

--- a/src/test/resources/examples/openFeignClient/client/OpenFeignClient.kt
+++ b/src/test/resources/examples/openFeignClient/client/OpenFeignClient.kt
@@ -72,7 +72,7 @@ public interface ExamplePath2Client {
     )
     public fun getExamplePath2PathParam(
         @Param("pathParam") pathParam: String,
-        @Param("limit") limit: Int? = 500,
+        @Param("limit") limit: Int = 500,
         @Param("queryParam2") queryParam2: Int? = null,
         @Param("ifNoneMatch") ifNoneMatch: String? = null,
         @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),

--- a/src/test/resources/examples/openFeignClient/client/OpenFeignClientWithResponseEntity.kt
+++ b/src/test/resources/examples/openFeignClient/client/OpenFeignClientWithResponseEntity.kt
@@ -83,7 +83,7 @@ public interface ExamplePath2Client {
     )
     public fun getExamplePath2PathParam(
         @Param("pathParam") pathParam: String,
-        @Param("limit") limit: Int? = 500,
+        @Param("limit") limit: Int = 500,
         @Param("queryParam2") queryParam2: Int? = null,
         @Param("ifNoneMatch") ifNoneMatch: String? = null,
         @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),

--- a/src/test/resources/examples/openFeignClient/client/SuspendableOpenFeignClient.kt
+++ b/src/test/resources/examples/openFeignClient/client/SuspendableOpenFeignClient.kt
@@ -72,7 +72,7 @@ public interface ExamplePath2Client {
     )
     public suspend fun getExamplePath2PathParam(
         @Param("pathParam") pathParam: String,
-        @Param("limit") limit: Int? = 500,
+        @Param("limit") limit: Int = 500,
         @Param("queryParam2") queryParam2: Int? = null,
         @Param("ifNoneMatch") ifNoneMatch: String? = null,
         @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClient.kt
@@ -75,7 +75,7 @@ public interface ExamplePath2Client {
     )
     public fun getExamplePath2PathParam(
         @PathVariable("path_param") pathParam: String,
-        @RequestParam("limit") limit: Int? = 500,
+        @RequestParam("limit") limit: Int = 500,
         @RequestParam("query_param2") queryParam2: Int? = null,
         @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SpringHttpInterfaceClientWithResponseEntity.kt
@@ -77,7 +77,7 @@ public interface ExamplePath2Client {
     )
     public fun getExamplePath2PathParam(
         @PathVariable("path_param") pathParam: String,
-        @RequestParam("limit") limit: Int? = 500,
+        @RequestParam("limit") limit: Int = 500,
         @RequestParam("query_param2") queryParam2: Int? = null,
         @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),

--- a/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/springHttpInterfaceClient/client/SuspendableSpringHttpInterfaceClient.kt
@@ -75,7 +75,7 @@ public interface ExamplePath2Client {
     )
     public suspend fun getExamplePath2PathParam(
         @PathVariable("path_param") pathParam: String,
-        @RequestParam("limit") limit: Int? = 500,
+        @RequestParam("limit") limit: Int = 500,
         @RequestParam("query_param2") queryParam2: Int? = null,
         @RequestHeader("If-None-Match") ifNoneMatch: String? = null,
         @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),


### PR DESCRIPTION
## Description

Fixes #612.

PR #603 (#603) introduced nullability for non-required parameters in the generated Kotlin signatures. This had the side effect of marking parameters that declare a `default` value as nullable too.

A parameter with a default value is always populated by the framework — for example Spring sets it via [`@RequestParam(defaultValue = ...)`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/RequestParam.html#defaultValue()) — so the generated type should remain non-nullable.

### Before

```kotlin
@RequestParam(value = "limit", required = false, defaultValue = "10")
limit: Int?,
```

### After

```kotlin
@RequestParam(value = "limit", required = false, defaultValue = "10")
limit: Int,
```

## Change

- Added `IncomingParameter.isNullable`, derived from `isRequired`.
- Overridden in `RequestParameter` so a present `defaultValue` keeps the type non-nullable.
- `toParameterSpecBuilder` now uses `isNullable` for both the standard and the `treatAnyTypeHeadersAsStrings` paths.
- Regenerated the affected controller/client example outputs.

This applies to all parameter locations (query, header, path) and restores the pre-#603 behaviour for parameters that carry a default value.