### PR TITLE
Add ANY_AS_JSONELEMENT type override

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ This section documents the available CLI parameters for controlling what gets ge
 |                                |   `DATE_AS_STRING` - Ignore string format `date` and use `String` as the type |
 |                                |   `DATETIME_AS_STRING` - Ignore string format `date-time` and use `String` as the type |
 |                                |   `BYTEARRAY_AS_INPUTSTREAM` - Use `InputStream` as ByteArray type. Defaults to `ByteArray` |
+|                                |   `ANY_AS_JSONELEMENT` - Use `kotlinx.serialization.json.JsonElement` for untyped (any) schemas and `JsonObject` for untyped objects. Requires the KOTLINX_SERIALIZATION serialization library. Defaults to `Any` |
 |   `--validation-library`       | Specify which validation library to use for annotations in generated model classes. Default: JAKARTA_VALIDATION |
 |                                | CHOOSE ONE OF: |
 |                                |   `JAVAX_VALIDATION` - Use `javax.validation` annotations in generated model classes |

--- a/end2end-tests/models-kotlinx/build.gradle.kts
+++ b/end2end-tests/models-kotlinx/build.gradle.kts
@@ -80,6 +80,13 @@ tasks {
         listOf("--http-model-opts", "FAULT_TOLERANT_OPEN_ENUMS")
     )
 
