### PR TITLE
fix: use kotlinx.io.IOException in Ktor client for KMP compatibility

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
@@ -203,7 +203,7 @@ class KtorClientGenerator(
                                 // Catch IOException
                                 .nextControlFlow(
                                     "catch (e: %T)",
-                                    ClassName("java.io", "IOException")
+                                    ClassName("kotlinx.io", "IOException")
                                 )
                                 .addStatement(
                                     "%T.Failure(%T.Network(e))",

--- a/src/main/resources/templates/client-code/ktor-api-models.kt.hbs
+++ b/src/main/resources/templates/client-code/ktor-api-models.kt.hbs
@@ -1,6 +1,6 @@
 package {{ client }}
 
-import java.io.IOException
+import kotlinx.io.IOException
 
 /**
  * Sealed interface representing all possible network errors that can occur during API calls.

--- a/src/test/resources/examples/ktorClient/client/ktor/KtorApiModels.kt
+++ b/src/test/resources/examples/ktorClient/client/ktor/KtorApiModels.kt
@@ -1,6 +1,6 @@
 package examples.ktorClient.client
 
-import java.io.IOException
+import kotlinx.io.IOException
 
 /**
  * Sealed interface representing all possible network errors that can occur during API calls.

--- a/src/test/resources/examples/ktorClient/client/ktor/KtorClient.kt
+++ b/src/test/resources/examples/ktorClient/client/ktor/KtorClient.kt
@@ -16,7 +16,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.serialization.ContentConvertException
 import kotlinx.coroutines.CancellationException
-import java.io.IOException
+import kotlinx.io.IOException
 import kotlin.Boolean
 import kotlin.Double
 import kotlin.Int

--- a/src/test/resources/examples/parameterNameClash/client/ktor/KtorApiModels.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ktor/KtorApiModels.kt
@@ -1,6 +1,6 @@
 package examples.parameterNameClash.client
 
-import java.io.IOException
+import kotlinx.io.IOException
 
 /**
  * Sealed interface representing all possible network errors that can occur during API calls.

--- a/src/test/resources/examples/parameterNameClash/client/ktor/KtorClient.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ktor/KtorClient.kt
@@ -14,7 +14,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.serialization.ContentConvertException
 import kotlinx.coroutines.CancellationException
-import java.io.IOException
+import kotlinx.io.IOException
 import kotlin.String
 import kotlin.Unit
 

--- a/src/test/resources/examples/tagGrouping/client/ktor/grouped/KtorClient.kt
+++ b/src/test/resources/examples/tagGrouping/client/ktor/grouped/KtorClient.kt
@@ -17,7 +17,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.serialization.ContentConvertException
 import kotlinx.coroutines.CancellationException
-import java.io.IOException
+import kotlinx.io.IOException
 import java.util.UUID
 import kotlin.Int
 import kotlin.Unit


### PR DESCRIPTION
Fixes #628

The generated Ktor client caught `java.io.IOException`, which is JVM only and breaks Kotlin Multiplatform builds.

This change switches both the generated client (`KtorClientGenerator`) and the `NetworkError` model template to `kotlinx.io.IOException`. Ktor 3 already depends on kotlinx-io, and on the JVM `kotlinx.io.IOException` is a typealias for `java.io.IOException`, so behaviour on the JVM is unchanged while the generated code becomes KMP compatible.
