### PR TITLE
Add FAULT_TOLERANT_OPEN_ENUMS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                                |   `DISABLE_SEALED_INTERFACES_FOR_ONE_OF` - This option disables the default sealed interfaces for oneOf behavior in v26+ |
 |                                |   `NON_NULL_MAP_VALUES` - This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable |
 |                                |   `FAULT_TOLERANT_ENUMS` - This option adds an UNRECOGNIZED enum entry as a fallback for unmapped values, preventing deserialization exceptions. If jackson is used, the deserialization option **READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE** will need to be enabled as well |
+|                                |   `FAULT_TOLERANT_OPEN_ENUMS` - This option converts the "open enum" pattern (an `anyOf` combining a string enum with an open `type: string`) into a fault-tolerant enum, i.e. an enum carrying the declared values plus an UNRECOGNIZED fallback, instead of collapsing the type to a plain `String`. Behaves like FAULT_TOLERANT_ENUMS for the affected enums |
 |   `--http-model-suffix`        | Specify custom suffix for all generated model classes. Defaults to no suffix. |
 |   `--instant-library`          | Specify which Instant library to use in generated model classes for kotlinx.serialization. Default: KOTLINX_INSTANT |
 |                                | CHOOSE ONE OF: |

--- a/end2end-tests/models-jackson/build.gradle.kts
+++ b/end2end-tests/models-jackson/build.gradle.kts
@@ -79,6 +79,12 @@ tasks {
         "${rootProject.projectDir}/src/test/resources/examples/discriminatedOneOf/api.yaml",
         "com.example.oneof",
     )
