### PR TITLE
Apply ANY_AS_JSONELEMENT override to untyped map values

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -174,6 +174,10 @@ class ModelGenerator(
                 typeInfo is KotlinTypeInfo.MapTypeAdditionalProperties ->
                     generatedType(basePackage, typeInfo.parameterizedType.generatedModelClassName!!)
 
+                typeInfo is KotlinTypeInfo.UnknownAdditionalProperties &&
+                    KotlinTypeInfo.anyAsJsonElementMapValueOverride() != null ->
+                    KotlinTypeInfo.JsonElement.modelKClass.asTypeName()
+
                 else -> typeInfo.modelKClass.asTypeName()
             }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinTypeInfo.kt
@@ -206,6 +206,14 @@ sealed class KotlinTypeInfo(val modelKClass: KClass<*>, val generatedModelClassN
         private fun getOverridableAnyType(): KotlinTypeInfo =
             if (isAnyAsJsonElementActive()) JsonElement else AnyType
 
+        /**
+         * When the ANY_AS_JSONELEMENT override is active, untyped map values (additional properties
+         * without a schema) are represented as [JsonElement] instead of `Any`. Returns null when the
+         * override is not active, so callers keep their existing `Any`-based type.
+         */
+        fun anyAsJsonElementMapValueOverride(): KotlinTypeInfo? =
+            if (isAnyAsJsonElementActive()) JsonElement else null
+
         private fun isAnyAsJsonElementActive(): kotlin.Boolean = when {
             CodeGenTypeOverride.ANY_AS_JSONELEMENT !in MutableSettings.typeOverrides -> false
             MutableSettings.serializationLibrary == KOTLINX_SERIALIZATION -> true

--- a/src/test/resources/examples/anyAsJsonElement/api.yaml
+++ b/src/test/resources/examples/anyAsJsonElement/api.yaml
@@ -31,4 +31,7 @@ components:
             - type: integer
         untypedObject:
           type: object
+        mapAny:
+          type: object
+          additionalProperties: {}
     Anything: {}

--- a/src/test/resources/examples/anyAsJsonElement/models/kotlinx/Example.kt
+++ b/src/test/resources/examples/anyAsJsonElement/models/kotlinx/Example.kt
@@ -1,7 +1,9 @@
 package examples.anyAsJsonElement.models
 
 import jakarta.validation.constraints.NotNull
+import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.Map
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -28,4 +30,6 @@ public data class Example(
   public val anyOfAny: JsonElement? = null,
   @SerialName("untypedObject")
   public val untypedObject: JsonObject? = null,
+  @SerialName("mapAny")
+  public val mapAny: Map<String, JsonElement?>? = null,
 )


### PR DESCRIPTION
Untyped additional properties (`additionalProperties: {}`) were still generated as `Map<String, Any?>` even with the ANY_AS_JSONELEMENT override active, because the map value type resolves to UnknownAdditionalProperties, which is not routed through the override.

Resolve untyped map values to JsonElement when the override is active, so `type: object` with an empty `additionalProperties` schema now generates `Map<String, JsonElement?>` under KOTLINX_SERIALIZATION.