### PR TITLE
feat: group generated clients by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                                |   `SUSPEND_MODIFIER` - This option adds the suspend modifier to the generated client functions (only for OpenFeign clients) |
 |                                |   `SPRING_RESPONSE_ENTITY_WRAPPER` - This option adds the Spring-ResponseEntity generic around the response to be able to get response headers and status (only for OpenFeign clients). |
 |                                |   `SPRING_CLOUD_OPENFEIGN_STARTER_ANNOTATION` - This option adds the @FeignClient annotation to generated client interface |
+|                                |   `GROUP_BY_TAG` - This option groups clients based on the first tag rather than paths |
 |   `--http-client-target`       | Optionally select the target client that you want to be generated. Defaults to OK_HTTP |
 |                                | CHOOSE ONE OF: |
 |                                |   `OK_HTTP` - Generate OkHttp client. |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -29,7 +29,8 @@ enum class ClientCodeGenOptionType(private val description: String) {
     RESILIENCE4J("Generates a fault tolerance service for the client using the following library \"io.github.resilience4j:resilience4j-all:+\" (only for OkHttp clients)"),
     SUSPEND_MODIFIER("This option adds the suspend modifier to the generated client functions (only for OpenFeign clients)"),
     SPRING_RESPONSE_ENTITY_WRAPPER("This option adds the Spring-ResponseEntity generic around the response to be able to get response headers and status (only for OpenFeign clients)."),
-    SPRING_CLOUD_OPENFEIGN_STARTER_ANNOTATION("This option adds the @FeignClient annotation to generated client interface")
+    SPRING_CLOUD_OPENFEIGN_STARTER_ANNOTATION("This option adds the @FeignClient annotation to generated client interface"),
+    GROUP_BY_TAG("This option groups clients based on the first tag rather than paths")
     ;
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -14,12 +14,15 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.OasDefault
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports.RESPONSE_ENTITY
 import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
+import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.RequestParameter
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPathsByFirstTag
 import com.fasterxml.jackson.databind.JsonNode
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
@@ -37,6 +40,13 @@ object ClientGeneratorUtils {
     const val CONTENT_TYPE_HEADER_NAME = "Content-Type"
     const val ADDITIONAL_HEADERS_PARAMETER_NAME = "additionalHeaders"
     const val ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME = "additionalQueryParameters"
+
+    fun SourceApi.groupedClientPaths(options: Set<ClientCodeGenOptionType>): Map<String, Map<String, Path>> =
+        if (ClientCodeGenOptionType.GROUP_BY_TAG in options) {
+            openApi3.routeToPathsByFirstTag()
+        } else {
+            openApi3.groupByPathSegment()
+        }
 
     /**
      * Gives the Kotlin return type for an API call based on the Content-Types specified in the Operation.

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpClientGenerator.kt
@@ -16,7 +16,7 @@ class OkHttpClientGenerator(
     private val enhancedClientGenerator = OkHttpEnhancedClientGenerator(packages, api, srcPath)
 
     override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
-        val simpleClient = simpleClientGenerator.generateDynamicClientCode()
+        val simpleClient = simpleClientGenerator.generateDynamicClientCode(options)
         val enhancedClient = enhancedClientGenerator.generateDynamicClientCode(options)
 
         return Clients(enhancedClient.plus(simpleClient).toSet())

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
@@ -10,6 +10,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ADDITIONAL_HEA
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.enhancedClientName
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.groupedClientPaths
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.toClientReturnType
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_IMPORT
@@ -20,7 +21,6 @@ import com.cjbooms.fabrikt.model.HandlebarsTemplates
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.SimpleFile
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
@@ -42,11 +42,11 @@ class OkHttpEnhancedClientGenerator(
 
     fun generateDynamicClientCode(options: Set<ClientCodeGenOptionType>): Collection<ClientType> =
         options.ifResilience4jIsEnabled {
-            generateResilience4jClientCode()
+            generateResilience4jClientCode(options)
         }
 
-    private fun generateResilience4jClientCode(): Collection<ClientType> {
-        return api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
+    private fun generateResilience4jClientCode(options: Set<ClientCodeGenOptionType>): Collection<ClientType> {
+        return api.groupedClientPaths(options).map { (resourceName, paths) ->
             val funSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     val parameters = deriveClientParameters(path, operation, packages.base)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators.client
 
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.GeneratorUtils.functionName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.getPrimaryContentMediaType
@@ -12,6 +13,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.ADDITIONAL_QUE
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.getReturnType
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.groupedClientPaths
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.toClientReturnType
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_IMPORT
@@ -27,7 +29,6 @@ import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
@@ -47,8 +48,8 @@ class OkHttpSimpleClientGenerator(
     private val api: SourceApi,
     private val srcPath: Path = Destinations.MAIN_KT_SOURCE
 ) {
-    fun generateDynamicClientCode(): Collection<ClientType> {
-        return api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
+    fun generateDynamicClientCode(options: Set<ClientCodeGenOptionType> = emptySet()): Collection<ClientType> {
+        return api.groupedClientPaths(options).map { (resourceName, paths) ->
             val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     val parameters = deriveClientParameters(path, operation, packages.base)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
@@ -13,6 +13,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingPar
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addSuspendModifier
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.getReturnType
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.groupedClientPaths
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.optionallyParameterizeWithResponseEntity
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.metadata.OpenFeignAnnotations
@@ -27,7 +28,6 @@ import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.cjbooms.fabrikt.util.toUpperCase
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
@@ -45,7 +45,7 @@ class OpenFeignInterfaceGenerator(
     private val api: SourceApi,
 ) : ClientGenerator {
     override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
-        val clientTypes = api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
+        val clientTypes = api.groupedClientPaths(options).map { (resourceName, paths) ->
             val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     buildFunction(path, resource, operation, verb, options)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -12,6 +12,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addIncomingPar
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.addSuspendModifier
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.deriveClientParameters
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.getReturnType
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.groupedClientPaths
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.optionallyParameterizeWithResponseEntity
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.metadata.SpringHttpInterfaceAnnotations
@@ -26,7 +27,6 @@ import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -43,7 +43,7 @@ class SpringHttpInterfaceGenerator(
     private val srcPath: java.nio.file.Path = Destinations.MAIN_KT_SOURCE
 ) : ClientGenerator {
     override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
-        val clientTypes = api.openApi3.groupByPathSegment().map { (resourceName, paths) ->
+        val clientTypes = api.groupedClientPaths(options).map { (resourceName, paths) ->
             val funcSpecs: List<FunSpec> = paths.flatMap { (resource, path) ->
                 path.operations.map { (verb, operation) ->
                     buildFunction(path, resource, operation, verb, options)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
@@ -6,6 +6,7 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.splitByType
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
 import com.cjbooms.fabrikt.generators.client.ClientGenerator
+import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.groupedClientPaths
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.toSuccessResponseType
 import com.cjbooms.fabrikt.model.ClientType
@@ -18,7 +19,6 @@ import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
 import com.github.javaparser.utils.CodeGenerationUtils
-import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -41,7 +41,7 @@ class KtorClientGenerator(
     private val networkErrorClassName = ClassName(packages.client, "NetworkError")
 
     override fun generate(options: Set<ClientCodeGenOptionType>): Clients {
-        val resources: List<TypeSpec> = api.openApi3.groupByPathSegment().flatMap { (resourceName, paths) ->
+        val resources: List<TypeSpec> = api.groupedClientPaths(options).flatMap { (resourceName, paths) ->
             val clientClassBuilder = TypeSpec.classBuilder(resourceName + "Client")
                 .addProperty(
                     PropertySpec.builder("httpClient", ClassName("io.ktor.client", "HttpClient"))

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
@@ -1,5 +1,6 @@
 package com.cjbooms.fabrikt.generators
 
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
 import com.cjbooms.fabrikt.cli.ClientCodeGenTargetType
 import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.SerializationLibrary
@@ -29,6 +30,9 @@ class KtorClientGeneratorTest {
         "parameterNameClash",
     )
 
+    @Suppress("unused")
+    private fun groupedClientTestCases(): Stream<String> = Stream.concat(fullApiTestCases(), Stream.of("tagGrouping"))
+
     @BeforeEach
     fun init() {
         MutableSettings.updateSettings(
@@ -41,19 +45,19 @@ class KtorClientGeneratorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("fullApiTestCases")
+    @MethodSource("groupedClientTestCases")
     fun `correct Ktor client code is generated`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
 
-        val expectedClient = "/examples/$testCaseName/client/ktor/KtorClient.kt"
+        val expectedClient = expectedClientPath(testCaseName, "KtorClient.kt")
 
         val clientCode = KtorClientGenerator(
             packages,
             sourceApi
         )
-            .generate(emptySet())
+            .generate(optionsFor(testCaseName))
             .clients
             .toSingleFile()
 
@@ -79,6 +83,16 @@ class KtorClientGeneratorTest {
 
         assertThatGenerated(apiModels.content).isEqualTo(expectedApiModels)
     }
+
+    private fun optionsFor(testCaseName: String): Set<ClientCodeGenOptionType> =
+        if (testCaseName == "tagGrouping") setOf(ClientCodeGenOptionType.GROUP_BY_TAG) else emptySet()
+
+    private fun expectedClientPath(testCaseName: String, fileName: String): String =
+        if (testCaseName == "tagGrouping") {
+            "/examples/$testCaseName/client/ktor/grouped/$fileName"
+        } else {
+            "/examples/$testCaseName/client/ktor/$fileName"
+        }
 
     @Test
     fun `operationId with dots is sanitized to valid Kotlin function name`() {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -8,6 +8,7 @@ import com.cjbooms.fabrikt.cli.ExternalReferencesResolutionMode
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.cli.OutputOptionType
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.client.OkHttpClientGenerator
 import com.cjbooms.fabrikt.generators.client.OkHttpEnhancedClientGenerator
 import com.cjbooms.fabrikt.generators.client.OkHttpSimpleClientGenerator
 import com.cjbooms.fabrikt.generators.model.ModelGenerator
@@ -42,6 +43,9 @@ class OkHttpClientGeneratorTest {
         "byteArrayStream",
     )
 
+    @Suppress("unused")
+    private fun groupedClientTestCases(): Stream<String> = Stream.concat(fullApiTestCases(), Stream.of("tagGrouping"))
+
     @BeforeEach
     fun init() {
         MutableSettings.updateSettings(
@@ -54,48 +58,55 @@ class OkHttpClientGeneratorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("fullApiTestCases")
+    @MethodSource("groupedClientTestCases")
     fun `correct api simple client is generated from a full API definition`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
 
         val expectedModel = "/examples/$testCaseName/models/ClientModels.kt"
-        val expectedClient = "/examples/$testCaseName/client/ApiClient.kt"
+        val expectedClient = expectedClientPath(testCaseName, "ApiClient.kt")
 
         val models = ModelGenerator(
             packages,
             sourceApi
         ).generate().toSingleFile()
-        val simpleClientCode = OkHttpSimpleClientGenerator(
+        val simpleClientCode = OkHttpClientGenerator(
             packages,
-            sourceApi
+            sourceApi,
+            Paths.get("src/main/kotlin")
         )
-            .generateDynamicClientCode()
+            .generate(optionsFor(testCaseName))
+            .clients
             .toSingleFile()
 
-        assertThatGenerated(models).isEqualTo(expectedModel)
+        if (testCaseName != "tagGrouping") {
+            assertThatGenerated(models).isEqualTo(expectedModel)
+        }
         assertThatGenerated(simpleClientCode).isEqualTo(expectedClient)
     }
 
     @ParameterizedTest
-    @MethodSource("fullApiTestCases")
+    @MethodSource("groupedClientTestCases")
     fun `correct api fault-tolerant service client is generated when the resilience4j option is set`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
 
         val expectedLibUtil = "/examples/$testCaseName/client/HttpResilience4jUtil.kt"
-        val expectedClientCode = "/examples/$testCaseName/client/ApiService.kt"
+        val expectedClientCode = expectedClientPath(testCaseName, "ApiService.kt")
+        val options = setOf(ClientCodeGenOptionType.RESILIENCE4J) + optionsFor(testCaseName)
 
         val generator =
             OkHttpEnhancedClientGenerator(packages, sourceApi)
-        val enhancedLibUtil = generator.generateLibrary(setOf(ClientCodeGenOptionType.RESILIENCE4J))
+        val enhancedLibUtil = generator.generateLibrary(options)
             .filterIsInstance<SimpleFile>()
             .first { it.path.fileName.toString() == "HttpResilience4jUtil.kt" }
-        val enhancedClientCode = generator.generateDynamicClientCode(setOf(ClientCodeGenOptionType.RESILIENCE4J))
+        val enhancedClientCode = generator.generateDynamicClientCode(options)
 
-        assertThatGenerated(enhancedLibUtil.content).isEqualTo(expectedLibUtil)
+        if (testCaseName != "tagGrouping") {
+            assertThatGenerated(enhancedLibUtil.content).isEqualTo(expectedLibUtil)
+        }
         assertThatGenerated(enhancedClientCode.toSingleFile()).isEqualTo(expectedClientCode)
     }
 
@@ -132,6 +143,16 @@ class OkHttpClientGeneratorTest {
 
         assertThatGenerated(generatedHttpUtils.content).isEqualTo(expectedHttpUtils)
     }
+
+    private fun optionsFor(testCaseName: String): Set<ClientCodeGenOptionType> =
+        if (testCaseName == "tagGrouping") setOf(ClientCodeGenOptionType.GROUP_BY_TAG) else emptySet()
+
+    private fun expectedClientPath(testCaseName: String, fileName: String): String =
+        if (testCaseName == "tagGrouping") {
+            "/examples/$testCaseName/client/grouped/$fileName"
+        } else {
+            "/examples/$testCaseName/client/$fileName"
+        }
 
     @Test
     fun `correct api client and models are generated with external reference solution mode AGGRESSIVE`() {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
@@ -31,6 +31,7 @@ class OpenFeignClientGeneratorTest {
         "multiMediaType",
         "pathLevelParameters",
         "parameterNameClash",
+        "tagGrouping",
     )
 
     @BeforeEach
@@ -47,7 +48,7 @@ class OpenFeignClientGeneratorTest {
     @ParameterizedTest
     @MethodSource("fullApiTestCases")
     fun `correct Open Feign interfaces are generated from a full API definition`(testCaseName: String) {
-        runTestCase(testCaseName)
+        runTestCase(testCaseName, options = optionsFor(testCaseName))
     }
 
     @Test
@@ -81,7 +82,7 @@ class OpenFeignClientGeneratorTest {
         val sourceApi = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
 
         val expectedModel = "/examples/$testCaseName/models/ClientModels.kt"
-        val expectedClient = "/examples/$testCaseName/client/$clientFileName"
+        val expectedClient = expectedClientPath(testCaseName, clientFileName)
 
         val models = ModelGenerator(
             packages,
@@ -96,8 +97,20 @@ class OpenFeignClientGeneratorTest {
             .toSingleFile()
 
         assertThatGenerated(clientCode).isEqualTo(expectedClient)
-        assertThatGenerated(models).isEqualTo(expectedModel)
+        if (testCaseName != "tagGrouping") {
+            assertThatGenerated(models).isEqualTo(expectedModel)
+        }
     }
+
+    private fun optionsFor(testCaseName: String): Set<ClientCodeGenOptionType> =
+        if (testCaseName == "tagGrouping") setOf(ClientCodeGenOptionType.GROUP_BY_TAG) else emptySet()
+
+    private fun expectedClientPath(testCaseName: String, fileName: String): String =
+        if (testCaseName == "tagGrouping") {
+            "/examples/$testCaseName/client/grouped/$fileName"
+        } else {
+            "/examples/$testCaseName/client/$fileName"
+        }
 
     private fun Collection<ClientType>.toSingleFile(): String {
         val destPackage = if (this.isNotEmpty()) first().destinationPackage else ""

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
@@ -34,6 +34,7 @@ class SpringHttpInterfaceGeneratorTest {
         "multiMediaType",
         "pathLevelParameters",
         "parameterNameClash",
+        "tagGrouping",
     )
 
     @BeforeEach
@@ -49,7 +50,7 @@ class SpringHttpInterfaceGeneratorTest {
     @ParameterizedTest
     @MethodSource("fullApiTestCases")
     fun `correct Spring HTTP Interface clients are generated from a full API definition`(testCaseName: String) {
-        runTestCase(testCaseName)
+        runTestCase(testCaseName, options = optionsFor(testCaseName))
     }
 
     @Test
@@ -81,7 +82,7 @@ class SpringHttpInterfaceGeneratorTest {
         val sourceApi = SourceApi(readTextResource("/examples/$testCaseName/api.yaml"))
 
         val expectedModel = "/examples/$testCaseName/models/ClientModels.kt"
-        val expectedClient = "/examples/$testCaseName/client/$clientFileName"
+        val expectedClient = expectedClientPath(testCaseName, clientFileName)
 
         val models = ModelGenerator(
             packages,
@@ -96,8 +97,20 @@ class SpringHttpInterfaceGeneratorTest {
             .toSingleFile()
 
         assertThatGenerated(clientCode).isEqualTo(expectedClient)
-        assertThatGenerated(models).isEqualTo(expectedModel)
+        if (testCaseName != "tagGrouping") {
+            assertThatGenerated(models).isEqualTo(expectedModel)
+        }
     }
+
+    private fun optionsFor(testCaseName: String): Set<ClientCodeGenOptionType> =
+        if (testCaseName == "tagGrouping") setOf(ClientCodeGenOptionType.GROUP_BY_TAG) else emptySet()
+
+    private fun expectedClientPath(testCaseName: String, fileName: String): String =
+        if (testCaseName == "tagGrouping") {
+            "/examples/$testCaseName/client/grouped/$fileName"
+        } else {
+            "/examples/$testCaseName/client/$fileName"
+        }
 
     @Test
     fun `adds disclaimer as comment to files if enabled`() {

--- a/src/test/resources/examples/tagGrouping/client/grouped/ApiClient.kt
+++ b/src/test/resources/examples/tagGrouping/client/grouped/ApiClient.kt
@@ -1,0 +1,338 @@
+package examples.tagGrouping.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import examples.tagGrouping.models.Owner
+import examples.tagGrouping.models.Pet
+import examples.tagGrouping.models.Vehicle
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.UUID
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+@Suppress("unused")
+public class PetClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val okHttpClient: OkHttpClient,
+) {
+    /**
+     * List all pets
+     *
+     * @param limit
+     */
+    @Throws(ApiException::class)
+    public fun listPets(
+        limit: Int? = null,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<List<Pet>> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/pets"
+                .toHttpUrl()
+                .newBuilder()
+                .queryParam("limit", limit)
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .get()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     * Create a pet
+     *
+     * @param pet
+     */
+    @Throws(ApiException::class)
+    public fun createPet(
+        pet: Pet,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/pets"
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .post(objectMapper.writeValueAsString(pet).toRequestBody("application/json".toMediaType()))
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     * Get a pet by ID
+     *
+     * @param petId
+     */
+    @Throws(ApiException::class)
+    public fun getPetById(
+        petId: UUID,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<Pet> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/pets/{petId}"
+                .pathParam("{petId}" to petId)
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .get()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     * Delete a pet
+     *
+     * @param petId
+     */
+    @Throws(ApiException::class)
+    public fun deletePet(
+        petId: UUID,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/pets/{petId}"
+                .pathParam("{petId}" to petId)
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .delete()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+}
+
+@Suppress("unused")
+public class OwnerClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val okHttpClient: OkHttpClient,
+) {
+    /**
+     * List all owners
+     */
+    @Throws(ApiException::class)
+    public fun listOwners(
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<List<Owner>> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/owners"
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .get()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     * Create an owner
+     *
+     * @param owner
+     */
+    @Throws(ApiException::class)
+    public fun createOwner(
+        owner: Owner,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/owners"
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .post(objectMapper.writeValueAsString(owner).toRequestBody("application/json".toMediaType()))
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     * List pets belonging to an owner
+     *
+     * @param ownerId
+     */
+    @Throws(ApiException::class)
+    public fun listPetsByOwner(
+        ownerId: UUID,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<List<Pet>> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/owners/{ownerId}/pets"
+                .pathParam("{ownerId}" to ownerId)
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .get()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+}
+
+@Suppress("unused")
+public class VehicleClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val okHttpClient: OkHttpClient,
+) {
+    /**
+     * List all vehicles (tagged vehicle, alphabetically first verb=get wins)
+     */
+    @Throws(ApiException::class)
+    public fun listVehicles(
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<List<Vehicle>> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/vehicles"
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .get()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     * Create a vehicle (tagged owner, but post > get alphabetically so owner tag does NOT win)
+     *
+     * @param vehicle
+     */
+    @Throws(ApiException::class)
+    public fun createVehicle(
+        vehicle: Vehicle,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/vehicles"
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .post(objectMapper.writeValueAsString(vehicle).toRequestBody("application/json".toMediaType()))
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/tagGrouping/client/grouped/ApiService.kt
+++ b/src/test/resources/examples/tagGrouping/client/grouped/ApiService.kt
@@ -1,0 +1,152 @@
+package examples.tagGrouping.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import examples.tagGrouping.models.Owner
+import examples.tagGrouping.models.Pet
+import examples.tagGrouping.models.Vehicle
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import okhttp3.OkHttpClient
+import java.util.UUID
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+public class PetService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    okHttpClient: OkHttpClient,
+) {
+    public var circuitBreakerName: String = "petClient"
+
+    private val apiClient: PetClient = PetClient(objectMapper, baseUrl, okHttpClient)
+
+    @Throws(ApiException::class)
+    public fun listPets(
+        limit: Int? = null,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<List<Pet>> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.listPets(limit, additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    public fun createPet(
+        pet: Pet,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.createPet(pet, additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    public fun getPetById(
+        petId: UUID,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<Pet> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.getPetById(petId, additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    public fun deletePet(
+        petId: UUID,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.deletePet(petId, additionalHeaders)
+        }
+}
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+public class OwnerService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    okHttpClient: OkHttpClient,
+) {
+    public var circuitBreakerName: String = "ownerClient"
+
+    private val apiClient: OwnerClient = OwnerClient(objectMapper, baseUrl, okHttpClient)
+
+    @Throws(ApiException::class)
+    public fun listOwners(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<List<Owner>> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.listOwners(additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    public fun createOwner(
+        owner: Owner,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.createOwner(owner, additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    public fun listPetsByOwner(
+        ownerId: UUID,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<List<Pet>> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.listPetsByOwner(ownerId, additionalHeaders)
+        }
+}
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+public class VehicleService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    okHttpClient: OkHttpClient,
+) {
+    public var circuitBreakerName: String = "vehicleClient"
+
+    private val apiClient: VehicleClient = VehicleClient(objectMapper, baseUrl, okHttpClient)
+
+    @Throws(ApiException::class)
+    public fun listVehicles(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<List<Vehicle>> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.listVehicles(additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    public fun createVehicle(
+        vehicle: Vehicle,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.createVehicle(vehicle, additionalHeaders)
+        }
+}

--- a/src/test/resources/examples/tagGrouping/client/grouped/OpenFeignClient.kt
+++ b/src/test/resources/examples/tagGrouping/client/grouped/OpenFeignClient.kt
@@ -1,0 +1,134 @@
+package examples.tagGrouping.client
+
+import examples.tagGrouping.models.Owner
+import examples.tagGrouping.models.Pet
+import examples.tagGrouping.models.Vehicle
+import feign.HeaderMap
+import feign.Headers
+import feign.Param
+import feign.QueryMap
+import feign.RequestLine
+import java.util.UUID
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@Suppress("unused")
+public interface PetClient {
+    /**
+     * List all pets
+     *
+     * @param limit
+     */
+    @RequestLine("GET /pets?limit={limit}")
+    @Headers("Accept: application/json")
+    public fun listPets(
+        @Param("limit") limit: Int? = null,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): List<Pet>
+
+    /**
+     * Create a pet
+     *
+     * @param pet
+     */
+    @RequestLine("POST /pets")
+    public fun createPet(
+        pet: Pet,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    )
+
+    /**
+     * Get a pet by ID
+     *
+     * @param petId
+     */
+    @RequestLine("GET /pets/{petId}")
+    @Headers("Accept: application/json")
+    public fun getPetById(
+        @Param("petId") petId: UUID,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): Pet
+
+    /**
+     * Delete a pet
+     *
+     * @param petId
+     */
+    @RequestLine("DELETE /pets/{petId}")
+    public fun deletePet(
+        @Param("petId") petId: UUID,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    )
+}
+
+@Suppress("unused")
+public interface OwnerClient {
+    /**
+     * List all owners
+     */
+    @RequestLine("GET /owners")
+    @Headers("Accept: application/json")
+    public fun listOwners(
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): List<Owner>
+
+    /**
+     * Create an owner
+     *
+     * @param owner
+     */
+    @RequestLine("POST /owners")
+    public fun createOwner(
+        owner: Owner,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    )
+
+    /**
+     * List pets belonging to an owner
+     *
+     * @param ownerId
+     */
+    @RequestLine("GET /owners/{ownerId}/pets")
+    @Headers("Accept: application/json")
+    public fun listPetsByOwner(
+        @Param("ownerId") ownerId: UUID,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): List<Pet>
+}
+
+@Suppress("unused")
+public interface VehicleClient {
+    /**
+     * List all vehicles (tagged vehicle, alphabetically first verb=get wins)
+     */
+    @RequestLine("GET /vehicles")
+    @Headers("Accept: application/json")
+    public fun listVehicles(
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): List<Vehicle>
+
+    /**
+     * Create a vehicle (tagged owner, but post > get alphabetically so owner tag does NOT win)
+     *
+     * @param vehicle
+     */
+    @RequestLine("POST /vehicles")
+    public fun createVehicle(
+        vehicle: Vehicle,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    )
+}

--- a/src/test/resources/examples/tagGrouping/client/grouped/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/tagGrouping/client/grouped/SpringHttpInterfaceClient.kt
@@ -1,0 +1,160 @@
+package examples.tagGrouping.client
+
+import examples.tagGrouping.models.Owner
+import examples.tagGrouping.models.Pet
+import examples.tagGrouping.models.Vehicle
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import java.util.UUID
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@Suppress("unused")
+public interface PetClient {
+    /**
+     * List all pets
+     *
+     * @param limit
+     */
+    @HttpExchange(
+        url = "/pets",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun listPets(
+        @RequestParam("limit") limit: Int? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): List<Pet>
+
+    /**
+     * Create a pet
+     *
+     * @param pet
+     */
+    @HttpExchange(
+        url = "/pets",
+        method = "POST",
+    )
+    public fun createPet(
+        @RequestBody pet: Pet,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+
+    /**
+     * Get a pet by ID
+     *
+     * @param petId
+     */
+    @HttpExchange(
+        url = "/pets/{petId}",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun getPetById(
+        @PathVariable("petId") petId: UUID,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): Pet
+
+    /**
+     * Delete a pet
+     *
+     * @param petId
+     */
+    @HttpExchange(
+        url = "/pets/{petId}",
+        method = "DELETE",
+    )
+    public fun deletePet(
+        @PathVariable("petId") petId: UUID,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}
+
+@Suppress("unused")
+public interface OwnerClient {
+    /**
+     * List all owners
+     */
+    @HttpExchange(
+        url = "/owners",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun listOwners(
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): List<Owner>
+
+    /**
+     * Create an owner
+     *
+     * @param owner
+     */
+    @HttpExchange(
+        url = "/owners",
+        method = "POST",
+    )
+    public fun createOwner(
+        @RequestBody owner: Owner,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+
+    /**
+     * List pets belonging to an owner
+     *
+     * @param ownerId
+     */
+    @HttpExchange(
+        url = "/owners/{ownerId}/pets",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun listPetsByOwner(
+        @PathVariable("ownerId") ownerId: UUID,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): List<Pet>
+}
+
+@Suppress("unused")
+public interface VehicleClient {
+    /**
+     * List all vehicles (tagged vehicle, alphabetically first verb=get wins)
+     */
+    @HttpExchange(
+        url = "/vehicles",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun listVehicles(
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): List<Vehicle>
+
+    /**
+     * Create a vehicle (tagged owner, but post > get alphabetically so owner tag does NOT win)
+     *
+     * @param vehicle
+     */
+    @HttpExchange(
+        url = "/vehicles",
+        method = "POST",
+    )
+    public fun createVehicle(
+        @RequestBody vehicle: Vehicle,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    )
+}

--- a/src/test/resources/examples/tagGrouping/client/ktor/grouped/KtorClient.kt
+++ b/src/test/resources/examples/tagGrouping/client/ktor/grouped/KtorClient.kt
@@ -1,0 +1,573 @@
+package examples.tagGrouping.client
+
+import examples.tagGrouping.models.Owner
+import examples.tagGrouping.models.Pet
+import examples.tagGrouping.models.Vehicle
+import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.delete
+import io.ktor.client.request.`get`
+import io.ktor.client.request.`header`
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.serialization.ContentConvertException
+import kotlinx.coroutines.CancellationException
+import java.io.IOException
+import java.util.UUID
+import kotlin.Int
+import kotlin.Unit
+import kotlin.collections.List
+
+public class PetClient(
+    private val httpClient: HttpClient,
+) {
+    /**
+     * List all pets
+     *
+     * Parameters:
+     * 	 @param limit
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.collections.List<examples.tagGrouping.models.Pet>] if the
+     * request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun listPets(
+        limit: Int? = null,
+        apiConfiguration: ApiConfiguration =
+            ApiConfiguration(),
+    ): NetworkResult<List<Pet>> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url =
+            buildString {
+                append(basePath)
+                append("""/pets""")
+                val params =
+                    buildList {
+                        limit?.let { add("limit=$it") }
+                    }
+                if (params.isNotEmpty()) append("?").append(params.joinToString("&"))
+            }
+
+        return try {
+            val response =
+                httpClient.`get`(url) {
+                    `header`("Accept", "application/json")
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+
+    /**
+     * Create a pet
+     *
+     * Parameters:
+     * 	 @param pet
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.Unit] if the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun createPet(
+        pet: Pet,
+        apiConfiguration: ApiConfiguration = ApiConfiguration(),
+    ): NetworkResult<Unit> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/pets"""
+
+        return try {
+            val response =
+                httpClient.post(url) {
+                    `header`("Accept", "application/json")
+                    `header`("Content-Type", "application/json")
+                    setBody(pet)
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+
+    /**
+     * Get a pet by ID
+     *
+     * Parameters:
+     * 	 @param petId
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [examples.tagGrouping.models.Pet] if the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun getPetById(
+        petId: UUID,
+        apiConfiguration: ApiConfiguration =
+            ApiConfiguration(),
+    ): NetworkResult<Pet> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/pets/$petId"""
+
+        return try {
+            val response =
+                httpClient.`get`(url) {
+                    `header`("Accept", "application/json")
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+
+    /**
+     * Delete a pet
+     *
+     * Parameters:
+     * 	 @param petId
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.Unit] if the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun deletePet(
+        petId: UUID,
+        apiConfiguration: ApiConfiguration =
+            ApiConfiguration(),
+    ): NetworkResult<Unit> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/pets/$petId"""
+
+        return try {
+            val response =
+                httpClient.delete(url) {
+                    `header`("Accept", "application/json")
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+}
+
+public class OwnerClient(
+    private val httpClient: HttpClient,
+) {
+    /**
+     * List all owners
+     *
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.collections.List<examples.tagGrouping.models.Owner>] if
+     * the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun listOwners(apiConfiguration: ApiConfiguration = ApiConfiguration()): NetworkResult<List<Owner>> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/owners"""
+
+        return try {
+            val response =
+                httpClient.`get`(url) {
+                    `header`("Accept", "application/json")
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+
+    /**
+     * Create an owner
+     *
+     * Parameters:
+     * 	 @param owner
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.Unit] if the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun createOwner(
+        owner: Owner,
+        apiConfiguration: ApiConfiguration =
+            ApiConfiguration(),
+    ): NetworkResult<Unit> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/owners"""
+
+        return try {
+            val response =
+                httpClient.post(url) {
+                    `header`("Accept", "application/json")
+                    `header`("Content-Type", "application/json")
+                    setBody(owner)
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+
+    /**
+     * List pets belonging to an owner
+     *
+     * Parameters:
+     * 	 @param ownerId
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.collections.List<examples.tagGrouping.models.Pet>] if the
+     * request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun listPetsByOwner(
+        ownerId: UUID,
+        apiConfiguration: ApiConfiguration =
+            ApiConfiguration(),
+    ): NetworkResult<List<Pet>> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/owners/$ownerId/pets"""
+
+        return try {
+            val response =
+                httpClient.`get`(url) {
+                    `header`("Accept", "application/json")
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+}
+
+public class VehicleClient(
+    private val httpClient: HttpClient,
+) {
+    /**
+     * List all vehicles (tagged vehicle, alphabetically first verb=get wins)
+     *
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.collections.List<examples.tagGrouping.models.Vehicle>] if
+     * the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun listVehicles(apiConfiguration: ApiConfiguration = ApiConfiguration()): NetworkResult<List<Vehicle>> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/vehicles"""
+
+        return try {
+            val response =
+                httpClient.`get`(url) {
+                    `header`("Accept", "application/json")
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+
+    /**
+     * Create a vehicle (tagged owner, but post > get alphabetically so owner tag does NOT win)
+     *
+     * Parameters:
+     * 	 @param vehicle
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [kotlin.Unit] if the request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun createVehicle(
+        vehicle: Vehicle,
+        apiConfiguration: ApiConfiguration =
+            ApiConfiguration(),
+    ): NetworkResult<Unit> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/vehicles"""
+
+        return try {
+            val response =
+                httpClient.post(url) {
+                    `header`("Accept", "application/json")
+                    `header`("Content-Type", "application/json")
+                    setBody(vehicle)
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This change adds support for grouping generated client classes by OpenAPI tag instead of URL path segment.

Today, client generation groups operations based on the URL structure, which can produce multiple generated classes for endpoints that belong to the same controller in the OpenAPI spec. That makes the generated client shape drift away from the way the spec is organised. With this change, clients can now be generated with a **1-to-1 mapping between controller/tag and client class**, so operations that share a tag are emitted into the same generated client.

To keep the change safe and backwards-compatible, this behaviour is **opt-in** via a new client codegen option: `GROUP_BY_TAG`. If the option is not provided, existing path-based grouping stays exactly as it is today.

Under the hood, the grouping decision is now centralised in shared client-generation logic and applied consistently across all supported client generators:
- OkHttp
- OpenFeign
- Spring HTTP Interface
- Ktor

The implementation also matches the existing controller generation semantics by grouping on the **first operation tag**, and it falls back to the existing path-based behaviour when tags are not present.

## Additional changes

- added snapshot test coverage for tag-grouped client generation
- added grouped fixtures for the `tagGrouping` example across supported client generators
- updated the README to document the new `GROUP_BY_TAG` option

## Other

Further addresses issue #366 