+    val generateOpenEnumCodeTask = createGenerateCodeTask(
+        "generateOpenEnumCode",
+        "${rootProject.projectDir}/src/test/resources/examples/openEnum/api.yaml",
+        "com.example.openenum",
+        listOf("--http-model-opts", "FAULT_TOLERANT_OPEN_ENUMS")
+    )
 
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
@@ -86,6 +92,7 @@ tasks {
         dependsOn(generatePrimitiveTypesCodeTask)
         dependsOn(generateStringFormatOverrideCodeTask)
         dependsOn(generateOneOfMarkerInterfaceCodeTask)
+        dependsOn(generateOpenEnumCodeTask)
     }
 
     withType<Test> {

--- a/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/OpenEnumTest.kt
+++ b/end2end-tests/models-jackson/src/test/kotlin/com/cjbooms/fabrikt/models/jackson/OpenEnumTest.kt
@@ -1,0 +1,47 @@
+package com.cjbooms.fabrikt.models.jackson
+
+import com.cjbooms.fabrikt.models.jackson.Helpers.mapper
+import com.example.openenum.models.CloseEnum
+import com.example.openenum.models.OpenEnum
+import com.example.openenum.models.SomeObj
+import com.fasterxml.jackson.databind.DeserializationFeature
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end verification of the FAULT_TOLERANT_OPEN_ENUMS option (fabrikt issue #374)
+ * with Jackson. The "open enum" `anyOf` is generated as a fault-tolerant enum: the declared values plus an
+ * UNRECOGNIZED fallback. `fromValue` returns UNRECOGNIZED for unmapped input, and Jackson deserializes
+ * unknown values to UNRECOGNIZED once READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE is enabled.
+ */
+class OpenEnumTest {
+    private val objectMapper = mapper()
+
+    @Test
+    fun `serializes known open enum value as its underlying string`() {
+        val obj = SomeObj(openEnum = OpenEnum.BAR, closeEnum = CloseEnum.BAR)
+        val json = objectMapper.writeValueAsString(obj)
+        assertThat(json).isEqualTo("""{"open_enum":"bar","close_enum":"bar"}""")
+    }
+
+    @Test
+    fun `deserializes known open enum value`() {
+        val obj = objectMapper.readValue("""{"open_enum":"foo","close_enum":"foo"}""", SomeObj::class.java)
+        assertThat(obj.openEnum).isEqualTo(OpenEnum.FOO)
+        assertThat(obj.closeEnum).isEqualTo(CloseEnum.FOO)
+    }
+
+    @Test
+    fun `deserializes unknown open enum value to UNRECOGNIZED when configured to`() {
+        val faultTolerantMapper = mapper()
+            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+        val obj = faultTolerantMapper.readValue("""{"open_enum":"qux","close_enum":"foo"}""", SomeObj::class.java)
+        assertThat(obj.openEnum).isEqualTo(OpenEnum.UNRECOGNIZED)
+    }
+
+    @Test
+    fun `fromValue maps known values and falls back to UNRECOGNIZED for the rest`() {
+        assertThat(OpenEnum.fromValue("baz")).isEqualTo(OpenEnum.BAZ)
+        assertThat(OpenEnum.fromValue("nope")).isEqualTo(OpenEnum.UNRECOGNIZED)
+    }
+}

--- a/end2end-tests/models-kotlinx/build.gradle.kts
+++ b/end2end-tests/models-kotlinx/build.gradle.kts
@@ -73,6 +73,13 @@ tasks {
         )
     )
 
+    val generateOpenEnumCodeTask = createGenerateCodeTask(
+        "generateOpenEnumCode",
+        "${rootProject.projectDir}/src/test/resources/examples/openEnum/api.yaml",
+        "com.example.openenum",
+        listOf("--http-model-opts", "FAULT_TOLERANT_OPEN_ENUMS")
+    )
+
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             optIn.add("kotlinx.serialization.ExperimentalSerializationApi")
@@ -82,6 +89,7 @@ tasks {
         dependsOn(generateCodeTask)
         dependsOn(generatePrimitiveTypesCodeTask)
         dependsOn(generateStringFormatOverrideCodeTask)
+        dependsOn(generateOpenEnumCodeTask)
     }
 
     withType<Test> {

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationOpenEnumTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationOpenEnumTest.kt
@@ -1,0 +1,37 @@
+package com.cjbooms.fabrikt.models.kotlinx
+
+import com.example.openenum.models.CloseEnum
+import com.example.openenum.models.OpenEnum
+import com.example.openenum.models.SomeObj
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end verification of the FAULT_TOLERANT_OPEN_ENUMS option (fabrikt issue #374)
+ * with kotlinx.serialization. The "open enum" `anyOf` is generated as a fault-tolerant enum: the declared
+ * values plus an UNRECOGNIZED fallback that `fromValue` returns for any unmapped input.
+ */
+class KotlinxSerializationOpenEnumTest {
+
+    @Test
+    fun `serializes known open enum value as its underlying string`() {
+        val obj = SomeObj(openEnum = OpenEnum.BAR, closeEnum = CloseEnum.BAR)
+        val json = Json.encodeToString(obj)
+        assertThat(json).isEqualTo("""{"open_enum":"bar","close_enum":"bar"}""")
+    }
+
+    @Test
+    fun `deserializes known open enum value`() {
+        val obj = Json.decodeFromString<SomeObj>("""{"open_enum":"foo","close_enum":"foo"}""")
+        assertThat(obj.openEnum).isEqualTo(OpenEnum.FOO)
+        assertThat(obj.closeEnum).isEqualTo(CloseEnum.FOO)
+    }
+
+    @Test
+    fun `fromValue maps known values and falls back to UNRECOGNIZED for the rest`() {
+        assertThat(OpenEnum.fromValue("baz")).isEqualTo(OpenEnum.BAZ)
+        assertThat(OpenEnum.fromValue("nope")).isEqualTo(OpenEnum.UNRECOGNIZED)
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -67,6 +67,7 @@ enum class ModelCodeGenOptionType(val description: String) {
     DISABLE_SEALED_INTERFACES_FOR_ONE_OF("This option disables the default sealed interfaces for oneOf behavior in v26+"),
     NON_NULL_MAP_VALUES("This option makes map values non-null. The default (since v15) and most spec compliant is make map values nullable"),
     FAULT_TOLERANT_ENUMS("This option adds an UNRECOGNIZED enum entry as a fallback for unmapped values, preventing deserialization exceptions. If jackson is used, the deserialization option **READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE** will need to be enabled as well"),
+    FAULT_TOLERANT_OPEN_ENUMS("This option converts the \"open enum\" pattern (an `anyOf` combining a string enum with an open `type: string`) into a fault-tolerant enum, i.e. an enum carrying the declared values plus an UNRECOGNIZED fallback, instead of collapsing the type to a plain `String`. Behaves like FAULT_TOLERANT_ENUMS for the affected enums"),
     ;
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -45,6 +45,7 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.isInlinedTypedAdditionalP
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfWhereAllTypesInheritFromACommonAllOfSuperType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOneOfResolvingToAnyType
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOpenEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isPolymorphicSubType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isPolymorphicSuperType
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSimpleType
@@ -479,7 +480,8 @@ class ModelGenerator(
 
     private fun buildEnumClass(schema: Schema, enum: KotlinTypeInfo.Enum): TypeSpec {
         val enumType = generatedType(packages.base, enum.enumClassName)
-        val isFaultTolerant = options.contains(ModelCodeGenOptionType.FAULT_TOLERANT_ENUMS)
+        val isFaultTolerant = options.contains(ModelCodeGenOptionType.FAULT_TOLERANT_ENUMS) ||
+            schema.isOpenEnumDefinition()
 
         val classBuilder = TypeSpec
             .enumBuilder(enumType)

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/OasType.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/OasType.kt
@@ -2,6 +2,7 @@ package com.cjbooms.fabrikt.model
 
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isMapTypeAdditionalProperties
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.isOpenEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSchemaLess
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSet
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isSimpleMapDefinition
@@ -90,7 +91,7 @@ sealed class OasType(
                 isStringDefinitionWithFormat("uri") -> Specialization.URI
                 isStringDefinitionWithFormat("byte") -> Specialization.BYTE
                 isStringDefinitionWithFormat("binary") -> Specialization.BINARY
-                isEnumDefinition() -> Specialization.ENUM
+                isEnumDefinition() || isOpenEnumDefinition() -> Specialization.ENUM
                 isMapTypeAdditionalProperties(oasKey) -> Specialization.TYPED_MAP_ADDITIONAL_PROPERTIES
                 isSimpleMapDefinition() -> Specialization.MAP
                 isTypedAdditionalProperties(oasKey) -> Specialization.TYPED_OBJECT_ADDITIONAL_PROPERTIES

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -99,10 +99,33 @@ object KaizenParserExtensions {
     @Suppress("UNCHECKED_CAST")
     fun Schema.getEnumValues(): List<String> = when {
         this.hasEnums() -> this.enums.filterNotNull().map { it.toString() }.filterNot { it.isBlank() }
+        this.isOpenEnumDefinition() -> this.getOpenEnumValues()
         !MutableSettings.modelOptions.contains(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS) -> emptyList()
         else -> extensions[EXTENSIBLE_ENUM_KEY]?.let { it as List<String?> }?.filterNotNull()
             ?.filterNot { it.isBlank() } ?: emptyList()
     }
+
+    /**
+     * Detects the "open enum" pattern: an `anyOf` combining a string enum with an open `type: string`, e.g.
+     * ```yaml
+     * anyOf:
+     *   - type: string
+     *     enum: [foo, bar, baz]
+     *   - type: string
+     * ```
+     * Only recognised when the [ModelCodeGenOptionType.FAULT_TOLERANT_OPEN_ENUMS] option is enabled.
+     */
+    fun Schema.isOpenEnumDefinition(): Boolean {
+        if (!MutableSettings.modelOptions.contains(ModelCodeGenOptionType.FAULT_TOLERANT_OPEN_ENUMS)) return false
+        val branches = anyOfSchemas ?: return false
+        if (oneOfSchemas?.isNotEmpty() == true || allOfSchemas?.isNotEmpty() == true) return false
+        if (properties?.isNotEmpty() == true) return false
+        if (!branches.all { it.type == OasType.Text.type }) return false
+        return branches.any { it.hasEnums() } && branches.any { !it.hasEnums() }
+    }
+
+    private fun Schema.getOpenEnumValues(): List<String> =
+        (anyOfSchemas ?: emptyList()).filter { it.hasEnums() }.flatMap { it.getEnumValues() }.distinct()
 
     fun Schema.hasAdditionalProperties(): Boolean = Overlay.of(additionalPropertiesSchema).isPresent && additionalProperties != false
 

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
@@ -34,7 +34,8 @@ class KotlinSerializationModelGeneratorTest {
     private fun testCases(): Stream<String> = Stream.of(
         "discriminatedOneOf",
         "primitiveTypes",
-        "normalizedNameConflation"
+        "normalizedNameConflation",
+        "openEnum"
     )
 
     @BeforeEach
@@ -55,6 +56,9 @@ class KotlinSerializationModelGeneratorTest {
         print("Testcase: $testCaseName")
         if (testCaseName !in listOf("discriminatedOneOf", "oneOfMarkerInterface")) {
             MutableSettings.addOption(ModelCodeGenOptionType.DISABLE_SEALED_INTERFACES_FOR_ONE_OF)
+        }
+        if (testCaseName == "openEnum") {
+            MutableSettings.addOption(ModelCodeGenOptionType.FAULT_TOLERANT_OPEN_ENUMS)
         }
         val basePackage = "examples.${testCaseName.replace("/", ".")}"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -77,6 +77,7 @@ class ModelGeneratorTest {
         "unsupportedInlinedDefinitions",
         "requestBodiesSchema",
         "normalizedNameConflation",
+        "openEnum",
     )
 
     @BeforeEach
@@ -110,6 +111,9 @@ class ModelGeneratorTest {
         }
         if (testCaseName == "faultTolerantEnums") {
             MutableSettings.addOption(ModelCodeGenOptionType.FAULT_TOLERANT_ENUMS)
+        }
+        if (testCaseName == "openEnum") {
+            MutableSettings.addOption(ModelCodeGenOptionType.FAULT_TOLERANT_OPEN_ENUMS)
         }
         if (testCaseName == "defaultValues") {
             MutableSettings.addOption(JacksonNullabilityMode.ENFORCE_OPTIONAL_NON_NULL)
@@ -155,6 +159,37 @@ class ModelGeneratorTest {
         }
         assertThatExpectedFiles(Path.of("src/test/resources$expectedModelsPath"))
             .areContainedInGenerated(tempFolderContents)
+
+        tempDirectory.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `open enum behaviour is unchanged when only FAULT_TOLERANT_ENUMS is enabled`() {
+        // Without FAULT_TOLERANT_OPEN_ENUMS, the open enum anyOf pattern must keep its
+        // current behaviour: it is not detected as an enum and collapses to a plain String.
+        MutableSettings.addOption(ModelCodeGenOptionType.FAULT_TOLERANT_ENUMS)
+        val basePackage = "examples.openEnum"
+        val apiLocation = javaClass.getResource("/examples/openEnum/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+
+        val models = ModelGenerator(
+            Packages(basePackage),
+            sourceApi,
+        ).generate()
+
+        val sourceSet = setOf(KotlinSourceSet(models.files, Paths.get("")))
+        val tempDirectory = Files.createTempDirectory("model_generator_test_openEnum_fault_tolerant")
+        sourceSet.forEach { it.writeFileTo(tempDirectory.toFile()) }
+        val generated = readFolder(
+            tempDirectory.resolve(basePackage.replace(".", File.separator)).resolve("models")
+        )
+
+        // The open enum anyOf is NOT converted: no OpenEnum model is emitted ...
+        assertThat(generated).doesNotContainKey("OpenEnum.kt")
+        // ... and the property still collapses to a plain String
+        assertThat(generated["SomeObj.kt"]).contains("public val openEnum: String? = null")
+        // The regular (closed) enum is still generated, and gets the UNRECOGNIZED fault-tolerant fallback
+        assertThat(generated["CloseEnum.kt"]).contains("UNRECOGNIZED")
 
         tempDirectory.toFile().deleteRecursively()
     }

--- a/src/test/resources/examples/openEnum/api.yaml
+++ b/src/test/resources/examples/openEnum/api.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Open Enum Example
+  version: 1.0.0
+  description: >-
+    Reproduces the "open enum" pattern from
+    https://github.com/fabrikt-io/fabrikt/issues/374 using `anyOf`.
+paths:
+  /some-obj:
+    get:
+      operationId: getSomeObj
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeObj'
+components:
+  schemas:
+    SomeObj:
+      type: object
+      properties:
+        open_enum:
+          $ref: '#/components/schemas/OpenEnum'
+        close_enum:
+          $ref: '#/components/schemas/CloseEnum'
+    OpenEnum:
+      anyOf:
+        - type: string
+          enum:
+            - foo
+            - bar
+            - baz
+        - type: string
+    CloseEnum:
+      type: string
+      enum:
+        - foo
+        - bar
+        - baz

--- a/src/test/resources/examples/openEnum/models/CloseEnum.kt
+++ b/src/test/resources/examples/openEnum/models/CloseEnum.kt
@@ -1,0 +1,23 @@
+package examples.openEnum.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class CloseEnum(
+  @JsonValue
+  public val `value`: String,
+) {
+  FOO("foo"),
+  BAR("bar"),
+  BAZ("baz"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, CloseEnum> = entries.associateBy(CloseEnum::value)
+
+    public fun fromValue(`value`: String): CloseEnum? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/openEnum/models/OpenEnum.kt
+++ b/src/test/resources/examples/openEnum/models/OpenEnum.kt
@@ -1,0 +1,26 @@
+package examples.openEnum.models
+
+import com.fasterxml.jackson.`annotation`.JsonEnumDefaultValue
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class OpenEnum(
+  @JsonValue
+  public val `value`: String,
+) {
+  FOO("foo"),
+  BAR("bar"),
+  BAZ("baz"),
+  @JsonEnumDefaultValue
+  UNRECOGNIZED("UNRECOGNIZED"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, OpenEnum> = entries.associateBy(OpenEnum::value)
+
+    public fun fromValue(`value`: String): OpenEnum = mapping[value] ?: UNRECOGNIZED
+  }
+}

--- a/src/test/resources/examples/openEnum/models/SomeObj.kt
+++ b/src/test/resources/examples/openEnum/models/SomeObj.kt
@@ -1,0 +1,12 @@
+package examples.openEnum.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+
+public data class SomeObj(
+  @param:JsonProperty("open_enum")
+  @get:JsonProperty("open_enum")
+  public val openEnum: OpenEnum? = null,
+  @param:JsonProperty("close_enum")
+  @get:JsonProperty("close_enum")
+  public val closeEnum: CloseEnum? = null,
+)

--- a/src/test/resources/examples/openEnum/models/kotlinx/CloseEnum.kt
+++ b/src/test/resources/examples/openEnum/models/kotlinx/CloseEnum.kt
@@ -1,0 +1,25 @@
+package examples.openEnum.models
+
+import kotlin.String
+import kotlin.collections.Map
+import kotlinx.serialization.SerialName
+
+public enum class CloseEnum(
+  public val `value`: String,
+) {
+  @SerialName("foo")
+  FOO("foo"),
+  @SerialName("bar")
+  BAR("bar"),
+  @SerialName("baz")
+  BAZ("baz"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, CloseEnum> = entries.associateBy(CloseEnum::value)
+
+    public fun fromValue(`value`: String): CloseEnum? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/openEnum/models/kotlinx/OpenEnum.kt
+++ b/src/test/resources/examples/openEnum/models/kotlinx/OpenEnum.kt
@@ -1,0 +1,27 @@
+package examples.openEnum.models
+
+import kotlin.String
+import kotlin.collections.Map
+import kotlinx.serialization.SerialName
+
+public enum class OpenEnum(
+  public val `value`: String,
+) {
+  @SerialName("foo")
+  FOO("foo"),
+  @SerialName("bar")
+  BAR("bar"),
+  @SerialName("baz")
+  BAZ("baz"),
+  @SerialName("UNRECOGNIZED")
+  UNRECOGNIZED("UNRECOGNIZED"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, OpenEnum> = entries.associateBy(OpenEnum::value)
+
+    public fun fromValue(`value`: String): OpenEnum = mapping[value] ?: UNRECOGNIZED
+  }
+}

--- a/src/test/resources/examples/openEnum/models/kotlinx/SomeObj.kt
+++ b/src/test/resources/examples/openEnum/models/kotlinx/SomeObj.kt
@@ -1,0 +1,12 @@
+package examples.openEnum.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class SomeObj(
+  @SerialName("open_enum")
+  public val openEnum: OpenEnum? = null,
+  @SerialName("close_enum")
+  public val closeEnum: CloseEnum? = null,
+)


### PR DESCRIPTION
As discussed in #374, open enum support would be great for sharing swagger between iOS/Android. This option add support for that with minor changes reusing the FAULT_TOLERANT_ENUM generation.