### PR TITLE
Update version of fabrikt-gradle-plugin in README.md to 1.39.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Latest version of the plugin: [![Gradle Plugin Portal Version](https://img.shiel
 ```kotlin
 plugins {
     // find latest version: https://github.com/acanda/fabrikt-gradle-plugin/releases
-    id("ch.acanda.gradle.fabrikt") version "1.38.1"
+    id("ch.acanda.gradle.fabrikt") version "1.39.0"
 }
 
 fabrikt {


### PR DESCRIPTION
I updated the gradle plugin to Fabrikt 27.6.0.