+    val generateAnyAsJsonElementCodeTask = createGenerateCodeTask(
+        "generateAnyAsJsonElementCode",
+        "${rootProject.projectDir}/src/test/resources/examples/anyAsJsonElement/api.yaml",
+        "com.example.jsonelement",
+        listOf("--type-overrides", "ANY_AS_JSONELEMENT")
+    )
+
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             optIn.add("kotlinx.serialization.ExperimentalSerializationApi")
@@ -90,6 +97,7 @@ tasks {
         dependsOn(generatePrimitiveTypesCodeTask)
         dependsOn(generateStringFormatOverrideCodeTask)
         dependsOn(generateOpenEnumCodeTask)
+        dependsOn(generateAnyAsJsonElementCodeTask)
     }
 
     withType<Test> {

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationAnyAsJsonElementTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationAnyAsJsonElementTest.kt
@@ -1,0 +1,112 @@
+package com.cjbooms.fabrikt.models.kotlinx
+
+import com.example.jsonelement.models.Example
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end verification of the ANY_AS_JSONELEMENT type override (fabrikt issue #633)
+ * with kotlinx.serialization. Untyped (any) schemas are generated as
+ * `kotlinx.serialization.json.JsonElement`, allowing dynamic JSON to round-trip without
+ * custom serializers.
+ */
+class KotlinxSerializationAnyAsJsonElementTest {
+
+    @Test
+    fun `serializes dynamic JSON of mixed shapes`() {
+        val example = Example(
+            anyValue = buildJsonObject {
+                put("name", "fabrikt")
+                put("stars", 1000)
+            },
+            optionalAnyValue = JsonPrimitive(42),
+            anyList = listOf(
+                JsonPrimitive("text"),
+                JsonPrimitive(true),
+                buildJsonArray { add(1) },
+            ),
+        )
+
+        val json = Json.encodeToString(example)
+
+        assertThat(json).isEqualTo(
+            """{"anyValue":{"name":"fabrikt","stars":1000},"optionalAnyValue":42,"anyList":["text",true,[1]]}"""
+        )
+    }
+
+    @Test
+    fun `deserializes arbitrary JSON into JsonElement properties`() {
+        val example = Json.decodeFromString<Example>(
+            """{"anyValue":{"nested":{"deep":[1,2,3]}},"anyList":[{"id":7}]}"""
+        )
+
+        assertThat(example.anyValue).isInstanceOf(JsonObject::class.java)
+        assertThat(
+            example.anyValue.jsonObject["nested"]!!.jsonObject["deep"]!!.jsonArray.map { it.jsonPrimitive.int }
+        ).containsExactly(1, 2, 3)
+        assertThat(example.optionalAnyValue).isNull()
+        assertThat(example.anyList!!.single().jsonObject["id"]!!.jsonPrimitive.int).isEqualTo(7)
+    }
+
+    @Test
+    fun `deserializes explicit null into JsonNull for a required any property`() {
+        val example = Json.decodeFromString<Example>("""{"anyValue":null}""")
+
+        assertThat(example.anyValue).isEqualTo(JsonNull)
+    }
+
+    @Test
+    fun `round trip preserves dynamic JSON structure`() {
+        val original = Json.decodeFromString<Example>(
+            """{"anyValue":{"a":[1,"two",null,{"b":false}]},"optionalAnyValue":"plain","anyList":[]}"""
+        )
+
+        val roundTripped = Json.decodeFromString<Example>(Json.encodeToString(original))
+
+        assertThat(roundTripped).isEqualTo(original)
+    }
+
+    @Test
+    fun `handles the other untyped shapes as JsonElement`() {
+        val example = Json.decodeFromString<Example>(
+            """
+            {
+              "anyValue": 1,
+              "anyListNoItems": [1, "two", {"three": 3}],
+              "nullableAny": null,
+              "refAny": {"anything": ["goes"]},
+              "oneOfAny": "either-a-string-or-an-int",
+              "untypedObject": {"free": {"form": [1, 2]}}
+            }
+            """.trimIndent()
+        )
+
+        assertThat(example.anyListNoItems!!.map { it is JsonPrimitive })
+            .containsExactly(true, true, false)
+        assertThat(example.anyListNoItems!![2]).isInstanceOf(JsonObject::class.java)
+        // explicit null decodes to Kotlin null on a nullable JsonElement?, unlike the required
+        // non-nullable JsonElement above where it decodes to JsonNull
+        assertThat(example.nullableAny).isNull()
+        assertThat(example.refAny!!.jsonObject["anything"]!!.jsonArray.single().jsonPrimitive.content)
+            .isEqualTo("goes")
+        assertThat(example.oneOfAny!!.jsonPrimitive.content).isEqualTo("either-a-string-or-an-int")
+        assertThat(example.untypedObject!!["free"]!!.jsonObject["form"]!!.jsonArray.map { it.jsonPrimitive.int })
+            .containsExactly(1, 2)
+
+        val roundTripped = Json.decodeFromString<Example>(Json.encodeToString(example))
+        assertThat(roundTripped).isEqualTo(example)
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -104,7 +104,8 @@ enum class CodeGenTypeOverride(val description: String) {
     UUID_AS_STRING("Ignore string format `uuid` and use `String` as the type"),
     DATE_AS_STRING("Ignore string format `date` and use `String` as the type"),
     DATETIME_AS_STRING("Ignore string format `date-time` and use `String` as the type"),
-    BYTEARRAY_AS_INPUTSTREAM("Use `InputStream` as ByteArray type. Defaults to `ByteArray`");
+    BYTEARRAY_AS_INPUTSTREAM("Use `InputStream` as ByteArray type. Defaults to `ByteArray`"),
+    ANY_AS_JSONELEMENT("Use `kotlinx.serialization.json.JsonElement` for untyped (any) schemas and `JsonObject` for untyped objects. Requires the KOTLINX_SERIALIZATION serialization library. Defaults to `Any`");
 
     override fun toString() = "`${super.toString()}` - $description"
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -150,7 +150,9 @@ class RequestParameter(
     override val isNullable: Boolean get() = !isRequired && defaultValue == null
 
     override fun toParameterSpecBuilder(treatAnyTypeHeadersAsStrings: Boolean): ParameterSpec.Builder =
-        if (treatAnyTypeHeadersAsStrings && parameterLocation == HeaderParam && typeInfo == KotlinTypeInfo.AnyType) {
+        if (treatAnyTypeHeadersAsStrings && parameterLocation == HeaderParam &&
+            (typeInfo == KotlinTypeInfo.AnyType || typeInfo == KotlinTypeInfo.JsonElement)
+        ) {
             ParameterSpec.builder(
                 name = name,
                 type = if (isNullable) String::class.asTypeName().copy(nullable = true) else String::class.asTypeName()

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -51,6 +51,8 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
     object Boolean : KotlinTypeInfo(kotlin.Boolean::class)
     object UntypedObject : KotlinTypeInfo(Any::class)
     object AnyType : KotlinTypeInfo(Any::class)
+    object JsonElement : KotlinTypeInfo(kotlinx.serialization.json.JsonElement::class)
+    object JsonObject : KotlinTypeInfo(kotlinx.serialization.json.JsonObject::class)
     data class Object(val simpleClassName: String) : KotlinTypeInfo(GeneratedType::class, simpleClassName)
     data class Array(
         val parameterizedType: KotlinTypeInfo,
@@ -93,7 +95,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                  * Defaults to Any for complex schemas inlined under the paths section.
                  * Necessary until support for generating inlined models like these is added.
                  */
-                return if (schema.isEnumDefinition()) Text else AnyType
+                return if (schema.isEnumDefinition()) Text else getOverridableAnyType()
             }
             return when (schema.toOasType(oasKey)) {
                 OasType.Date -> {
@@ -165,14 +167,14 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                     SimpleTypedAdditionalProperties(from(schema, OasType.ADDITIONAL_PROPERTIES_VALUE))
 
                 OasType.UntypedObjectAdditionalProperties -> UntypedObjectAdditionalProperties
-                OasType.UntypedObject -> UntypedObject
+                OasType.UntypedObject -> if (isAnyAsJsonElementActive()) JsonObject else UntypedObject
                 OasType.UnknownAdditionalProperties -> UnknownAdditionalProperties
                 OasType.TypedMapAdditionalProperties ->
                     MapTypeAdditionalProperties(
                         from(schema.additionalPropertiesSchema, "", enclosingSchema)
                     )
 
-                OasType.Any -> AnyType
+                OasType.Any -> getOverridableAnyType()
                 OasType.OneOfAny ->
                     if (schema.isOneOfSuperInterfaceWithDiscriminator() ||
                         (schema.isOneOfSuperInterface() &&
@@ -181,7 +183,7 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                     ) {
                         Object(ModelNameRegistry.getOrRegister(schema, enclosingSchema))
                     } else {
-                        AnyType
+                        getOverridableAnyType()
                     }
             }
         }
@@ -196,8 +198,26 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
                     Object(ModelNameRegistry.getOrRegister(arraySchema, enclosingSchema))
                 arraySchema.hasInlinedItemsSchemaWithOneOf() || arraySchema.hasInlinedItemsSchemaOfTypeObject() ->
                     Object(ModelNameRegistry.getOrRegister(arraySchema))
-                arraySchema.itemsSchema.isNotDefined() -> AnyType
+                arraySchema.itemsSchema.isNotDefined() -> getOverridableAnyType()
                 else -> from(arraySchema.itemsSchema, oasKey, enclosingSchema)
+            }
+        }
+
+        private fun getOverridableAnyType(): KotlinTypeInfo =
+            if (isAnyAsJsonElementActive()) JsonElement else AnyType
+
+        private fun isAnyAsJsonElementActive(): kotlin.Boolean = when {
+            CodeGenTypeOverride.ANY_AS_JSONELEMENT !in MutableSettings.typeOverrides -> false
+            MutableSettings.serializationLibrary == KOTLINX_SERIALIZATION -> true
+            else -> {
+                logger.log(
+                    Level.WARNING,
+                    """
+                        The override flag 'ANY_AS_JSONELEMENT' requires the KOTLINX_SERIALIZATION serialization
+                        library and is ignored. Defaulting to `Any`...
+                    """.trimIndent()
+                )
+                false
             }
         }
 

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
@@ -184,6 +184,38 @@ class KotlinSerializationModelGeneratorTest {
     }
 
     @Test
+    fun `ANY_AS_JSONELEMENT override is respected with KOTLINX_SERIALIZATION`() {
+        MutableSettings.addOption(CodeGenTypeOverride.ANY_AS_JSONELEMENT)
+        val basePackage = "examples.anyAsJsonElement"
+        val apiLocation = javaClass.getResource("/examples/anyAsJsonElement/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val expectedModels = readFolder(Path.of("src/test/resources/examples/anyAsJsonElement/models/kotlinx/"))
+
+        val models = ModelGenerator(
+            Packages(basePackage),
+            sourceApi,
+        ).generate()
+
+        val sourceSet = setOf(KotlinSourceSet(models.files, Paths.get("")))
+        val tempDirectory = Files.createTempDirectory("model_generator_test_kotlinx_jsonelement")
+        sourceSet.forEach {
+            it.writeFileTo(tempDirectory.toFile())
+        }
+
+        val tempFolderContents =
+            readFolder(tempDirectory.resolve(basePackage.replace(".", File.separator)).resolve("models"))
+        tempFolderContents.forEach {
+            if (expectedModels.containsKey(it.key)) {
+                assertThat((it.value)).isEqualTo(expectedModels[it.key])
+            } else {
+                assertThat(it.value).isEqualTo("File not found in expected models")
+            }
+        }
+
+        tempDirectory.toFile().deleteRecursively()
+    }
+
+    @Test
     fun `all AS_STRING overrides are respected with KOTLINX_SERIALIZATION`() {
         MutableSettings.addOption(CodeGenTypeOverride.DATE_AS_STRING)
         MutableSettings.addOption(CodeGenTypeOverride.DATETIME_AS_STRING)

--- a/src/test/resources/examples/anyAsJsonElement/api.yaml
+++ b/src/test/resources/examples/anyAsJsonElement/api.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Any as JsonElement
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Example:
+      type: object
+      required:
+        - anyValue
+      properties:
+        anyValue: {}
+        optionalAnyValue: {}
+        anyList:
+          type: array
+          items: {}
+        anyListNoItems:
+          type: array
+        nullableAny:
+          nullable: true
+        refAny:
+          $ref: '#/components/schemas/Anything'
+        oneOfAny:
+          oneOf:
+            - type: string
+            - type: integer
+        anyOfAny:
+          anyOf:
+            - type: string
+            - type: integer
+        untypedObject:
+          type: object
+    Anything: {}

--- a/src/test/resources/examples/anyAsJsonElement/models/kotlinx/Example.kt
+++ b/src/test/resources/examples/anyAsJsonElement/models/kotlinx/Example.kt
@@ -1,0 +1,31 @@
+package examples.anyAsJsonElement.models
+
+import jakarta.validation.constraints.NotNull
+import kotlin.collections.List
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+public data class Example(
+  @SerialName("anyValue")
+  @get:NotNull
+  public val anyValue: JsonElement,
+  @SerialName("optionalAnyValue")
+  public val optionalAnyValue: JsonElement? = null,
+  @SerialName("anyList")
+  public val anyList: List<JsonElement>? = null,
+  @SerialName("anyListNoItems")
+  public val anyListNoItems: List<JsonElement>? = null,
+  @SerialName("nullableAny")
+  public val nullableAny: JsonElement? = null,
+  @SerialName("refAny")
+  public val refAny: JsonElement? = null,
+  @SerialName("oneOfAny")
+  public val oneOfAny: JsonElement? = null,
+  @SerialName("anyOfAny")
+  public val anyOfAny: JsonElement? = null,
+  @SerialName("untypedObject")
+  public val untypedObject: JsonObject? = null,
+)


### PR DESCRIPTION
Closes #633

With `KOTLINX_SERIALIZATION`, untyped (any) schemas now generate as `kotlinx.serialization.json.JsonElement` instead of `Any` (which has no kotlinx serializer), and untyped objects (`type: object` without properties) generate as `JsonObject` instead of throwing `UnsupportedOperationException`.

Includes 
* unit tests, 
* an end2end test in `models-kotlinx`, 
* and README docs. 

The flattened `additionalProperties` catch-all (fixed properties plus unknown keys) remains unsupported for kotlinx, as it needs generated custom serializers (Kotlin/kotlinx.serialization#1978).