### PR TITLE
fix: don't crash code generation for a templated server url (#596)

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -421,8 +421,9 @@ object KaizenParserExtensions {
     fun OpenApi3.basePath(): String =
         servers
             .firstOrNull()
-            ?.url?.let { URI.create(it) }
-            ?.path.orEmpty()
+            ?.url
+            ?.let { url -> runCatching { URI.create(url).path }.getOrNull() }
+            .orEmpty()
             .removeSuffix("/")
 
     fun OpenApi3.groupedPaths(groupingStrategy: GroupingStrategy): Map<String, Map<String, Path>> = when (groupingStrategy) {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -370,4 +370,46 @@ class SpringControllerGeneratorTest {
         }
     }
 
+    @Test
+    fun `generates controllers without crashing for a templated server url with variables`() {
+        // Issue #596: a server object with a templated url and a variables section caused
+        // URI.create() in basePath() to throw, aborting the whole generation run.
+        val spec =
+            """
+            openapi: 3.1.0
+            info:
+              title: test
+              version: 1.0.0
+            servers:
+              - url: https://{username}.gigantic-server.com:{port}/{basePath}
+                description: The production API server
+                variables:
+                  username:
+                    default: demo
+                  port:
+                    enum:
+                      - '8443'
+                      - '443'
+                    default: '8443'
+                  basePath:
+                    default: v2
+            paths:
+              /ping:
+                get:
+                  operationId: ping
+                  responses:
+                    '200':
+                      description: ok
+            """.trimIndent()
+
+        val api = SourceApi(spec)
+        val generated = SpringControllerInterfaceGenerator(Packages(basePackage), api, JavaxValidationAnnotations)
+            .generate()
+            .files
+
+        assertThat(generated).isNotEmpty()
+        // The templated url has no usable path, so the request mapping falls back to an empty base path.
+        assertThat(generated.toString()).doesNotContain("{username}")
+    }
+
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensionsTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensionsTest.kt
@@ -1,0 +1,48 @@
+package com.cjbooms.fabrikt.util
+
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.basePath
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+class KaizenParserExtensionsTest {
+
+    private fun apiWithServerUrl(url: String?): com.reprezen.kaizen.oasparser.model3.OpenApi3 {
+        val serverBlock = if (url == null) "" else "servers:\n  - url: \"$url\"\n"
+        val spec = serverBlock +
+            """
+            |openapi: 3.1.0
+            |info:
+            |  title: test
+            |  version: 1.0.0
+            |paths:
+            |  /ping:
+            |    get:
+            |      operationId: ping
+            |      responses:
+            |        '200':
+            |          description: ok
+            """.trimMargin()
+        return YamlUtils.parseOpenApi(spec)
+    }
+
+    @Test
+    fun `basePath returns the path portion of a normal server url`() {
+        assertThat(apiWithServerUrl("https://api.example.com/v2/").basePath()).isEqualTo("/v2")
+        assertThat(apiWithServerUrl("https://api.example.com/v2").basePath()).isEqualTo("/v2")
+    }
+
+    @Test
+    fun `basePath returns empty when there are no servers`() {
+        assertThat(apiWithServerUrl(null).basePath()).isEqualTo("")
+    }
+
+    @Test
+    fun `basePath does not throw on a templated server url and returns empty`() {
+        // Templated server URLs (issue #596) contain '{' and '}', which are illegal URI characters
+        // and previously made URI.create() throw, aborting the whole code generation run.
+        val api = apiWithServerUrl("https://{username}.gigantic-server.com:{port}/{basePath}")
+        assertDoesNotThrow { api.basePath() }
+        assertThat(api.basePath()).isEqualTo("")
+    }
+}


### PR DESCRIPTION
## Summary

Makes `OpenApi3.basePath()` resilient to a templated server URL so that an OpenAPI spec whose `servers[]` entry uses a templated URL (with a `variables` section) no longer crashes code generation. The `URI.create(...)` call is wrapped in `runCatching` and falls back to an empty base path when the URL cannot be parsed.

## Why this matters

A server object with a templated URL such as `https://{username}.gigantic-server.com:{port}/{basePath}` plus a matching `variables` block is valid OpenAPI, copied verbatim from the spec's own server-object example (issue #596).

The actual crash is in `OpenApi3.basePath()` (src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt:421), which is called during controller generation, for example from `AnnotationBasedControllerInterfaceGenerator` (src/main/kotlin/com/cjbooms/fabrikt/generators/controller/AnnotationBasedControllerInterfaceGenerator.kt:29). It does `URI.create(server.url)`, and the `{` and `}` characters in a templated URL are illegal in a URI, so `URI.create` throws `URISyntaxException`, which aborts the whole generation run.

I confirmed empirically that the `variables` section itself is parsed harmlessly by the kaizen parser. Removing only `variables` from the server objects does not stop the crash, because the templated `url` is the trigger. Hardening `basePath()` is the minimal change on the exercised codegen path: a templated server URL has no usable base path, so falling back to an empty string produces a controller with no request-mapping prefix rather than crashing. Normal server URLs are unaffected and still return their path.

## Testing

Adds `KaizenParserExtensionsTest` covering `basePath()`:
- a normal server URL returns its path (trailing slash trimmed)
- no servers returns an empty string
- a templated server URL does not throw and returns an empty string

Adds a `SpringControllerGeneratorTest` case that runs full controller generation against the issue's server-variables spec and asserts it generates files without crashing and emits no templated placeholder in the output.

Ran locally with JDK 21:
- `./gradlew :test --tests "com.cjbooms.fabrikt.util.KaizenParserExtensionsTest"` passes
- `./gradlew :test --tests "com.cjbooms.fabrikt.generators.SpringControllerGeneratorTest"` passes, plus the Micronaut and Ktor client generator suites and the `util` suite for regressions

Fixes #596
